### PR TITLE
Feature/property array push

### DIFF
--- a/src/codegen/functions/locals.rs
+++ b/src/codegen/functions/locals.rs
@@ -136,6 +136,7 @@ pub fn collect_local_vars(
                 } else {
                 }
             }
+            StmtKind::PropertyArrayPush { .. } => {}
             StmtKind::DoWhile { body, .. } | StmtKind::While { body, .. } => {
                 collect_local_vars(body, ctx, sig);
             }

--- a/src/codegen/functions/locals.rs
+++ b/src/codegen/functions/locals.rs
@@ -136,7 +136,7 @@ pub fn collect_local_vars(
                 } else {
                 }
             }
-            StmtKind::PropertyArrayPush { .. } => {}
+            StmtKind::PropertyArrayPush { .. } | StmtKind::PropertyArrayAssign { .. } => {}
             StmtKind::DoWhile { body, .. } | StmtKind::While { body, .. } => {
                 collect_local_vars(body, ctx, sig);
             }

--- a/src/codegen/program_usage.rs
+++ b/src/codegen/program_usage.rs
@@ -138,6 +138,10 @@ fn collect_required_class_names_in_body(stmts: &[Stmt], names: &mut HashSet<Stri
             | StmtKind::PropertyArrayPush { value, .. } => {
                 collect_required_class_names_in_expr(value, names);
             }
+            StmtKind::PropertyArrayAssign { index, value, .. } => {
+                collect_required_class_names_in_expr(index, names);
+                collect_required_class_names_in_expr(value, names);
+            }
             _ => {}
         }
     }
@@ -377,6 +381,16 @@ fn stmt_uses_variable(stmt: &Stmt, needle: &str) -> bool {
         }
         StmtKind::PropertyArrayPush { object, value, .. } => {
             expr_uses_variable(object, needle) || expr_uses_variable(value, needle)
+        }
+        StmtKind::PropertyArrayAssign {
+            object,
+            index,
+            value,
+            ..
+        } => {
+            expr_uses_variable(object, needle)
+                || expr_uses_variable(index, needle)
+                || expr_uses_variable(value, needle)
         }
         StmtKind::FunctionDecl { body, .. } | StmtKind::NamespaceBlock { body, .. } => {
             body.iter().any(|stmt| stmt_uses_variable(stmt, needle))

--- a/src/codegen/program_usage.rs
+++ b/src/codegen/program_usage.rs
@@ -134,7 +134,8 @@ fn collect_required_class_names_in_body(stmts: &[Stmt], names: &mut HashSet<Stri
             StmtKind::ArrayPush { value, .. }
             | StmtKind::Return(Some(value))
             | StmtKind::ListUnpack { value, .. }
-            | StmtKind::PropertyAssign { value, .. } => {
+            | StmtKind::PropertyAssign { value, .. }
+            | StmtKind::PropertyArrayPush { value, .. } => {
                 collect_required_class_names_in_expr(value, names);
             }
             _ => {}
@@ -372,6 +373,9 @@ fn stmt_uses_variable(stmt: &Stmt, needle: &str) -> bool {
         StmtKind::ListUnpack { value, .. } => expr_uses_variable(value, needle),
         StmtKind::StaticVar { init, .. } => expr_uses_variable(init, needle),
         StmtKind::PropertyAssign { object, value, .. } => {
+            expr_uses_variable(object, needle) || expr_uses_variable(value, needle)
+        }
+        StmtKind::PropertyArrayPush { object, value, .. } => {
             expr_uses_variable(object, needle) || expr_uses_variable(value, needle)
         }
         StmtKind::FunctionDecl { body, .. } | StmtKind::NamespaceBlock { body, .. } => {

--- a/src/codegen/stmt.rs
+++ b/src/codegen/stmt.rs
@@ -245,6 +245,13 @@ pub fn emit_stmt(stmt: &Stmt, emitter: &mut Emitter, ctx: &mut Context, data: &m
         } => {
             assignments::emit_property_assign_stmt(object, property, value, emitter, ctx, data);
         }
+        StmtKind::PropertyArrayPush {
+            object,
+            property,
+            value,
+        } => {
+            assignments::emit_property_array_push_stmt(object, property, value, emitter, ctx, data);
+        }
     }
 }
 

--- a/src/codegen/stmt.rs
+++ b/src/codegen/stmt.rs
@@ -252,6 +252,22 @@ pub fn emit_stmt(stmt: &Stmt, emitter: &mut Emitter, ctx: &mut Context, data: &m
         } => {
             assignments::emit_property_array_push_stmt(object, property, value, emitter, ctx, data);
         }
+        StmtKind::PropertyArrayAssign {
+            object,
+            property,
+            index,
+            value,
+        } => {
+            assignments::emit_property_array_assign_stmt(
+                object,
+                property,
+                index,
+                value,
+                emitter,
+                ctx,
+                data,
+            );
+        }
     }
 }
 

--- a/src/codegen/stmt/assignments.rs
+++ b/src/codegen/stmt/assignments.rs
@@ -2,4 +2,8 @@ mod locals;
 mod properties;
 
 pub(super) use locals::emit_assign_stmt;
-pub(super) use properties::{emit_property_array_push_stmt, emit_property_assign_stmt};
+pub(super) use properties::{
+    emit_property_array_assign_stmt,
+    emit_property_array_push_stmt,
+    emit_property_assign_stmt,
+};

--- a/src/codegen/stmt/assignments.rs
+++ b/src/codegen/stmt/assignments.rs
@@ -2,4 +2,4 @@ mod locals;
 mod properties;
 
 pub(super) use locals::emit_assign_stmt;
-pub(super) use properties::emit_property_assign_stmt;
+pub(super) use properties::{emit_property_array_push_stmt, emit_property_assign_stmt};

--- a/src/codegen/stmt/assignments/properties.rs
+++ b/src/codegen/stmt/assignments/properties.rs
@@ -59,3 +59,137 @@ pub(crate) fn emit_property_assign_stmt(
 
     storage::store_property_value(emitter, object_reg, &val_ty, target.offset);
 }
+
+pub(crate) fn emit_property_array_push_stmt(
+    object: &Expr,
+    property: &str,
+    value: &Expr,
+    emitter: &mut Emitter,
+    ctx: &mut Context,
+    data: &mut DataSection,
+) {
+    emitter.blank();
+    emitter.comment(&format!("->{}[] = ...", property));
+
+    let obj_ty = emit_expr(object, emitter, ctx, data);
+    let target = match target::resolve_property_assign_target(&obj_ty, property, None, emitter, ctx) {
+        target::PropertyAssignResolution::Resolved(target) => target,
+        target::PropertyAssignResolution::UseMagicSet(_) | target::PropertyAssignResolution::Abort => {
+            emitter.comment("WARNING: property array push requires a concrete array property");
+            return;
+        }
+    };
+    let elem_ty = match &target.prop_ty {
+        crate::types::PhpType::Array(elem_ty) => *elem_ty.clone(),
+        _ => {
+            emitter.comment("WARNING: property array push on non-array property");
+            return;
+        }
+    };
+
+    if target.needs_deref {
+        abi::emit_call_label(emitter, "__rt_ptr_check_nonnull");
+        emitter.comment(&format!(
+            "append to extern field {}::{} at offset {}",
+            target.class_name, property, target.offset
+        ));
+    }
+
+    let object_reg = abi::symbol_scratch_reg(emitter);
+    emitter.instruction(&format!("mov {}, {}", object_reg, abi::int_result_reg(emitter))); // preserve the owning object pointer while the append helper evaluates the value and may reallocate the array
+    abi::emit_load_from_address(emitter, abi::int_result_reg(emitter), object_reg, target.offset);
+    abi::emit_push_reg(emitter, object_reg);
+    abi::emit_push_reg(emitter, abi::int_result_reg(emitter));
+
+    let mut val_ty = emit_expr(value, emitter, ctx, data);
+    if matches!(elem_ty, crate::types::PhpType::Mixed)
+        && !matches!(val_ty, crate::types::PhpType::Mixed | crate::types::PhpType::Union(_))
+    {
+        crate::codegen::emit_box_current_value_as_mixed(emitter, &val_ty);
+        val_ty = crate::types::PhpType::Mixed;
+    } else {
+        super::super::helpers::retain_borrowed_heap_result(emitter, value, &val_ty);
+    }
+
+    match emitter.target.arch {
+        crate::codegen::platform::Arch::AArch64 => {
+            abi::emit_pop_reg(emitter, "x9");
+            match &val_ty {
+                crate::types::PhpType::Int | crate::types::PhpType::Bool => {
+                    emitter.instruction("mov x1, x0");                                  // move the appended scalar payload into the runtime helper value register
+                    emitter.instruction("mov x0, x9");                                  // move the current array pointer into the runtime helper receiver register
+                    emitter.instruction("bl __rt_array_push_int");                      // append the scalar payload and return the possibly-grown array pointer
+                }
+                crate::types::PhpType::Float => {
+                    emitter.instruction("fmov x1, d0");                                 // move the appended float payload bits into the runtime helper value register
+                    emitter.instruction("mov x0, x9");                                  // move the current array pointer into the runtime helper receiver register
+                    emitter.instruction("bl __rt_array_push_int");                      // append the float payload bits as an 8-byte scalar slot
+                }
+                crate::types::PhpType::Str => {
+                    emitter.instruction("mov x0, x9");                                  // move the current array pointer into the runtime helper receiver register
+                    emitter.instruction("bl __rt_array_push_str");                      // persist and append the string payload, returning the possibly-grown array pointer
+                }
+                crate::types::PhpType::Callable => {
+                    emitter.instruction("mov x1, x0");                                  // move the callable pointer bits into the runtime helper value register
+                    emitter.instruction("mov x0, x9");                                  // move the current array pointer into the runtime helper receiver register
+                    emitter.instruction("bl __rt_array_push_int");                      // append the callable pointer bits as a plain scalar slot
+                }
+                crate::types::PhpType::Mixed
+                | crate::types::PhpType::Array(_)
+                | crate::types::PhpType::AssocArray { .. }
+                | crate::types::PhpType::Object(_) => {
+                    emitter.instruction("mov x1, x0");                                  // move the retained heap payload pointer into the runtime helper child register
+                    emitter.instruction("mov x0, x9");                                  // move the current array pointer into the runtime helper receiver register
+                    emitter.instruction("bl __rt_array_push_refcounted");               // append the retained heap payload and return the possibly-grown array pointer
+                }
+                _ => {
+                    emitter.comment("WARNING: unsupported property array push payload");
+                    abi::emit_pop_reg(emitter, "x10");
+                    return;
+                }
+            }
+            abi::emit_pop_reg(emitter, "x10");
+            abi::emit_store_to_address(emitter, "x0", "x10", target.offset);
+        }
+        crate::codegen::platform::Arch::X86_64 => {
+            abi::emit_pop_reg(emitter, "r11");
+            match &val_ty {
+                crate::types::PhpType::Int | crate::types::PhpType::Bool => {
+                    emitter.instruction("mov rsi, rax");                                // move the appended scalar payload into the SysV runtime helper value register
+                    emitter.instruction("mov rdi, r11");                                // move the current array pointer into the SysV runtime helper receiver register
+                    abi::emit_call_label(emitter, "__rt_array_push_int");
+                }
+                crate::types::PhpType::Float => {
+                    emitter.instruction("movq rsi, xmm0");                              // move the appended float payload bits into the SysV runtime helper value register
+                    emitter.instruction("mov rdi, r11");                                // move the current array pointer into the SysV runtime helper receiver register
+                    abi::emit_call_label(emitter, "__rt_array_push_int");
+                }
+                crate::types::PhpType::Str => {
+                    emitter.instruction("mov rsi, rax");                                // move the appended string pointer into the SysV runtime helper payload register
+                    emitter.instruction("mov rdi, r11");                                // move the current array pointer into the SysV runtime helper receiver register
+                    abi::emit_call_label(emitter, "__rt_array_push_str");
+                }
+                crate::types::PhpType::Callable => {
+                    emitter.instruction("mov rsi, rax");                                // move the callable pointer bits into the SysV runtime helper value register
+                    emitter.instruction("mov rdi, r11");                                // move the current array pointer into the SysV runtime helper receiver register
+                    abi::emit_call_label(emitter, "__rt_array_push_int");
+                }
+                crate::types::PhpType::Mixed
+                | crate::types::PhpType::Array(_)
+                | crate::types::PhpType::AssocArray { .. }
+                | crate::types::PhpType::Object(_) => {
+                    emitter.instruction("mov rsi, rax");                                // move the retained heap payload pointer into the SysV runtime helper child register
+                    emitter.instruction("mov rdi, r11");                                // move the current array pointer into the SysV runtime helper receiver register
+                    abi::emit_call_label(emitter, "__rt_array_push_refcounted");
+                }
+                _ => {
+                    emitter.comment("WARNING: unsupported property array push payload");
+                    abi::emit_pop_reg(emitter, "r10");
+                    return;
+                }
+            }
+            abi::emit_pop_reg(emitter, "r10");
+            abi::emit_store_to_address(emitter, "rax", "r10", target.offset);
+        }
+    }
+}

--- a/src/codegen/stmt/assignments/properties.rs
+++ b/src/codegen/stmt/assignments/properties.rs
@@ -193,3 +193,458 @@ pub(crate) fn emit_property_array_push_stmt(
         }
     }
 }
+
+pub(crate) fn emit_property_array_assign_stmt(
+    object: &Expr,
+    property: &str,
+    index: &Expr,
+    value: &Expr,
+    emitter: &mut Emitter,
+    ctx: &mut Context,
+    data: &mut DataSection,
+) {
+    emitter.blank();
+    emitter.comment(&format!("->{}[...] = ...", property));
+
+    let obj_ty = emit_expr(object, emitter, ctx, data);
+    let target = match target::resolve_property_assign_target(&obj_ty, property, None, emitter, ctx) {
+        target::PropertyAssignResolution::Resolved(target) => target,
+        target::PropertyAssignResolution::UseMagicSet(_) | target::PropertyAssignResolution::Abort => {
+            emitter.comment("WARNING: property array assign requires a concrete array property");
+            return;
+        }
+    };
+    let elem_ty = match &target.prop_ty {
+        crate::types::PhpType::Array(elem_ty) => *elem_ty.clone(),
+        _ => {
+            emitter.comment("WARNING: property array assign on non-array property");
+            return;
+        }
+    };
+
+    if target.needs_deref {
+        abi::emit_call_label(emitter, "__rt_ptr_check_nonnull");
+        emitter.comment(&format!(
+            "assign into extern field {}::{} at offset {}",
+            target.class_name, property, target.offset
+        ));
+    }
+
+    let object_reg = abi::symbol_scratch_reg(emitter);
+    emitter.instruction(&format!("mov {}, {}", object_reg, abi::int_result_reg(emitter))); // preserve the owning object pointer while the indexed write evaluates the index/value and may reallocate the array
+    abi::emit_load_from_address(emitter, abi::int_result_reg(emitter), object_reg, target.offset);
+    match emitter.target.arch {
+        crate::codegen::platform::Arch::AArch64 => {
+            abi::emit_push_reg(emitter, object_reg);
+            emitter.instruction("bl __rt_array_ensure_unique");                         // split shared indexed arrays before mutating the property-backed array storage
+            abi::emit_pop_reg(emitter, object_reg);
+            abi::emit_store_to_address(emitter, "x0", object_reg, target.offset);
+            abi::emit_push_reg(emitter, object_reg);
+            abi::emit_push_reg(emitter, "x0");
+            emit_expr(index, emitter, ctx, data);
+            abi::emit_push_reg(emitter, "x0");
+            let val_ty = prepare_property_array_assign_value(value, emitter, ctx, data, &elem_ty);
+            let state = PropertyIndexedAssignState::new(&elem_ty, &val_ty);
+            emitter.instruction("ldr x9, [sp, #16]");                                   // reload the indexed target slot after preserving the assigned value on the temporary stack
+            emitter.instruction("ldr x10, [sp, #32]");                                  // reload the property-backed array pointer after preserving the assigned value on the temporary stack
+            emitter.instruction("ldr x11, [x10]");                                      // load the original logical length before growth so overwrites can be distinguished from extensions
+            emitter.instruction("ldr x12, [x10, #8]");                                  // load the current capacity before checking whether the target slot already fits
+            let grow_check = ctx.next_label("prop_array_assign_grow_check");
+            let grow_ready = ctx.next_label("prop_array_assign_grow_ready");
+            emitter.label(&grow_check);
+            emitter.instruction("cmp x9, x12");                                         // does the target index already fit within the current property-backed array capacity?
+            emitter.instruction(&format!("b.lo {}", grow_ready));                       // skip growth once the target indexed slot is already addressable
+            emitter.instruction("str x9, [sp, #-16]!");                                 // preserve the target index because the growth helper clobbers caller-saved registers
+            emitter.instruction("mov x0, x10");                                         // pass the property-backed array pointer to the growth helper
+            emitter.instruction("bl __rt_array_grow");                                  // grow the indexed array until the requested slot fits
+            emitter.instruction("mov x10, x0");                                         // keep the possibly-reallocated property-backed array pointer in the long-lived working register
+            emitter.instruction("ldr x9, [sp], #16");                                   // restore the target index after the growth helper returns
+            emitter.instruction("ldr x12, [x10, #8]");                                  // reload the capacity after growth so the loop converges on the new header values
+            emitter.instruction(&format!("b {}", grow_check));                          // continue growing until the target property slot fits
+            emitter.label(&grow_ready);
+            emitter.instruction("ldr x13, [sp, #48]");                                  // reload the preserved owning object pointer before publishing the possibly-grown array pointer back into the property slot
+            abi::emit_store_to_address(emitter, "x10", "x13", target.offset);
+            restore_property_array_assign_value_aarch64(emitter, &val_ty);
+            normalize_property_indexed_array_layout_aarch64(&state, emitter, ctx);
+            store_property_indexed_array_value_aarch64(&target.prop_ty, &state, emitter, ctx);
+            extend_property_indexed_array_if_needed_aarch64(&state, emitter, ctx);
+            emitter.instruction("add sp, sp, #48");                                     // drop the preserved object pointer, array pointer, and index after completing the property-backed indexed write
+        }
+        crate::codegen::platform::Arch::X86_64 => {
+            abi::emit_push_reg(emitter, object_reg);
+            emitter.instruction("mov rdi, rax");                                        // pass the property-backed array pointer to the x86_64 uniqueness helper before mutating indexed storage
+            abi::emit_call_label(emitter, "__rt_array_ensure_unique");
+            abi::emit_pop_reg(emitter, object_reg);
+            abi::emit_store_to_address(emitter, "rax", object_reg, target.offset);
+            abi::emit_push_reg(emitter, object_reg);
+            abi::emit_push_reg(emitter, "rax");
+            emit_expr(index, emitter, ctx, data);
+            abi::emit_push_reg(emitter, "rax");
+            let val_ty = prepare_property_array_assign_value(value, emitter, ctx, data, &elem_ty);
+            let state = PropertyIndexedAssignState::new(&elem_ty, &val_ty);
+            emitter.instruction("mov r9, QWORD PTR [rsp + 16]");                        // reload the indexed target slot after preserving the assigned value on the temporary stack
+            emitter.instruction("mov r10, QWORD PTR [rsp + 32]");                       // reload the property-backed array pointer after preserving the assigned value on the temporary stack
+            emitter.instruction("mov r11, QWORD PTR [r10]");                            // load the original logical length before growth so overwrites can be distinguished from extensions
+            let grow_check = ctx.next_label("prop_array_assign_grow_check");
+            let grow_ready = ctx.next_label("prop_array_assign_grow_ready");
+            emitter.label(&grow_check);
+            emitter.instruction("mov r12, QWORD PTR [r10 + 8]");                        // load the current capacity before checking whether the target slot already fits
+            emitter.instruction("cmp r9, r12");                                         // does the target index already fit within the current property-backed array capacity?
+            emitter.instruction(&format!("jb {}", grow_ready));                         // skip growth once the target indexed slot is already addressable
+            abi::emit_push_reg(emitter, "r9");
+            emitter.instruction("mov rdi, r10");                                        // pass the property-backed array pointer to the x86_64 growth helper
+            abi::emit_call_label(emitter, "__rt_array_grow");
+            emitter.instruction("mov r10, rax");                                        // keep the possibly-reallocated property-backed array pointer in the long-lived working register
+            abi::emit_pop_reg(emitter, "r9");
+            emitter.instruction(&format!("jmp {}", grow_check));                        // continue growing until the target property slot fits
+            emitter.label(&grow_ready);
+            emitter.instruction("mov r13, QWORD PTR [rsp + 48]");                       // reload the preserved owning object pointer before publishing the possibly-grown array pointer back into the property slot
+            abi::emit_store_to_address(emitter, "r10", "r13", target.offset);
+            restore_property_array_assign_value_x86_64(emitter, &val_ty);
+            normalize_property_indexed_array_layout_x86_64(&state, emitter, ctx);
+            store_property_indexed_array_value_x86_64(&target.prop_ty, &state, emitter, ctx);
+            extend_property_indexed_array_if_needed_x86_64(&state, emitter, ctx);
+            emitter.instruction("add rsp, 48");                                         // drop the preserved object pointer, array pointer, and index after completing the property-backed indexed write
+        }
+    }
+}
+
+struct PropertyIndexedAssignState {
+    val_ty: crate::types::PhpType,
+    effective_store_ty: crate::types::PhpType,
+    stores_refcounted_pointer: bool,
+}
+
+impl PropertyIndexedAssignState {
+    fn new(elem_ty: &crate::types::PhpType, val_ty: &crate::types::PhpType) -> Self {
+        let effective_store_ty = if matches!(elem_ty, crate::types::PhpType::Mixed) {
+            crate::types::PhpType::Mixed
+        } else if elem_ty != val_ty {
+            val_ty.clone()
+        } else {
+            elem_ty.clone()
+        };
+        let stores_refcounted_pointer = matches!(
+            effective_store_ty,
+            crate::types::PhpType::Mixed
+                | crate::types::PhpType::Array(_)
+                | crate::types::PhpType::AssocArray { .. }
+                | crate::types::PhpType::Object(_)
+        );
+        Self {
+            val_ty: val_ty.clone(),
+            effective_store_ty,
+            stores_refcounted_pointer,
+        }
+    }
+}
+
+fn prepare_property_array_assign_value(
+    value: &Expr,
+    emitter: &mut Emitter,
+    ctx: &mut Context,
+    data: &mut DataSection,
+    elem_ty: &crate::types::PhpType,
+) -> crate::types::PhpType {
+    let mut val_ty = emit_expr(value, emitter, ctx, data);
+    if matches!(elem_ty, crate::types::PhpType::Mixed)
+        && !matches!(val_ty, crate::types::PhpType::Mixed | crate::types::PhpType::Union(_))
+    {
+        crate::codegen::emit_box_current_value_as_mixed(emitter, &val_ty);
+        val_ty = crate::types::PhpType::Mixed;
+    } else {
+        super::super::helpers::retain_borrowed_heap_result(emitter, value, &val_ty);
+    }
+    match &val_ty {
+        crate::types::PhpType::Str => {
+            let (ptr_reg, len_reg) = abi::string_result_regs(emitter);
+            abi::emit_push_reg_pair(emitter, ptr_reg, len_reg);
+        }
+        crate::types::PhpType::Float => abi::emit_push_float_reg(emitter, abi::float_result_reg(emitter)),
+        _ => abi::emit_push_reg(emitter, abi::int_result_reg(emitter)),
+    }
+    val_ty
+}
+
+fn restore_property_array_assign_value_aarch64(
+    emitter: &mut Emitter,
+    val_ty: &crate::types::PhpType,
+) {
+    match val_ty {
+        crate::types::PhpType::Str => abi::emit_pop_reg_pair(emitter, "x1", "x2"),
+        crate::types::PhpType::Float => abi::emit_pop_float_reg(emitter, abi::float_result_reg(emitter)),
+        _ => abi::emit_pop_reg(emitter, "x0"),
+    }
+}
+
+fn restore_property_array_assign_value_x86_64(
+    emitter: &mut Emitter,
+    val_ty: &crate::types::PhpType,
+) {
+    match val_ty {
+        crate::types::PhpType::Str => abi::emit_pop_reg_pair(emitter, "rax", "rdx"),
+        crate::types::PhpType::Float => abi::emit_pop_float_reg(emitter, "xmm0"),
+        _ => abi::emit_pop_reg(emitter, "rax"),
+    }
+}
+
+fn normalize_property_indexed_array_layout_aarch64(
+    state: &PropertyIndexedAssignState,
+    emitter: &mut Emitter,
+    ctx: &mut Context,
+) {
+    let skip_normalize = ctx.next_label("prop_array_assign_skip_normalize");
+    emitter.instruction("cmp x11, #0");                                         // is this the first indexed write into the property-backed array?
+    emitter.instruction(&format!("b.ne {}", skip_normalize));                   // keep the existing slot layout once the property-backed array already has elements
+    match &state.effective_store_ty {
+        crate::types::PhpType::Str => {
+            emitter.instruction("mov x12, #16");                                // string arrays need 16-byte pointer-plus-length slots
+            emitter.instruction("str x12, [x10, #16]");                         // persist the string-slot width in the property-backed array header
+            super::super::helpers::stamp_indexed_array_value_type(emitter, "x10", &state.val_ty);
+        }
+        crate::types::PhpType::Mixed
+        | crate::types::PhpType::Array(_)
+        | crate::types::PhpType::AssocArray { .. }
+        | crate::types::PhpType::Object(_) => {
+            emitter.instruction("mov x12, #8");                                 // nested heap pointers still use 8-byte slots in property-backed indexed arrays
+            emitter.instruction("str x12, [x10, #16]");                         // persist the pointer-sized slot width in the property-backed array header
+        }
+        _ => {
+            emitter.instruction("mov x12, #8");                                 // scalar indexed arrays use ordinary 8-byte slots
+            emitter.instruction("str x12, [x10, #16]");                         // persist the scalar slot width in the property-backed array header
+            emitter.instruction("ldr x12, [x10, #-8]");                         // load the packed kind word from the property-backed array heap header
+            emitter.instruction("mov x14, #0x80ff");                            // preserve the indexed-array kind and persistent copy-on-write flag bits
+            emitter.instruction("and x12, x12, x14");                           // clear stale value_type bits while keeping the stable container metadata
+            emitter.instruction("str x12, [x10, #-8]");                         // persist the scalar-oriented packed kind word back into the heap header
+        }
+    }
+    emitter.label(&skip_normalize);
+}
+
+fn normalize_property_indexed_array_layout_x86_64(
+    state: &PropertyIndexedAssignState,
+    emitter: &mut Emitter,
+    ctx: &mut Context,
+) {
+    let skip_normalize = ctx.next_label("prop_array_assign_skip_normalize");
+    emitter.instruction("cmp r11, 0");                                          // is this the first indexed write into the property-backed array?
+    emitter.instruction(&format!("jne {}", skip_normalize));                    // keep the existing slot layout once the property-backed array already has elements
+    match &state.effective_store_ty {
+        crate::types::PhpType::Str => {
+            emitter.instruction("mov r12, 16");                                 // string arrays need 16-byte pointer-plus-length slots
+            emitter.instruction("mov QWORD PTR [r10 + 16], r12");               // persist the string-slot width in the property-backed array header
+            super::super::helpers::stamp_indexed_array_value_type(emitter, "r10", &state.val_ty);
+        }
+        crate::types::PhpType::Mixed
+        | crate::types::PhpType::Array(_)
+        | crate::types::PhpType::AssocArray { .. }
+        | crate::types::PhpType::Object(_) => {
+            emitter.instruction("mov r12, 8");                                  // nested heap pointers still use 8-byte slots in property-backed indexed arrays
+            emitter.instruction("mov QWORD PTR [r10 + 16], r12");               // persist the pointer-sized slot width in the property-backed array header
+        }
+        _ => {
+            emitter.instruction("mov r12, 8");                                  // scalar indexed arrays use ordinary 8-byte slots
+            emitter.instruction("mov QWORD PTR [r10 + 16], r12");               // persist the scalar slot width in the property-backed array header
+            emitter.instruction("mov r12, QWORD PTR [r10 - 8]");                // load the packed kind word from the property-backed array heap header
+            emitter.instruction("mov r14, r12");                                // preserve the high x86_64 heap-marker bits while rewriting the low container metadata
+            emitter.instruction("and r12, 0x80ff");                             // keep the low indexed-array kind and persistent copy-on-write flag bits while clearing stale value_type bits
+            emitter.instruction("and r14, -65536");                             // keep the high x86_64 heap-marker bits while clearing the low container payload lane
+            emitter.instruction("or r12, r14");                                 // combine the preserved heap marker bits with the stable scalar container metadata
+            emitter.instruction("mov QWORD PTR [r10 - 8], r12");                // persist the scalar-oriented packed kind word back into the heap header
+        }
+    }
+    emitter.label(&skip_normalize);
+}
+
+fn store_property_indexed_array_value_aarch64(
+    elem_ty: &crate::types::PhpType,
+    state: &PropertyIndexedAssignState,
+    emitter: &mut Emitter,
+    ctx: &mut Context,
+) {
+    if state.stores_refcounted_pointer {
+        emitter.instruction("cmp x9, x11");                                     // does this indexed write overwrite an existing property-backed slot from the original logical length?
+        let skip_release = ctx.next_label("prop_array_assign_skip_release");
+        emitter.instruction(&format!("b.hs {}", skip_release));                 // skip release work for writes that extend the property-backed array past its original logical length
+        emitter.instruction("stp x0, x9, [sp, #-16]!");                         // preserve the new nested pointer and target index across the decref helper call
+        emitter.instruction("str x10, [sp, #-16]!");                            // preserve the property-backed array pointer across the decref helper call
+        emitter.instruction("add x12, x10, #24");                               // compute the base of the property-backed array data region
+        emitter.instruction("ldr x0, [x12, x9, lsl #3]");                       // load the previous nested pointer from the overwritten property-backed array slot
+        abi::emit_decref_if_refcounted(emitter, elem_ty);
+        emitter.instruction("ldr x10, [sp], #16");                              // restore the property-backed array pointer after releasing the previous nested payload
+        emitter.instruction("ldp x0, x9, [sp], #16");                           // restore the new nested pointer and target index after releasing the previous nested payload
+        emitter.label(&skip_release);
+        super::super::helpers::stamp_indexed_array_value_type(emitter, "x10", &state.val_ty);
+        emitter.instruction("add x12, x10, #24");                               // compute the base of the property-backed array data region
+        emitter.instruction("str x0, [x12, x9, lsl #3]");                       // store the new nested pointer in the addressed property-backed array slot
+        return;
+    }
+
+    match &state.effective_store_ty {
+        crate::types::PhpType::Int | crate::types::PhpType::Bool | crate::types::PhpType::Callable => {
+            emitter.instruction("add x12, x10, #24");                           // compute the base of the scalar property-backed array data region
+            emitter.instruction("str x0, [x12, x9, lsl #3]");                   // store the scalar payload in the addressed property-backed array slot
+        }
+        crate::types::PhpType::Float => {
+            emitter.instruction("fmov x12, d0");                                // move the floating-point payload bits into an integer scratch register for property-backed indexed storage
+            emitter.instruction("add x13, x10, #24");                           // compute the base of the property-backed array data region
+            emitter.instruction("str x12, [x13, x9, lsl #3]");                  // store the floating-point payload bits in the addressed property-backed array slot
+        }
+        crate::types::PhpType::Str => {
+            emitter.instruction("cmp x9, x11");                                 // does this indexed write overwrite an existing property-backed string slot?
+            let skip_release = ctx.next_label("prop_array_assign_skip_release");
+            emitter.instruction(&format!("b.hs {}", skip_release));             // skip release work for writes that extend the property-backed array past its original logical length
+            emitter.instruction("stp x1, x2, [sp, #-16]!");                     // preserve the new string pointer and length across the previous-string release helper call
+            emitter.instruction("stp x9, x10, [sp, #-16]!");                    // preserve the target index and property-backed array pointer across the previous-string release helper call
+            emitter.instruction("lsl x12, x9, #4");                             // convert the indexed string slot into its 16-byte byte offset
+            emitter.instruction("add x12, x10, x12");                           // compute the address of the overwritten property-backed string slot
+            emitter.instruction("add x12, x12, #24");                           // skip the array header to reach the string-slot payload
+            emitter.instruction("ldr x0, [x12]");                               // load the previous string pointer from the overwritten property-backed array slot
+            emitter.instruction("bl __rt_heap_free_safe");                      // release the previous owned string before replacing the property-backed array slot
+            emitter.instruction("ldp x9, x10, [sp], #16");                      // restore the target index and property-backed array pointer after the previous-string release
+            emitter.instruction("ldp x1, x2, [sp], #16");                       // restore the new string pointer and length after the previous-string release
+            emitter.label(&skip_release);
+            super::super::helpers::stamp_indexed_array_value_type(emitter, "x10", &state.val_ty);
+            emitter.instruction("lsl x12, x9, #4");                             // convert the indexed string slot into its 16-byte byte offset
+            emitter.instruction("add x12, x10, x12");                           // compute the address of the destination property-backed string slot
+            emitter.instruction("add x12, x12, #24");                           // skip the array header to reach the string-slot payload
+            emitter.instruction("str x1, [x12]");                               // store the new string pointer in the destination property-backed array slot
+            emitter.instruction("str x2, [x12, #8]");                           // store the new string length in the destination property-backed array slot
+        }
+        _ => {}
+    }
+}
+
+fn store_property_indexed_array_value_x86_64(
+    elem_ty: &crate::types::PhpType,
+    state: &PropertyIndexedAssignState,
+    emitter: &mut Emitter,
+    ctx: &mut Context,
+) {
+    if state.stores_refcounted_pointer {
+        emitter.instruction("cmp r9, r11");                                     // does this indexed write overwrite an existing property-backed slot from the original logical length?
+        let skip_release = ctx.next_label("prop_array_assign_skip_release");
+        emitter.instruction(&format!("jae {}", skip_release));                  // skip release work for writes that extend the property-backed array past its original logical length
+        abi::emit_push_reg(emitter, "rax");
+        abi::emit_push_reg(emitter, "r9");
+        abi::emit_push_reg(emitter, "r10");
+        emitter.instruction("mov rax, QWORD PTR [r10 + 24 + r9 * 8]");          // load the previous nested pointer from the overwritten property-backed array slot
+        abi::emit_decref_if_refcounted(emitter, elem_ty);
+        abi::emit_pop_reg(emitter, "r10");
+        abi::emit_pop_reg(emitter, "r9");
+        abi::emit_pop_reg(emitter, "rax");
+        emitter.label(&skip_release);
+        abi::emit_push_reg(emitter, "rax");
+        super::super::helpers::stamp_indexed_array_value_type(emitter, "r10", &state.val_ty);
+        abi::emit_pop_reg(emitter, "rax");
+        emitter.instruction("mov QWORD PTR [r10 + 24 + r9 * 8], rax");          // store the new nested pointer in the addressed property-backed array slot
+        return;
+    }
+
+    match &state.effective_store_ty {
+        crate::types::PhpType::Int | crate::types::PhpType::Bool | crate::types::PhpType::Callable => {
+            emitter.instruction("mov QWORD PTR [r10 + 24 + r9 * 8], rax");      // store the scalar payload directly into the addressed property-backed array slot
+        }
+        crate::types::PhpType::Float => {
+            emitter.instruction("movq r12, xmm0");                              // move the floating-point payload bits into an integer scratch register for property-backed indexed storage
+            emitter.instruction("mov QWORD PTR [r10 + 24 + r9 * 8], r12");      // store the floating-point payload bits in the addressed property-backed array slot
+        }
+        crate::types::PhpType::Str => {
+            emitter.instruction("cmp r9, r11");                                 // does this indexed write overwrite an existing property-backed string slot?
+            let skip_release = ctx.next_label("prop_array_assign_skip_release");
+            emitter.instruction(&format!("jae {}", skip_release));              // skip release work for writes that extend the property-backed array past its original logical length
+            abi::emit_push_reg_pair(emitter, "rax", "rdx");
+            abi::emit_push_reg(emitter, "r9");
+            abi::emit_push_reg(emitter, "r10");
+            emitter.instruction("mov rcx, r9");                                 // copy the target index before scaling it into a 16-byte string-slot byte offset
+            emitter.instruction("shl rcx, 4");                                  // convert the target index into the byte offset of the overwritten string slot
+            emitter.instruction("lea rcx, [r10 + rcx + 24]");                   // compute the address of the overwritten property-backed string slot
+            emitter.instruction("mov rax, QWORD PTR [rcx]");                    // load the previous string pointer from the overwritten property-backed array slot
+            abi::emit_call_label(emitter, "__rt_heap_free_safe");
+            abi::emit_pop_reg(emitter, "r10");
+            abi::emit_pop_reg(emitter, "r9");
+            abi::emit_pop_reg_pair(emitter, "rax", "rdx");
+            emitter.label(&skip_release);
+            abi::emit_push_reg_pair(emitter, "rax", "rdx");
+            super::super::helpers::stamp_indexed_array_value_type(emitter, "r10", &state.val_ty);
+            abi::emit_pop_reg_pair(emitter, "rax", "rdx");
+            emitter.instruction("mov rcx, r9");                                 // copy the target index before scaling it into a 16-byte string-slot byte offset
+            emitter.instruction("shl rcx, 4");                                  // convert the target index into the byte offset of the destination string slot
+            emitter.instruction("lea rcx, [r10 + rcx + 24]");                   // compute the address of the destination property-backed string slot
+            emitter.instruction("mov QWORD PTR [rcx], rax");                    // store the new string pointer in the destination property-backed array slot
+            emitter.instruction("mov QWORD PTR [rcx + 8], rdx");                // store the new string length in the destination property-backed array slot
+        }
+        _ => {}
+    }
+}
+
+fn extend_property_indexed_array_if_needed_aarch64(
+    state: &PropertyIndexedAssignState,
+    emitter: &mut Emitter,
+    ctx: &mut Context,
+) {
+    emitter.instruction("ldr x11, [x10]");                                      // reload the current logical length after the indexed store path because helper calls may clobber caller-saved registers
+    let skip_extend = ctx.next_label("prop_array_assign_skip_extend");
+    let extend_loop = ctx.next_label("prop_array_assign_extend_loop");
+    let extend_store_len = ctx.next_label("prop_array_assign_store_len");
+    emitter.instruction("cmp x9, x11");                                         // does this indexed write extend the property-backed array beyond its current logical length?
+    emitter.instruction(&format!("b.lo {}", skip_extend));                      // existing property-backed slots already keep the current logical length
+    emitter.instruction("mov x12, x11");                                        // start zero-filling at the previous logical end of the property-backed array
+    emitter.label(&extend_loop);
+    emitter.instruction("cmp x12, x9");                                         // have we filled every property-backed gap slot before the target index?
+    emitter.instruction(&format!("b.ge {}", extend_store_len));                 // stop zero-filling once we reach the target indexed slot
+    match &state.effective_store_ty {
+        crate::types::PhpType::Str => {
+            emitter.instruction("lsl x13, x12, #4");                            // convert the gap index into the byte offset of the 16-byte string slot
+            emitter.instruction("add x13, x10, x13");                           // compute the address of the property-backed string gap slot
+            emitter.instruction("add x13, x13, #24");                           // skip the array header to reach the string-slot payload
+            emitter.instruction("str xzr, [x13]");                              // initialize the gap string pointer to null
+            emitter.instruction("str xzr, [x13, #8]");                          // initialize the gap string length to zero
+        }
+        _ => {
+            emitter.instruction("add x13, x10, #24");                           // compute the base of the property-backed scalar or pointer data region
+            emitter.instruction("str xzr, [x13, x12, lsl #3]");                 // initialize the property-backed gap slot to zero/null
+        }
+    }
+    emitter.instruction("add x12, x12, #1");                                    // advance to the next gap slot that still needs zero-initialization
+    emitter.instruction(&format!("b {}", extend_loop));                         // continue zero-filling until the target indexed slot is reached
+    emitter.label(&extend_store_len);
+    emitter.instruction("add x12, x9, #1");                                     // compute the new logical length as the highest written index plus one
+    emitter.instruction("str x12, [x10]");                                      // persist the extended logical length in the property-backed array header
+    emitter.label(&skip_extend);
+}
+
+fn extend_property_indexed_array_if_needed_x86_64(
+    state: &PropertyIndexedAssignState,
+    emitter: &mut Emitter,
+    ctx: &mut Context,
+) {
+    emitter.instruction("mov r11, QWORD PTR [r10]");                            // reload the current logical length after the indexed store path because helper calls may clobber caller-saved registers
+    let skip_extend = ctx.next_label("prop_array_assign_skip_extend");
+    let extend_loop = ctx.next_label("prop_array_assign_extend_loop");
+    let extend_store_len = ctx.next_label("prop_array_assign_store_len");
+    emitter.instruction("cmp r9, r11");                                         // does this indexed write extend the property-backed array beyond its current logical length?
+    emitter.instruction(&format!("jb {}", skip_extend));                        // existing property-backed slots already keep the current logical length
+    emitter.instruction("mov r12, r11");                                        // start zero-filling at the previous logical end of the property-backed array
+    emitter.label(&extend_loop);
+    emitter.instruction("cmp r12, r9");                                         // have we filled every property-backed gap slot before the target index?
+    emitter.instruction(&format!("jae {}", extend_store_len));                  // stop zero-filling once we reach the target indexed slot
+    match &state.effective_store_ty {
+        crate::types::PhpType::Str => {
+            emitter.instruction("mov r13, r12");                                // copy the gap index before scaling it into a 16-byte string-slot byte offset
+            emitter.instruction("shl r13, 4");                                  // convert the gap index into the byte offset of the property-backed string slot
+            emitter.instruction("lea r13, [r10 + r13 + 24]");                   // compute the address of the property-backed string gap slot
+            emitter.instruction("mov QWORD PTR [r13], 0");                      // initialize the gap string pointer to null
+            emitter.instruction("mov QWORD PTR [r13 + 8], 0");                  // initialize the gap string length to zero
+        }
+        _ => {
+            emitter.instruction("mov QWORD PTR [r10 + 24 + r12 * 8], 0");       // initialize the property-backed scalar or pointer gap slot to zero/null
+        }
+    }
+    emitter.instruction("add r12, 1");                                          // advance to the next gap slot that still needs zero-initialization
+    emitter.instruction(&format!("jmp {}", extend_loop));                       // continue zero-filling until the target indexed slot is reached
+    emitter.label(&extend_store_len);
+    emitter.instruction("lea r12, [r9 + 1]");                                   // compute the new logical length as the highest written index plus one
+    emitter.instruction("mov QWORD PTR [r10], r12");                            // persist the extended logical length in the property-backed array header
+    emitter.label(&skip_extend);
+}

--- a/src/conditional.rs
+++ b/src/conditional.rs
@@ -269,6 +269,15 @@ fn rewrite_stmt_kind(kind: StmtKind, defines: &HashSet<String>) -> StmtKind {
             property,
             value: rewrite_expr(value, defines),
         },
+        StmtKind::PropertyArrayPush {
+            object,
+            property,
+            value,
+        } => StmtKind::PropertyArrayPush {
+            object: Box::new(rewrite_expr(*object, defines)),
+            property,
+            value: rewrite_expr(value, defines),
+        },
         StmtKind::ExternFunctionDecl {
             name,
             params,

--- a/src/conditional.rs
+++ b/src/conditional.rs
@@ -278,6 +278,17 @@ fn rewrite_stmt_kind(kind: StmtKind, defines: &HashSet<String>) -> StmtKind {
             property,
             value: rewrite_expr(value, defines),
         },
+        StmtKind::PropertyArrayAssign {
+            object,
+            property,
+            index,
+            value,
+        } => StmtKind::PropertyArrayAssign {
+            object: Box::new(rewrite_expr(*object, defines)),
+            property,
+            index: rewrite_expr(index, defines),
+            value: rewrite_expr(value, defines),
+        },
         StmtKind::ExternFunctionDecl {
             name,
             params,

--- a/src/name_resolver/statements.rs
+++ b/src/name_resolver/statements.rs
@@ -410,6 +410,25 @@ pub(super) fn resolve_stmt_list(
                             stmt.span,
                         ));
                     }
+                    StmtKind::PropertyArrayPush {
+                        object,
+                        property,
+                        value,
+                    } => {
+                        resolved.push(Stmt::new(
+                            StmtKind::PropertyArrayPush {
+                                object: Box::new(resolve_expr(
+                                    object,
+                                    namespace.as_deref(),
+                                    &imports,
+                                    symbols,
+                                )),
+                                property: property.clone(),
+                                value: resolve_expr(value, namespace.as_deref(), &imports, symbols),
+                            },
+                            stmt.span,
+                        ));
+                    }
                     _ => resolved.push(stmt.clone()),
                 }
             }

--- a/src/name_resolver/statements.rs
+++ b/src/name_resolver/statements.rs
@@ -429,6 +429,27 @@ pub(super) fn resolve_stmt_list(
                             stmt.span,
                         ));
                     }
+                    StmtKind::PropertyArrayAssign {
+                        object,
+                        property,
+                        index,
+                        value,
+                    } => {
+                        resolved.push(Stmt::new(
+                            StmtKind::PropertyArrayAssign {
+                                object: Box::new(resolve_expr(
+                                    object,
+                                    namespace.as_deref(),
+                                    &imports,
+                                    symbols,
+                                )),
+                                property: property.clone(),
+                                index: resolve_expr(index, namespace.as_deref(), &imports, symbols),
+                                value: resolve_expr(value, namespace.as_deref(), &imports, symbols),
+                            },
+                            stmt.span,
+                        ));
+                    }
                     _ => resolved.push(stmt.clone()),
                 }
             }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -390,6 +390,12 @@ pub enum StmtKind {
         property: String,
         value: Expr,
     },
+    PropertyArrayAssign {
+        object: Box<Expr>,
+        property: String,
+        index: Expr,
+        value: Expr,
+    },
     ExternFunctionDecl {
         name: String,
         params: Vec<ExternParam>,

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -385,6 +385,11 @@ pub enum StmtKind {
         property: String,
         value: Expr,
     },
+    PropertyArrayPush {
+        object: Box<Expr>,
+        property: String,
+        value: Expr,
+    },
     ExternFunctionDecl {
         name: String,
         params: Vec<ExternParam>,

--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -166,14 +166,19 @@ pub(super) fn try_parse_postfix_assignment(
             value,
         },
         ExprKind::ArrayAccess { array, index } => {
-            if let ExprKind::Variable(array) = array.kind {
-                StmtKind::ArrayAssign {
+            match array.kind {
+                ExprKind::Variable(array) => StmtKind::ArrayAssign {
                     array,
                     index: *index,
                     value,
-                }
-            } else {
-                return Err(CompileError::new(span, "Invalid assignment target"));
+                },
+                ExprKind::PropertyAccess { object, property } => StmtKind::PropertyArrayAssign {
+                    object,
+                    property,
+                    index: *index,
+                    value,
+                },
+                _ => return Err(CompileError::new(span, "Invalid assignment target")),
             }
         }
         ExprKind::PropertyAccess { object, property } => StmtKind::PropertyAssign {

--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -13,97 +13,13 @@ pub(super) fn parse_variable_stmt(
     pos: &mut usize,
     span: Span,
 ) -> Result<Stmt, CompileError> {
-    let start_pos = *pos;
     let name = match &tokens[*pos].0 {
         Token::Variable(n) => n.clone(),
         _ => unreachable!(),
     };
 
-    // Property access/method call: $var->prop or $var->method()
-    if *pos + 1 < tokens.len() && tokens[*pos + 1].0 == Token::Arrow {
-        // Parse as expression first (handles $var->method() and chained access)
-        let expr = parse_expr(tokens, pos)?;
-        // Check if followed by assignment: $var->prop = value;
-        if *pos < tokens.len() && tokens[*pos].0 == Token::Assign {
-            *pos += 1;
-            let value = parse_expr(tokens, pos)?;
-            expect_semicolon(tokens, pos)?;
-            // Extract property from the expression
-            if let ExprKind::PropertyAccess { object, property } = expr.kind {
-                return Ok(Stmt::new(
-                    StmtKind::PropertyAssign {
-                        object,
-                        property,
-                        value,
-                    },
-                    span,
-                ));
-            }
-            return Err(CompileError::new(span, "Invalid assignment target"));
-        }
-        expect_semicolon(tokens, pos)?;
-        return Ok(Stmt::new(StmtKind::ExprStmt(expr), span));
-    }
-
-    // Array access: $var[...]
-    if *pos + 1 < tokens.len() && tokens[*pos + 1].0 == Token::LBracket {
-        *pos += 1; // consume $var
-        *pos += 1; // consume [
-
-        // $var[] = ... (push)
-        if *pos < tokens.len() && tokens[*pos].0 == Token::RBracket {
-            *pos += 1;
-            expect_token(tokens, pos, &Token::Assign, "Expected '=' after '$var[]'")?;
-            let value = parse_expr(tokens, pos)?;
-            expect_semicolon(tokens, pos)?;
-            return Ok(Stmt::new(StmtKind::ArrayPush { array: name, value }, span));
-        }
-
-        // $var[index] = ...
-        let index = parse_expr(tokens, pos)?;
-        if *pos >= tokens.len() || tokens[*pos].0 != Token::RBracket {
-            return Err(CompileError::new(span, "Expected ']'"));
-        }
-        *pos += 1;
-
-        if *pos < tokens.len() && tokens[*pos].0 == Token::Arrow {
-            *pos = start_pos;
-            let expr = parse_expr(tokens, pos)?;
-            if *pos < tokens.len() && tokens[*pos].0 == Token::Assign {
-                *pos += 1;
-                let value = parse_expr(tokens, pos)?;
-                expect_semicolon(tokens, pos)?;
-                if let ExprKind::PropertyAccess { object, property } = expr.kind {
-                    return Ok(Stmt::new(
-                        StmtKind::PropertyAssign {
-                            object,
-                            property,
-                            value,
-                        },
-                        span,
-                    ));
-                }
-                return Err(CompileError::new(span, "Invalid assignment target"));
-            }
-            expect_semicolon(tokens, pos)?;
-            return Ok(Stmt::new(StmtKind::ExprStmt(expr), span));
-        }
-
-        if *pos < tokens.len() && tokens[*pos].0 == Token::Assign {
-            *pos += 1;
-            let value = parse_expr(tokens, pos)?;
-            expect_semicolon(tokens, pos)?;
-            return Ok(Stmt::new(
-                StmtKind::ArrayAssign {
-                    array: name,
-                    index,
-                    value,
-                },
-                span,
-            ));
-        }
-
-        return Err(CompileError::new(span, "Expected '=' after array access"));
+    if let Some(stmt) = try_parse_postfix_assignment(tokens, pos, span)? {
+        return Ok(stmt);
     }
 
     // Post-increment/decrement
@@ -123,6 +39,30 @@ pub(super) fn parse_variable_stmt(
             }
             _ => {}
         }
+    }
+
+    if *pos + 1 < tokens.len()
+        && matches!(tokens[*pos + 1].0, Token::Arrow | Token::LBracket)
+    {
+        let expr = parse_expr(tokens, pos)?;
+        if *pos < tokens.len() && tokens[*pos].0 == Token::Assign {
+            *pos += 1;
+            let value = parse_expr(tokens, pos)?;
+            expect_semicolon(tokens, pos)?;
+            if let ExprKind::PropertyAccess { object, property } = expr.kind {
+                return Ok(Stmt::new(
+                    StmtKind::PropertyAssign {
+                        object,
+                        property,
+                        value,
+                    },
+                    span,
+                ));
+            }
+            return Err(CompileError::new(span, "Invalid assignment target"));
+        }
+        expect_semicolon(tokens, pos)?;
+        return Ok(Stmt::new(StmtKind::ExprStmt(expr), span));
     }
 
     // Closure call: $fn(args);
@@ -181,6 +121,98 @@ pub(super) fn parse_assign(
     };
 
     Ok(Stmt::new(StmtKind::Assign { name, value }, span))
+}
+
+pub(super) fn try_parse_postfix_assignment(
+    tokens: &[(Token, Span)],
+    pos: &mut usize,
+    span: Span,
+) -> Result<Option<Stmt>, CompileError> {
+    let start = *pos;
+    let Some(assign_pos) = find_top_level_assign(tokens, start) else {
+        return Ok(None);
+    };
+    if assign_pos < start + 3 {
+        return Ok(None);
+    }
+
+    let lhs = &tokens[start..assign_pos];
+    let is_append =
+        lhs.len() >= 3 && lhs[lhs.len() - 2].0 == Token::LBracket && lhs[lhs.len() - 1].0 == Token::RBracket;
+    let contains_postfix = lhs
+        .iter()
+        .skip(1)
+        .any(|(token, _)| matches!(token, Token::Arrow | Token::LBracket));
+    if !contains_postfix {
+        return Ok(None);
+    }
+
+    let mut lhs_pos = 0;
+    let lhs_expr_tokens = if is_append { &lhs[..lhs.len() - 2] } else { lhs };
+    let lhs_expr = parse_expr(lhs_expr_tokens, &mut lhs_pos)?;
+    if lhs_pos != lhs_expr_tokens.len() {
+        return Err(CompileError::new(span, "Invalid assignment target"));
+    }
+
+    *pos = assign_pos + 1;
+    let value = parse_expr(tokens, pos)?;
+    expect_semicolon(tokens, pos)?;
+
+    let stmt = match lhs_expr.kind {
+        ExprKind::Variable(array) if is_append => StmtKind::ArrayPush { array, value },
+        ExprKind::PropertyAccess { object, property } if is_append => StmtKind::PropertyArrayPush {
+            object,
+            property,
+            value,
+        },
+        ExprKind::ArrayAccess { array, index } => {
+            if let ExprKind::Variable(array) = array.kind {
+                StmtKind::ArrayAssign {
+                    array,
+                    index: *index,
+                    value,
+                }
+            } else {
+                return Err(CompileError::new(span, "Invalid assignment target"));
+            }
+        }
+        ExprKind::PropertyAccess { object, property } => StmtKind::PropertyAssign {
+            object,
+            property,
+            value,
+        },
+        _ => return Err(CompileError::new(span, "Invalid assignment target")),
+    };
+
+    Ok(Some(Stmt::new(stmt, span)))
+}
+
+fn find_top_level_assign(tokens: &[(Token, Span)], start: usize) -> Option<usize> {
+    let mut paren_depth = 0usize;
+    let mut bracket_depth = 0usize;
+    let mut brace_depth = 0usize;
+    let mut pos = start;
+
+    while pos < tokens.len() {
+        match tokens[pos].0 {
+            Token::LParen => paren_depth += 1,
+            Token::RParen => paren_depth = paren_depth.saturating_sub(1),
+            Token::LBracket => bracket_depth += 1,
+            Token::RBracket => bracket_depth = bracket_depth.saturating_sub(1),
+            Token::LBrace => brace_depth += 1,
+            Token::RBrace => brace_depth = brace_depth.saturating_sub(1),
+            Token::Assign if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0 => {
+                return Some(pos);
+            }
+            Token::Semicolon if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0 => {
+                return None;
+            }
+            _ => {}
+        }
+        pos += 1;
+    }
+
+    None
 }
 
 /// Handle ++$var; or --$var; as standalone statements.

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -4,6 +4,7 @@ use crate::parser::ast::{ExprKind, Stmt, StmtKind};
 use crate::parser::expr::parse_expr;
 use crate::span::Span;
 
+use super::assign::try_parse_postfix_assignment;
 use super::{expect_semicolon, expect_token};
 
 pub(super) fn parse_include(
@@ -91,6 +92,10 @@ pub(super) fn parse_this_stmt(
     pos: &mut usize,
     span: Span,
 ) -> Result<Stmt, CompileError> {
+    if let Some(stmt) = try_parse_postfix_assignment(tokens, pos, span)? {
+        return Ok(stmt);
+    }
+
     // Parse as expression first
     let expr = parse_expr(tokens, pos)?;
     // Check if followed by assignment

--- a/src/types/checker/driver.rs
+++ b/src/types/checker/driver.rs
@@ -124,27 +124,31 @@ pub(super) fn check_types_impl(
 
     checker.prescan_extern_decls(program, &mut errors);
 
-    let mut global_env: TypeEnv = HashMap::new();
-    global_env.insert("argc".to_string(), PhpType::Int);
-    global_env.insert("argv".to_string(), PhpType::Array(Box::new(PhpType::Str)));
-    for (name, ty) in &checker.extern_globals {
-        global_env.insert(name.clone(), ty.clone());
-    }
-    for stmt in program {
-        checker.top_level_env = global_env.clone();
-        if let Err(error) = checker.check_stmt(stmt, &mut global_env) {
-            errors.extend(error.flatten());
-        }
-    }
+    let (global_env, initial_top_level_errors) = checker.check_top_level_program(program);
 
     checker.resolve_unchecked_functions(&mut errors);
     checker.type_check_methods_until_stable(&flattened_classes, &global_env, &mut errors)?;
+
+    let (final_global_env, final_top_level_errors) = checker.check_top_level_program(program);
+    for ((stmt, initial_errors), final_errors) in program
+        .iter()
+        .zip(initial_top_level_errors.into_iter())
+        .zip(final_top_level_errors.into_iter())
+    {
+        if !final_errors.is_empty() {
+            errors.extend(final_errors);
+            continue;
+        }
+        if !Checker::can_suppress_initial_top_level_errors(stmt, &initial_errors) {
+            errors.extend(initial_errors);
+        }
+    }
 
     if !errors.is_empty() {
         return Err(CompileError::from_many(errors));
     }
 
-    Ok((checker, global_env))
+    Ok((checker, final_global_env))
 }
 
 impl Checker {
@@ -405,6 +409,167 @@ impl Checker {
                     Err(error) => errors.extend(error.flatten()),
                 }
             }
+        }
+    }
+
+    fn seed_global_env(&self) -> TypeEnv {
+        let mut global_env: TypeEnv = HashMap::new();
+        global_env.insert("argc".to_string(), PhpType::Int);
+        global_env.insert("argv".to_string(), PhpType::Array(Box::new(PhpType::Str)));
+        for (name, ty) in &self.extern_globals {
+            global_env.insert(name.clone(), ty.clone());
+        }
+        global_env
+    }
+
+    fn check_top_level_program(
+        &mut self,
+        program: &Program,
+    ) -> (TypeEnv, Vec<Vec<CompileError>>) {
+        let mut global_env = self.seed_global_env();
+        let mut all_errors = Vec::with_capacity(program.len());
+        for stmt in program {
+            self.top_level_env = global_env.clone();
+            let stmt_errors = self
+                .check_stmt(stmt, &mut global_env)
+                .err()
+                .map(|error| error.flatten())
+                .unwrap_or_default();
+            all_errors.push(stmt_errors);
+        }
+        (global_env, all_errors)
+    }
+
+    fn can_suppress_initial_top_level_errors(
+        stmt: &crate::parser::ast::Stmt,
+        errors: &[CompileError],
+    ) -> bool {
+        !errors.is_empty()
+            && Self::stmt_contains_method_call(stmt)
+            && errors.iter().all(|error| {
+                matches!(
+                    error.message.as_str(),
+                    "Cannot index non-array"
+                        | "Property access requires an object or typed pointer"
+                )
+            })
+    }
+
+    fn stmt_contains_method_call(stmt: &crate::parser::ast::Stmt) -> bool {
+        match &stmt.kind {
+            StmtKind::ExprStmt(expr)
+            | StmtKind::Echo(expr)
+            | StmtKind::Return(Some(expr)) => Self::expr_contains_method_call(expr),
+            StmtKind::Assign { value, .. }
+            | StmtKind::TypedAssign { value, .. }
+            | StmtKind::ConstDecl { value, .. }
+            | StmtKind::ListUnpack { value, .. } => Self::expr_contains_method_call(value),
+            StmtKind::ArrayAssign { index, value, .. } => {
+                Self::expr_contains_method_call(index) || Self::expr_contains_method_call(value)
+            }
+            StmtKind::ArrayPush { value, .. } => Self::expr_contains_method_call(value),
+            StmtKind::PropertyAssign { object, value, .. } => {
+                Self::expr_contains_method_call(object) || Self::expr_contains_method_call(value)
+            }
+            StmtKind::PropertyArrayPush { object, value, .. } => {
+                Self::expr_contains_method_call(object) || Self::expr_contains_method_call(value)
+            }
+            StmtKind::PropertyArrayAssign {
+                object,
+                index,
+                value,
+                ..
+            } => {
+                Self::expr_contains_method_call(object)
+                    || Self::expr_contains_method_call(index)
+                    || Self::expr_contains_method_call(value)
+            }
+            _ => false,
+        }
+    }
+
+    fn expr_contains_method_call(expr: &Expr) -> bool {
+        match &expr.kind {
+            crate::parser::ast::ExprKind::MethodCall { object, args, .. } => {
+                Self::expr_contains_method_call(object)
+                    || args.iter().any(Self::expr_contains_method_call)
+                    || true
+            }
+            crate::parser::ast::ExprKind::PropertyAccess { object, .. }
+            | crate::parser::ast::ExprKind::Negate(object)
+            | crate::parser::ast::ExprKind::Not(object)
+            | crate::parser::ast::ExprKind::BitNot(object)
+            | crate::parser::ast::ExprKind::Spread(object)
+            | crate::parser::ast::ExprKind::Throw(object) => Self::expr_contains_method_call(object),
+            crate::parser::ast::ExprKind::ArrayAccess { array, index } => {
+                Self::expr_contains_method_call(array) || Self::expr_contains_method_call(index)
+            }
+            crate::parser::ast::ExprKind::BinaryOp { left, right, .. } => {
+                Self::expr_contains_method_call(left) || Self::expr_contains_method_call(right)
+            }
+            crate::parser::ast::ExprKind::Ternary {
+                condition,
+                then_expr,
+                else_expr,
+            } => {
+                Self::expr_contains_method_call(condition)
+                    || Self::expr_contains_method_call(then_expr)
+                    || Self::expr_contains_method_call(else_expr)
+            }
+            crate::parser::ast::ExprKind::NullCoalesce { value, default } => {
+                Self::expr_contains_method_call(value) || Self::expr_contains_method_call(default)
+            }
+            crate::parser::ast::ExprKind::FunctionCall { args, .. }
+            | crate::parser::ast::ExprKind::ClosureCall { args, .. }
+            | crate::parser::ast::ExprKind::ExprCall { args, .. }
+            | crate::parser::ast::ExprKind::StaticMethodCall { args, .. }
+            | crate::parser::ast::ExprKind::NewObject { args, .. } => {
+                args.iter().any(Self::expr_contains_method_call)
+            }
+            crate::parser::ast::ExprKind::Match {
+                subject,
+                arms,
+                default,
+            } => {
+                Self::expr_contains_method_call(subject)
+                    || arms.iter().any(|(conditions, result)| {
+                        conditions.iter().any(Self::expr_contains_method_call)
+                            || Self::expr_contains_method_call(result)
+                    })
+                    || default
+                        .as_ref()
+                        .map(|expr| Self::expr_contains_method_call(expr))
+                        .unwrap_or(false)
+            }
+            crate::parser::ast::ExprKind::ArrayLiteral(items) => {
+                items.iter().any(Self::expr_contains_method_call)
+            }
+            crate::parser::ast::ExprKind::ArrayLiteralAssoc(items) => items.iter().any(
+                |(key, value)| {
+                    Self::expr_contains_method_call(key) || Self::expr_contains_method_call(value)
+                },
+            ),
+            crate::parser::ast::ExprKind::Cast { expr, .. }
+            | crate::parser::ast::ExprKind::PtrCast { expr, .. }
+            | crate::parser::ast::ExprKind::NamedArg { value: expr, .. } => {
+                Self::expr_contains_method_call(expr)
+            }
+            crate::parser::ast::ExprKind::Closure { .. }
+            | crate::parser::ast::ExprKind::FirstClassCallable(_)
+            | crate::parser::ast::ExprKind::EnumCase { .. }
+            | crate::parser::ast::ExprKind::BoolLiteral(_)
+            | crate::parser::ast::ExprKind::Null
+            | crate::parser::ast::ExprKind::StringLiteral(_)
+            | crate::parser::ast::ExprKind::IntLiteral(_)
+            | crate::parser::ast::ExprKind::FloatLiteral(_)
+            | crate::parser::ast::ExprKind::Variable(_)
+            | crate::parser::ast::ExprKind::PreIncrement(_)
+            | crate::parser::ast::ExprKind::PostIncrement(_)
+            | crate::parser::ast::ExprKind::PreDecrement(_)
+            | crate::parser::ast::ExprKind::PostDecrement(_)
+            | crate::parser::ast::ExprKind::ConstRef(_)
+            | crate::parser::ast::ExprKind::This
+            | crate::parser::ast::ExprKind::BufferNew { .. } => false,
         }
     }
 }

--- a/src/types/checker/extern_decl.rs
+++ b/src/types/checker/extern_decl.rs
@@ -173,11 +173,19 @@ impl Checker {
             ));
         }
         if let Some(sig) = self.functions.get(callback_name) {
+            if !Self::callback_type_is_c_compatible(&sig.return_type) {
+                return Err(CompileError::new(
+                    span,
+                    &format!(
+                        "Callback function '{}' uses an unsupported return type; only int, float, bool, ptr, and void are supported",
+                        callback_name
+                    ),
+                ));
+            }
             if sig
                 .params
                 .iter()
                 .any(|(_, ty)| !Self::callback_type_is_c_compatible(ty))
-                || !Self::callback_type_is_c_compatible(&sig.return_type)
             {
                 return Err(CompileError::new(
                     span,

--- a/src/types/checker/stmt_check.rs
+++ b/src/types/checker/stmt_check.rs
@@ -32,7 +32,8 @@ impl Checker {
             | StmtKind::Global { .. }
             | StmtKind::StaticVar { .. }
             | StmtKind::PropertyAssign { .. }
-            | StmtKind::PropertyArrayPush { .. } => self.check_assignment_like_stmt(stmt, env),
+            | StmtKind::PropertyArrayPush { .. }
+            | StmtKind::PropertyArrayAssign { .. } => self.check_assignment_like_stmt(stmt, env),
             StmtKind::Foreach { .. }
             | StmtKind::Switch { .. }
             | StmtKind::If { .. }

--- a/src/types/checker/stmt_check.rs
+++ b/src/types/checker/stmt_check.rs
@@ -31,7 +31,8 @@ impl Checker {
             | StmtKind::ListUnpack { .. }
             | StmtKind::Global { .. }
             | StmtKind::StaticVar { .. }
-            | StmtKind::PropertyAssign { .. } => self.check_assignment_like_stmt(stmt, env),
+            | StmtKind::PropertyAssign { .. }
+            | StmtKind::PropertyArrayPush { .. } => self.check_assignment_like_stmt(stmt, env),
             StmtKind::Foreach { .. }
             | StmtKind::Switch { .. }
             | StmtKind::If { .. }

--- a/src/types/checker/stmt_check/assignments.rs
+++ b/src/types/checker/stmt_check/assignments.rs
@@ -453,6 +453,158 @@ impl Checker {
                     )),
                 }
             }
+            StmtKind::PropertyArrayAssign {
+                object,
+                property,
+                index,
+                value,
+            } => {
+                let obj_ty = self.infer_type(object, env)?;
+                let idx_ty = self.infer_type(index, env)?;
+                let val_ty = self.infer_type(value, env)?;
+                match &obj_ty {
+                    PhpType::Object(class_name) => {
+                        let prop_ty = {
+                            let class_info = self.classes.get(class_name).ok_or_else(|| {
+                                CompileError::new(
+                                    stmt.span,
+                                    &format!("Undefined class: {}", class_name),
+                                )
+                            })?;
+                            if !class_info.properties.iter().any(|(n, _)| n == property) {
+                                return Err(CompileError::new(
+                                    stmt.span,
+                                    &format!("Undefined property: {}::{}", class_name, property),
+                                ));
+                            }
+                            if let Some(visibility) = class_info.property_visibilities.get(property) {
+                                let declaring_class = class_info
+                                    .property_declaring_classes
+                                    .get(property)
+                                    .map(String::as_str)
+                                    .unwrap_or(class_name);
+                                if !self.can_access_member(declaring_class, visibility) {
+                                    return Err(CompileError::new(
+                                        stmt.span,
+                                        &format!(
+                                            "Cannot access {} property: {}::{}",
+                                            Self::visibility_label(visibility),
+                                            class_name,
+                                            property
+                                        ),
+                                    ));
+                                }
+                            }
+                            if class_info.readonly_properties.contains(property)
+                                && !(self.current_class.as_deref()
+                                    == class_info
+                                        .property_declaring_classes
+                                        .get(property)
+                                        .map(String::as_str)
+                                    && self.current_method.as_deref() == Some("__construct"))
+                            {
+                                return Err(CompileError::new(
+                                    stmt.span,
+                                    &format!(
+                                        "Cannot assign to readonly property outside constructor: {}::{}",
+                                        class_name, property
+                                    ),
+                                ));
+                            }
+                            class_info
+                                .properties
+                                .iter()
+                                .find(|(name, _)| name == property)
+                                .map(|(_, ty)| ty.clone())
+                                .unwrap_or(PhpType::Int)
+                        };
+
+                        if idx_ty != PhpType::Int {
+                            return Err(CompileError::new(
+                                stmt.span,
+                                "Array index must be integer",
+                            ));
+                        }
+
+                        let updated_prop_ty = match prop_ty {
+                            PhpType::Array(elem_ty) => {
+                                if *elem_ty == val_ty {
+                                    PhpType::Array(elem_ty)
+                                } else {
+                                    let merged_ty = self
+                                        .merge_array_element_type(&elem_ty, &val_ty)
+                                        .unwrap_or(val_ty.clone());
+                                    PhpType::Array(Box::new(merged_ty))
+                                }
+                            }
+                            other => {
+                                return Err(CompileError::new(
+                                    stmt.span,
+                                    &format!(
+                                        "Array index assignment requires an array property, got {}",
+                                        other
+                                    ),
+                                ))
+                            }
+                        };
+
+                        if let Some(class_info) = self.classes.get_mut(class_name) {
+                            if let Some(prop) = class_info
+                                .properties
+                                .iter_mut()
+                                .find(|(name, _)| name == property)
+                            {
+                                prop.1 = updated_prop_ty;
+                            }
+                        }
+                        Ok(())
+                    }
+                    PhpType::Pointer(Some(class_name)) => {
+                        let field_ty = if let Some(field_ty) = self.extern_field_type(class_name, property) {
+                            field_ty
+                        } else if let Some(field_ty) = self.packed_field_type(class_name, property) {
+                            field_ty
+                        } else if self.extern_classes.contains_key(class_name) {
+                            return Err(CompileError::new(
+                                stmt.span,
+                                &format!("Undefined extern field: {}::{}", class_name, property),
+                            ));
+                        } else if self.packed_classes.contains_key(class_name) {
+                            return Err(CompileError::new(
+                                stmt.span,
+                                &format!("Undefined packed field: {}::{}", class_name, property),
+                            ));
+                        } else {
+                            return Err(CompileError::new(
+                                stmt.span,
+                                "Array index assignment requires an object or typed pointer",
+                            ));
+                        };
+
+                        if idx_ty != PhpType::Int {
+                            return Err(CompileError::new(
+                                stmt.span,
+                                "Array index must be integer",
+                            ));
+                        }
+
+                        match field_ty {
+                            PhpType::Array(_) => Ok(()),
+                            other => Err(CompileError::new(
+                                stmt.span,
+                                &format!(
+                                    "Array index assignment requires an array property, got {}",
+                                    other
+                                ),
+                            )),
+                        }
+                    }
+                    _ => Err(CompileError::new(
+                        stmt.span,
+                        "Array index assignment requires an object or typed pointer",
+                    )),
+                }
+            }
             _ => unreachable!("non-assignment statement routed to assignment checker"),
         }
     }

--- a/src/types/checker/stmt_check/assignments.rs
+++ b/src/types/checker/stmt_check/assignments.rs
@@ -309,6 +309,150 @@ impl Checker {
                 }
                 Ok(())
             }
+            StmtKind::PropertyArrayPush {
+                object,
+                property,
+                value,
+            } => {
+                let obj_ty = self.infer_type(object, env)?;
+                let val_ty = self.infer_type(value, env)?;
+                match &obj_ty {
+                    PhpType::Object(class_name) => {
+                        let prop_ty = {
+                            let class_info = self.classes.get(class_name).ok_or_else(|| {
+                                CompileError::new(
+                                    stmt.span,
+                                    &format!("Undefined class: {}", class_name),
+                                )
+                            })?;
+                            if !class_info.properties.iter().any(|(n, _)| n == property) {
+                                return Err(CompileError::new(
+                                    stmt.span,
+                                    &format!("Undefined property: {}::{}", class_name, property),
+                                ));
+                            }
+                            if let Some(visibility) = class_info.property_visibilities.get(property) {
+                                let declaring_class = class_info
+                                    .property_declaring_classes
+                                    .get(property)
+                                    .map(String::as_str)
+                                    .unwrap_or(class_name);
+                                if !self.can_access_member(declaring_class, visibility) {
+                                    return Err(CompileError::new(
+                                        stmt.span,
+                                        &format!(
+                                            "Cannot access {} property: {}::{}",
+                                            Self::visibility_label(visibility),
+                                            class_name,
+                                            property
+                                        ),
+                                    ));
+                                }
+                            }
+                            if class_info.readonly_properties.contains(property)
+                                && !(self.current_class.as_deref()
+                                    == class_info
+                                        .property_declaring_classes
+                                        .get(property)
+                                        .map(String::as_str)
+                                    && self.current_method.as_deref() == Some("__construct"))
+                            {
+                                return Err(CompileError::new(
+                                    stmt.span,
+                                    &format!(
+                                        "Cannot assign to readonly property outside constructor: {}::{}",
+                                        class_name, property
+                                    ),
+                                ));
+                            }
+                            class_info
+                                .properties
+                                .iter()
+                                .find(|(name, _)| name == property)
+                                .map(|(_, ty)| ty.clone())
+                                .unwrap_or(PhpType::Int)
+                        };
+
+                        let updated_prop_ty = match prop_ty {
+                            PhpType::Array(elem_ty) => {
+                                if *elem_ty == val_ty {
+                                    PhpType::Array(elem_ty)
+                                } else {
+                                    let merged_ty = self
+                                        .merge_array_element_type(&elem_ty, &val_ty)
+                                        .unwrap_or(val_ty.clone());
+                                    PhpType::Array(Box::new(merged_ty))
+                                }
+                            }
+                            PhpType::Int => PhpType::Array(Box::new(val_ty.clone())),
+                            PhpType::Buffer(_) => {
+                                return Err(CompileError::new(
+                                    stmt.span,
+                                    "buffer<T> does not support push; allocate with buffer_new<T>(len)",
+                                ))
+                            }
+                            other => {
+                                return Err(CompileError::new(
+                                    stmt.span,
+                                    &format!(
+                                        "Array push requires an array property, got {}",
+                                        other
+                                    ),
+                                ))
+                            }
+                        };
+
+                        if let Some(class_info) = self.classes.get_mut(class_name) {
+                            if let Some(prop) = class_info
+                                .properties
+                                .iter_mut()
+                                .find(|(name, _)| name == property)
+                            {
+                                prop.1 = updated_prop_ty;
+                            }
+                        }
+                        Ok(())
+                    }
+                    PhpType::Pointer(Some(class_name)) => {
+                        let field_ty = if let Some(field_ty) = self.extern_field_type(class_name, property) {
+                            field_ty
+                        } else if let Some(field_ty) = self.packed_field_type(class_name, property) {
+                            field_ty
+                        } else if self.extern_classes.contains_key(class_name) {
+                            return Err(CompileError::new(
+                                stmt.span,
+                                &format!("Undefined extern field: {}::{}", class_name, property),
+                            ));
+                        } else if self.packed_classes.contains_key(class_name) {
+                            return Err(CompileError::new(
+                                stmt.span,
+                                &format!("Undefined packed field: {}::{}", class_name, property),
+                            ));
+                        } else {
+                            return Err(CompileError::new(
+                                stmt.span,
+                                "Array push requires an object or typed pointer",
+                            ));
+                        };
+
+                        match field_ty {
+                            PhpType::Array(_) => Ok(()),
+                            PhpType::Buffer(_) => Err(CompileError::new(
+                                stmt.span,
+                                "buffer<T> does not support push; allocate with buffer_new<T>(len)",
+                            )),
+                            other => Err(CompileError::new(
+                                stmt.span,
+                                &format!("Array push requires an array property, got {}", other),
+                            )),
+                        }
+                    }
+                    _ => Err(CompileError::new(
+                        stmt.span,
+                        "Array push requires an object or typed pointer",
+                    )),
+                }
+            }
             _ => unreachable!("non-assignment statement routed to assignment checker"),
         }
     }

--- a/src/types/warnings/expr_reads.rs
+++ b/src/types/warnings/expr_reads.rs
@@ -154,6 +154,17 @@ pub(super) fn collect_closure_warnings_in_stmt(stmt: &Stmt, warnings: &mut Vec<C
             collect_expr_reads(object, &mut scope, warnings);
             collect_expr_reads(value, &mut scope, warnings);
         }
+        StmtKind::PropertyArrayAssign {
+            object,
+            index,
+            value,
+            ..
+        } => {
+            let mut scope = ScopeUsage::default();
+            collect_expr_reads(object, &mut scope, warnings);
+            collect_expr_reads(index, &mut scope, warnings);
+            collect_expr_reads(value, &mut scope, warnings);
+        }
         StmtKind::If {
             condition,
             then_body,

--- a/src/types/warnings/expr_reads.rs
+++ b/src/types/warnings/expr_reads.rs
@@ -149,6 +149,11 @@ pub(super) fn collect_closure_warnings_in_stmt(stmt: &Stmt, warnings: &mut Vec<C
             collect_expr_reads(object, &mut scope, warnings);
             collect_expr_reads(value, &mut scope, warnings);
         }
+        StmtKind::PropertyArrayPush { object, value, .. } => {
+            let mut scope = ScopeUsage::default();
+            collect_expr_reads(object, &mut scope, warnings);
+            collect_expr_reads(value, &mut scope, warnings);
+        }
         StmtKind::If {
             condition,
             then_body,

--- a/src/types/warnings/scope_usage.rs
+++ b/src/types/warnings/scope_usage.rs
@@ -234,6 +234,14 @@ pub(super) fn collect_scope_reads(
                 collect_expr_reads(object, scope, warnings);
                 collect_expr_reads(value, scope, warnings);
             }
+            StmtKind::PropertyArrayPush {
+                object,
+                value,
+                ..
+            } => {
+                collect_expr_reads(object, scope, warnings);
+                collect_expr_reads(value, scope, warnings);
+            }
             StmtKind::FunctionDecl {
                 params,
                 variadic,

--- a/src/types/warnings/scope_usage.rs
+++ b/src/types/warnings/scope_usage.rs
@@ -242,6 +242,16 @@ pub(super) fn collect_scope_reads(
                 collect_expr_reads(object, scope, warnings);
                 collect_expr_reads(value, scope, warnings);
             }
+            StmtKind::PropertyArrayAssign {
+                object,
+                index,
+                value,
+                ..
+            } => {
+                collect_expr_reads(object, scope, warnings);
+                collect_expr_reads(index, scope, warnings);
+                collect_expr_reads(value, scope, warnings);
+            }
             StmtKind::FunctionDecl {
                 params,
                 variadic,

--- a/tests/codegen/array_basics.rs
+++ b/tests/codegen/array_basics.rs
@@ -101,6 +101,19 @@ fn test_array_push_builtin() {
 }
 
 #[test]
+fn test_array_access_on_function_call_result() {
+    let out = compile_and_run(
+        r#"<?php
+function getColor() {
+    return [255, 128, 0];
+}
+echo getColor()[1];
+"#,
+    );
+    assert_eq!(out, "128");
+}
+
+#[test]
 fn test_foreach_int() {
     let out = compile_and_run("<?php $a = [1, 2, 3]; foreach ($a as $v) { echo $v; }");
     assert_eq!(out, "123");
@@ -317,4 +330,3 @@ else { echo "other"; }
     );
     assert_eq!(out, "four");
 }
-

--- a/tests/codegen/objects.rs
+++ b/tests/codegen/objects.rs
@@ -754,6 +754,34 @@ echo $total;
 }
 
 #[test]
+fn test_class_property_array_push() {
+    let out = compile_and_run(
+        r#"<?php
+class Bucket {
+    public $items;
+
+    public function __construct() {
+        $this->items = [1, 2];
+    }
+
+    public function add($value) {
+        $this->items[] = $value;
+    }
+
+    public function last(): int {
+        return $this->items[2];
+    }
+}
+
+$bucket = new Bucket();
+$bucket->add(7);
+echo $bucket->last();
+"#,
+    );
+    assert_eq!(out, "7");
+}
+
+#[test]
 fn test_class_static_method_string_param() {
     let out = compile_and_run(
         r#"<?php

--- a/tests/codegen/objects.rs
+++ b/tests/codegen/objects.rs
@@ -810,6 +810,81 @@ echo $bucket->first();
 }
 
 #[test]
+fn test_deep_mixed_property_and_array_chain() {
+    let out = compile_and_run(
+        r#"<?php
+class Color {
+    public $r;
+
+    public function __construct($r) {
+        $this->r = $r;
+    }
+}
+
+class Palette {
+    public $colors;
+
+    public function __construct() {
+        $this->colors = [];
+        $this->colors[] = new Color(4);
+        $this->colors[] = new Color(9);
+    }
+}
+
+class Catalog {
+    public $palette;
+
+    public function __construct() {
+        $this->palette = new Palette();
+    }
+
+    public function sample(): int {
+        $i = 1;
+        return $this->palette->colors[$i]->r;
+    }
+}
+
+$catalog = new Catalog();
+echo $catalog->sample();
+"#,
+    );
+    assert_eq!(out, "9");
+}
+
+#[test]
+fn test_method_call_array_access_then_property_access() {
+    let out = compile_and_run(
+        r#"<?php
+class Item {
+    public $name;
+
+    public function __construct($name) {
+        $this->name = $name;
+    }
+}
+
+class Shop {
+    public $items;
+
+    public function __construct() {
+        $this->items = [];
+        $this->items[] = new Item("apple");
+        $this->items[] = new Item("banana");
+    }
+
+    public function getItems() {
+        return $this->items;
+    }
+}
+
+$shop = new Shop();
+echo $shop->getItems()[0]->name;
+"#,
+    );
+    assert_eq!(out, "apple");
+}
+
+#[test]
 fn test_class_static_method_string_param() {
     let out = compile_and_run(
         r#"<?php

--- a/tests/codegen/objects.rs
+++ b/tests/codegen/objects.rs
@@ -782,6 +782,34 @@ echo $bucket->last();
 }
 
 #[test]
+fn test_class_property_array_assign() {
+    let out = compile_and_run(
+        r#"<?php
+class Bucket {
+    public $items;
+
+    public function __construct() {
+        $this->items = [1, 2, 3];
+    }
+
+    public function replaceFirst($value) {
+        $this->items[0] = $value;
+    }
+
+    public function first(): int {
+        return $this->items[0];
+    }
+}
+
+$bucket = new Bucket();
+$bucket->replaceFirst(9);
+echo $bucket->first();
+"#,
+    );
+    assert_eq!(out, "9");
+}
+
+#[test]
 fn test_class_static_method_string_param() {
     let out = compile_and_run(
         r#"<?php

--- a/tests/codegen/objects.rs
+++ b/tests/codegen/objects.rs
@@ -885,6 +885,133 @@ echo $shop->getItems()[0]->name;
 }
 
 #[test]
+fn test_deep_property_assign_after_array_access() {
+    let out = compile_and_run(
+        r#"<?php
+class Color {
+    public $r;
+
+    public function __construct($r) {
+        $this->r = $r;
+    }
+}
+
+class Palette {
+    public $colors;
+
+    public function __construct() {
+        $this->colors = [];
+        $this->colors[] = new Color(4);
+        $this->colors[] = new Color(9);
+    }
+}
+
+class Catalog {
+    public $palette;
+
+    public function __construct() {
+        $this->palette = new Palette();
+    }
+
+    public function repaint(): int {
+        $i = 1;
+        $this->palette->colors[$i]->r = 12;
+        return $this->palette->colors[$i]->r;
+    }
+}
+
+$catalog = new Catalog();
+echo $catalog->repaint();
+"#,
+    );
+    assert_eq!(out, "12");
+}
+
+#[test]
+fn test_deep_property_array_assign_after_array_access() {
+    let out = compile_and_run(
+        r#"<?php
+class Color {
+    public $shades;
+
+    public function __construct() {
+        $this->shades = [1, 2];
+    }
+}
+
+class Palette {
+    public $colors;
+
+    public function __construct() {
+        $this->colors = [];
+        $this->colors[] = new Color();
+    }
+}
+
+class Catalog {
+    public $palette;
+
+    public function __construct() {
+        $this->palette = new Palette();
+    }
+
+    public function repaint(): int {
+        $i = 0;
+        $this->palette->colors[$i]->shades[1] = 7;
+        return $this->palette->colors[$i]->shades[1];
+    }
+}
+
+$catalog = new Catalog();
+echo $catalog->repaint();
+"#,
+    );
+    assert_eq!(out, "7");
+}
+
+#[test]
+fn test_deep_property_array_push_after_array_access() {
+    let out = compile_and_run(
+        r#"<?php
+class Color {
+    public $shades;
+
+    public function __construct() {
+        $this->shades = [1, 2];
+    }
+}
+
+class Palette {
+    public $colors;
+
+    public function __construct() {
+        $this->colors = [];
+        $this->colors[] = new Color();
+    }
+}
+
+class Catalog {
+    public $palette;
+
+    public function __construct() {
+        $this->palette = new Palette();
+    }
+
+    public function repaint(): int {
+        $i = 0;
+        $this->palette->colors[$i]->shades[] = 7;
+        return $this->palette->colors[$i]->shades[2];
+    }
+}
+
+$catalog = new Catalog();
+echo $catalog->repaint();
+"#,
+    );
+    assert_eq!(out, "7");
+}
+
+#[test]
 fn test_class_static_method_string_param() {
     let out = compile_and_run(
         r#"<?php

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -1843,6 +1843,75 @@ fn test_parse_array_access_on_function_call_result() {
 }
 
 #[test]
+fn test_parse_deep_mixed_property_and_array_chain() {
+    let stmts = parse_source("<?php echo $catalog->palette->colors[$i]->r;");
+    match &stmts[0].kind {
+        StmtKind::Echo(expr) => match &expr.kind {
+            ExprKind::PropertyAccess { object, property } => {
+                assert_eq!(property, "r");
+                match &object.kind {
+                    ExprKind::ArrayAccess { array, index } => {
+                        assert!(matches!(index.kind, ExprKind::Variable(ref name) if name == "i"));
+                        match &array.kind {
+                            ExprKind::PropertyAccess { object, property } => {
+                                assert_eq!(property, "colors");
+                                match &object.kind {
+                                    ExprKind::PropertyAccess { object, property } => {
+                                        assert_eq!(property, "palette");
+                                        assert!(matches!(object.kind, ExprKind::Variable(ref name) if name == "catalog"));
+                                    }
+                                    other => {
+                                        panic!("Expected nested PropertyAccess, got {:?}", other)
+                                    }
+                                }
+                            }
+                            other => panic!("Expected PropertyAccess, got {:?}", other),
+                        }
+                    }
+                    other => panic!("Expected ArrayAccess, got {:?}", other),
+                }
+            }
+            other => panic!("Expected PropertyAccess, got {:?}", other),
+        },
+        other => panic!("Expected Echo, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_property_access_after_array_access_on_method_call_result() {
+    let stmts = parse_source("<?php echo $shop->getItems()[0]->name;");
+    match &stmts[0].kind {
+        StmtKind::Echo(expr) => match &expr.kind {
+            ExprKind::PropertyAccess { object, property } => {
+                assert_eq!(property, "name");
+                match &object.kind {
+                    ExprKind::ArrayAccess { array, index } => {
+                        assert!(matches!(index.kind, ExprKind::IntLiteral(0)));
+                        match &array.kind {
+                            ExprKind::MethodCall {
+                                object,
+                                method,
+                                args,
+                            } => {
+                                assert_eq!(method, "getItems");
+                                assert!(args.is_empty());
+                                assert!(
+                                    matches!(object.kind, ExprKind::Variable(ref name) if name == "shop")
+                                );
+                            }
+                            other => panic!("Expected MethodCall, got {:?}", other),
+                        }
+                    }
+                    other => panic!("Expected ArrayAccess, got {:?}", other),
+                }
+            }
+            other => panic!("Expected PropertyAccess, got {:?}", other),
+        },
+        other => panic!("Expected Echo, got {:?}", other),
+    }
+}
+
+#[test]
 fn test_parse_ptr_cast() {
     let stmts = parse_source("<?php $q = ptr_cast<Point>($p);");
     match &stmts[0].kind {

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -1775,6 +1775,125 @@ fn test_parse_property_array_assign() {
 }
 
 #[test]
+fn test_parse_deep_property_assign_after_array_access() {
+    let stmts = parse_source("<?php $catalog->palette->colors[$i]->r = 12;");
+    match &stmts[0].kind {
+        StmtKind::PropertyAssign {
+            object,
+            property,
+            value,
+        } => {
+            assert_eq!(property, "r");
+            assert!(matches!(value.kind, ExprKind::IntLiteral(12)));
+            match &object.kind {
+                ExprKind::ArrayAccess { array, index } => {
+                    assert!(matches!(index.kind, ExprKind::Variable(ref name) if name == "i"));
+                    match &array.kind {
+                        ExprKind::PropertyAccess { object, property } => {
+                            assert_eq!(property, "colors");
+                            match &object.kind {
+                                ExprKind::PropertyAccess { object, property } => {
+                                    assert_eq!(property, "palette");
+                                    assert!(
+                                        matches!(object.kind, ExprKind::Variable(ref name) if name == "catalog")
+                                    );
+                                }
+                                other => {
+                                    panic!("Expected nested PropertyAccess, got {:?}", other)
+                                }
+                            }
+                        }
+                        other => panic!("Expected PropertyAccess, got {:?}", other),
+                    }
+                }
+                other => panic!("Expected ArrayAccess, got {:?}", other),
+            }
+        }
+        other => panic!("Expected PropertyAssign, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_deep_property_array_assign_after_array_access() {
+    let stmts = parse_source("<?php $catalog->palette->colors[$i]->shades[1] = 12;");
+    match &stmts[0].kind {
+        StmtKind::PropertyArrayAssign {
+            object,
+            property,
+            index,
+            value,
+        } => {
+            assert_eq!(property, "shades");
+            assert!(matches!(index.kind, ExprKind::IntLiteral(1)));
+            assert!(matches!(value.kind, ExprKind::IntLiteral(12)));
+            match &object.kind {
+                ExprKind::ArrayAccess { array, index } => {
+                    assert!(matches!(index.kind, ExprKind::Variable(ref name) if name == "i"));
+                    match &array.kind {
+                        ExprKind::PropertyAccess { object, property } => {
+                            assert_eq!(property, "colors");
+                            match &object.kind {
+                                ExprKind::PropertyAccess { object, property } => {
+                                    assert_eq!(property, "palette");
+                                    assert!(
+                                        matches!(object.kind, ExprKind::Variable(ref name) if name == "catalog")
+                                    );
+                                }
+                                other => {
+                                    panic!("Expected nested PropertyAccess, got {:?}", other)
+                                }
+                            }
+                        }
+                        other => panic!("Expected PropertyAccess, got {:?}", other),
+                    }
+                }
+                other => panic!("Expected ArrayAccess, got {:?}", other),
+            }
+        }
+        other => panic!("Expected PropertyArrayAssign, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_deep_property_array_push_after_array_access() {
+    let stmts = parse_source("<?php $catalog->palette->colors[$i]->shades[] = 12;");
+    match &stmts[0].kind {
+        StmtKind::PropertyArrayPush {
+            object,
+            property,
+            value,
+        } => {
+            assert_eq!(property, "shades");
+            assert!(matches!(value.kind, ExprKind::IntLiteral(12)));
+            match &object.kind {
+                ExprKind::ArrayAccess { array, index } => {
+                    assert!(matches!(index.kind, ExprKind::Variable(ref name) if name == "i"));
+                    match &array.kind {
+                        ExprKind::PropertyAccess { object, property } => {
+                            assert_eq!(property, "colors");
+                            match &object.kind {
+                                ExprKind::PropertyAccess { object, property } => {
+                                    assert_eq!(property, "palette");
+                                    assert!(
+                                        matches!(object.kind, ExprKind::Variable(ref name) if name == "catalog")
+                                    );
+                                }
+                                other => {
+                                    panic!("Expected nested PropertyAccess, got {:?}", other)
+                                }
+                            }
+                        }
+                        other => panic!("Expected PropertyAccess, got {:?}", other),
+                    }
+                }
+                other => panic!("Expected ArrayAccess, got {:?}", other),
+            }
+        }
+        other => panic!("Expected PropertyArrayPush, got {:?}", other),
+    }
+}
+
+#[test]
 fn test_parse_chained_access() {
     let stmts = parse_source("<?php echo $obj->make()->prop;");
     match &stmts[0].kind {

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -1756,6 +1756,25 @@ fn test_parse_property_array_push() {
 }
 
 #[test]
+fn test_parse_property_array_assign() {
+    let stmts = parse_source("<?php $obj->items[0] = 42;");
+    match &stmts[0].kind {
+        StmtKind::PropertyArrayAssign {
+            object,
+            property,
+            index,
+            value,
+        } => {
+            assert_eq!(property, "items");
+            assert!(matches!(object.kind, ExprKind::Variable(_)));
+            assert!(matches!(index.kind, ExprKind::IntLiteral(0)));
+            assert!(matches!(value.kind, ExprKind::IntLiteral(42)));
+        }
+        other => panic!("Expected PropertyArrayAssign, got {:?}", other),
+    }
+}
+
+#[test]
 fn test_parse_chained_access() {
     let stmts = parse_source("<?php echo $obj->make()->prop;");
     match &stmts[0].kind {
@@ -1778,6 +1797,27 @@ fn test_parse_chained_access() {
             _ => panic!("Expected PropertyAccess"),
         },
         _ => panic!("Expected Echo"),
+    }
+}
+
+#[test]
+fn test_parse_property_access_after_array_index() {
+    let stmts = parse_source("<?php echo $items[0]->name;");
+    match &stmts[0].kind {
+        StmtKind::Echo(expr) => match &expr.kind {
+            ExprKind::PropertyAccess { object, property } => {
+                assert_eq!(property, "name");
+                match &object.kind {
+                    ExprKind::ArrayAccess { array, index } => {
+                        assert!(matches!(array.kind, ExprKind::Variable(_)));
+                        assert!(matches!(index.kind, ExprKind::IntLiteral(0)));
+                    }
+                    other => panic!("Expected ArrayAccess, got {:?}", other),
+                }
+            }
+            other => panic!("Expected PropertyAccess, got {:?}", other),
+        },
+        other => panic!("Expected Echo, got {:?}", other),
     }
 }
 

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -1739,6 +1739,23 @@ fn test_parse_property_assign() {
 }
 
 #[test]
+fn test_parse_property_array_push() {
+    let stmts = parse_source("<?php $obj->entries[] = $item;");
+    match &stmts[0].kind {
+        StmtKind::PropertyArrayPush {
+            object,
+            property,
+            value,
+        } => {
+            assert_eq!(property, "entries");
+            assert!(matches!(object.kind, ExprKind::Variable(_)));
+            assert!(matches!(value.kind, ExprKind::Variable(_)));
+        }
+        other => panic!("Expected PropertyArrayPush, got {:?}", other),
+    }
+}
+
+#[test]
 fn test_parse_chained_access() {
     let stmts = parse_source("<?php echo $obj->make()->prop;");
     match &stmts[0].kind {
@@ -1761,6 +1778,27 @@ fn test_parse_chained_access() {
             _ => panic!("Expected PropertyAccess"),
         },
         _ => panic!("Expected Echo"),
+    }
+}
+
+#[test]
+fn test_parse_array_access_on_function_call_result() {
+    let stmts = parse_source("<?php echo getColor()[0];");
+    match &stmts[0].kind {
+        StmtKind::Echo(expr) => match &expr.kind {
+            ExprKind::ArrayAccess { array, index } => {
+                assert!(matches!(index.kind, ExprKind::IntLiteral(0)));
+                match &array.kind {
+                    ExprKind::FunctionCall { name, args } => {
+                        assert_eq!(name.as_str(), "getColor");
+                        assert!(args.is_empty());
+                    }
+                    other => panic!("Expected FunctionCall, got {:?}", other),
+                }
+            }
+            other => panic!("Expected ArrayAccess, got {:?}", other),
+        },
+        other => panic!("Expected Echo, got {:?}", other),
     }
 }
 


### PR DESCRIPTION
## Summary

This PR completes the parser/lvalue slice for mixed postfix chains involving `->` and `[]`.

It adds end-to-end support for:
- property array push assignments like `$obj->items[] = $value`
- property indexed assignments like `$obj->items[0] = $value`
- deep mixed chains such as `$catalog->palette->colors[$i]->r`
- deep mixed write chains such as:
  - `$catalog->palette->colors[$i]->r = 12`
  - `$catalog->palette->colors[$i]->shades[1] = 7`
  - `$catalog->palette->colors[$i]->shades[] = 7`
- array access on function/method call results followed by further postfix access

## What changed

- unified statement-side parsing for postfix assignment targets so mixed `->` / `[]` chains are parsed through the same expression machinery
- added dedicated assignment forms for property-backed array push and indexed writes
- wired the new statement forms through name resolution, warnings, checker, conditional cloning, locals/program usage, and codegen
- fixed deep mixed postfix validation at top level so transient first-pass checker errors do not reject valid method-call chains
- added regression coverage for both read-side and write-side deep mixed chains

## Issues closed

Closes #62  
Closes #63  
Closes #64  
Closes #68  
Closes #69

## Testing

Verified on:
- macOS ARM64
- Linux x86_64
- Linux ARM64

Ran:
- targeted parser/codegen tests for the new postfix-chain cases
- `cargo test -- --include-ignored`
