### PR TITLE
Specialize generic array hints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "elephc"
-version = "0.18.0"
+version = "0.18.2"

--- a/src/types/checker/functions/resolution.rs
+++ b/src/types/checker/functions/resolution.rs
@@ -286,7 +286,8 @@ impl Checker {
                         arg.span,
                         &format!("Function '{}' parameter ${}", name, param_name),
                     )?;
-                    param_types.push((decl.params[arg_idx].clone(), declared_ty));
+                    let specialized_ty = Self::specialize_generic_array_hint(&declared_ty, &ty);
+                    param_types.push((decl.params[arg_idx].clone(), specialized_ty));
                     arg_idx += 1;
                     continue;
                 }
@@ -454,7 +455,13 @@ impl Checker {
                     )?;
                 }
             }
-            return_type = declared_ret;
+            return_type = if Self::is_generic_array_hint(&declared_ret)
+                && matches!(inferred_specific_array_type(&all_return_types), Some(_))
+            {
+                inferred_specific_array_type(&all_return_types).unwrap()
+            } else {
+                declared_ret
+            };
         } else if !all_return_types.is_empty() {
             return_type = all_return_types[0].clone();
             for rt in &all_return_types[1..] {
@@ -479,4 +486,22 @@ impl Checker {
 
         Ok(return_type)
     }
+}
+
+fn inferred_specific_array_type(return_types: &[PhpType]) -> Option<PhpType> {
+    let mut specific: Option<PhpType> = None;
+    for return_ty in return_types {
+        if matches!(return_ty, PhpType::Void) {
+            continue;
+        }
+        if !matches!(return_ty, PhpType::Array(_) | PhpType::AssocArray { .. }) {
+            return None;
+        }
+        match &specific {
+            None => specific = Some(return_ty.clone()),
+            Some(existing) if existing == return_ty => {}
+            _ => return None,
+        }
+    }
+    specific
 }

--- a/src/types/checker/method_pass.rs
+++ b/src/types/checker/method_pass.rs
@@ -162,7 +162,13 @@ impl Checker {
                         self.current_method_is_static = false;
                         return;
                     }
-                    declared
+                    if Self::is_generic_array_hint(&declared)
+                        && matches!(inferred_return, PhpType::Array(_) | PhpType::AssocArray { .. })
+                    {
+                        inferred_return
+                    } else {
+                        declared
+                    }
                 }
                 Err(error) => {
                     pass_errors.extend(error.flatten());

--- a/src/types/checker/stmt_check/assignments.rs
+++ b/src/types/checker/stmt_check/assignments.rs
@@ -270,6 +270,12 @@ impl Checker {
                         {
                             if prop.1 == PhpType::Int && val_ty != PhpType::Int {
                                 prop.1 = val_ty.clone();
+                            } else {
+                                let refined_ty =
+                                    Self::specialize_generic_array_hint(&prop.1, &val_ty);
+                                if refined_ty != prop.1 {
+                                    prop.1 = refined_ty;
+                                }
                             }
                         }
                     }

--- a/src/types/checker/type_compat/pointers.rs
+++ b/src/types/checker/type_compat/pointers.rs
@@ -81,7 +81,7 @@ impl Checker {
                 "mixed" => Ok(PhpType::Mixed),
                 "callable" => Ok(PhpType::Callable),
                 "void" => Ok(PhpType::Void),
-                "array" => Ok(PhpType::Array(Box::new(PhpType::Int))),
+                "array" => Ok(PhpType::Array(Box::new(PhpType::Mixed))),
                 _ if self.classes.contains_key(name.as_str())
                     || self.declared_classes.contains(name.as_str())
                     || self.interfaces.contains_key(name.as_str())

--- a/src/types/checker/type_compat/unions.rs
+++ b/src/types/checker/type_compat/unions.rs
@@ -37,6 +37,30 @@ impl Checker {
             PhpType::Union(members) => members
                 .iter()
                 .any(|member| self.type_accepts(member, actual)),
+            PhpType::Array(expected_elem) => match actual {
+                PhpType::Array(actual_elem) => self.type_accepts(expected_elem.as_ref(), actual_elem.as_ref()),
+                PhpType::AssocArray { .. } => matches!(expected_elem.as_ref(), PhpType::Mixed),
+                _ => false,
+            },
+            PhpType::AssocArray {
+                key: expected_key,
+                value: expected_value,
+            } => match actual {
+                PhpType::AssocArray {
+                    key: actual_key,
+                    value: actual_value,
+                } => {
+                    self.type_accepts(expected_key.as_ref(), actual_key.as_ref())
+                        && self.type_accepts(expected_value.as_ref(), actual_value.as_ref())
+                }
+                PhpType::Array(actual_elem)
+                    if matches!(expected_key.as_ref(), PhpType::Mixed)
+                        && self.type_accepts(expected_value.as_ref(), actual_elem.as_ref()) =>
+                {
+                    true
+                }
+                _ => false,
+            },
             PhpType::Object(expected_name) => match actual {
                 PhpType::Object(actual_name) => {
                     expected_name == actual_name
@@ -142,6 +166,23 @@ impl Checker {
         match (existing, new_ty) {
             (PhpType::Object(left), PhpType::Object(right)) => self.common_object_type(left, right),
             _ => None,
+        }
+    }
+
+    pub(crate) fn is_generic_array_hint(ty: &PhpType) -> bool {
+        matches!(ty, PhpType::Array(inner) if matches!(inner.as_ref(), PhpType::Mixed))
+    }
+
+    pub(crate) fn specialize_generic_array_hint(
+        declared_ty: &PhpType,
+        actual_ty: &PhpType,
+    ) -> PhpType {
+        if Self::is_generic_array_hint(declared_ty)
+            && matches!(actual_ty, PhpType::Array(_) | PhpType::AssocArray { .. })
+        {
+            actual_ty.clone()
+        } else {
+            declared_ty.clone()
         }
     }
 }

--- a/tests/codegen/objects.rs
+++ b/tests/codegen/objects.rs
@@ -885,6 +885,42 @@ echo $shop->getItems()[0]->name;
 }
 
 #[test]
+fn test_property_access_on_array_of_objects_element() {
+    let out = compile_and_run(
+        r#"<?php
+class Entry {
+    public $name;
+
+    public function __construct($name) {
+        $this->name = $name;
+    }
+}
+
+class Wad {
+    public $entries;
+
+    public function __construct() {
+        $this->entries = $this->loadEntries();
+    }
+
+    public function loadEntries(): array {
+        return [new Entry("PLAYPAL"), new Entry("COLORMAP")];
+    }
+
+    public function secondName(): string {
+        $i = 1;
+        return $this->entries[$i]->name;
+    }
+}
+
+$wad = new Wad();
+echo $wad->secondName();
+"#,
+    );
+    assert_eq!(out, "COLORMAP");
+}
+
+#[test]
 fn test_deep_property_assign_after_array_access() {
     let out = compile_and_run(
         r#"<?php

--- a/tests/codegen/types/return_inference.rs
+++ b/tests/codegen/types/return_inference.rs
@@ -66,3 +66,55 @@ echo check(5) . "|" . check(15);
     );
     assert_eq!(out, "small|big");
 }
+
+#[test]
+fn test_array_return_type_survives_indexing() {
+    let out = compile_and_run(
+        r#"<?php
+function getColor(): array {
+    return [255, 128, 0];
+}
+
+$color = getColor();
+echo $color[0] . "," . $color[1] . "," . $color[2];
+"#,
+    );
+    assert_eq!(out, "255,128,0");
+}
+
+#[test]
+fn test_string_array_element_keeps_string_type() {
+    let out = compile_and_run(
+        r#"<?php
+function paint(string $name): string {
+    return $name;
+}
+
+function pickSecond(array $names): string {
+    return paint($names[1]);
+}
+
+echo pickSecond(["foo", "bar"]);
+"#,
+    );
+    assert_eq!(out, "bar");
+}
+
+#[test]
+fn test_string_array_return_type_keeps_string_elements() {
+    let out = compile_and_run(
+        r#"<?php
+function paint(string $name): string {
+    return $name;
+}
+
+function loadNames(): array {
+    return ["foo", "bar"];
+}
+
+$names = loadNames();
+echo paint($names[1]);
+"#,
+    );
+    assert_eq!(out, "bar");
+}

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -1108,6 +1108,94 @@ fn test_null_coalesce_widens_function_return_type_in_checker() {
     assert_eq!(sig.return_type, PhpType::Float);
 }
 
+#[test]
+fn test_generic_array_return_hint_keeps_specific_method_and_property_types() {
+    let result = check_source_full(
+        r#"<?php
+class Entry {
+    public $name;
+
+    public function __construct($name) {
+        $this->name = $name;
+    }
+}
+
+class Wad {
+    public $entries;
+
+    public function __construct() {
+        $this->entries = $this->loadEntries();
+    }
+
+    public function loadEntries(): array {
+        return [new Entry("PLAYPAL"), new Entry("COLORMAP")];
+    }
+
+    public function secondName(): string {
+        $i = 1;
+        return $this->entries[$i]->name;
+    }
+}
+"#,
+    )
+    .expect("expected source to type-check");
+
+    let wad = result.classes.get("Wad").expect("missing Wad class");
+    let entries_ty = wad
+        .properties
+        .iter()
+        .find(|(name, _)| name == "entries")
+        .map(|(_, ty)| ty.clone())
+        .expect("missing entries property");
+    assert_eq!(
+        entries_ty,
+        PhpType::Array(Box::new(PhpType::Object("Entry".to_string())))
+    );
+
+    let load_entries = wad.methods.get("loadEntries").expect("missing loadEntries");
+    assert_eq!(
+        load_entries.return_type,
+        PhpType::Array(Box::new(PhpType::Object("Entry".to_string())))
+    );
+}
+
+#[test]
+fn test_generic_array_param_and_return_hints_keep_specific_string_array_types() {
+    let result = check_source_full(
+        r#"<?php
+function paint(string $name): string {
+    return $name;
+}
+
+function pickSecond(array $names): string {
+    return paint($names[1]);
+}
+
+function loadNames(): array {
+    return ["foo", "bar"];
+}
+
+echo pickSecond(loadNames());
+"#,
+    )
+    .expect("expected source to type-check");
+
+    let pick_second = result
+        .functions
+        .get("pickSecond")
+        .expect("missing pickSecond signature");
+    assert_eq!(
+        pick_second.params[0].1,
+        PhpType::Array(Box::new(PhpType::Str))
+    );
+
+    let load_names = result
+        .functions
+        .get("loadNames")
+        .expect("missing loadNames signature");
+    assert_eq!(load_names.return_type, PhpType::Array(Box::new(PhpType::Str)));
+}
+
 // --- Include/Require errors ---
 
 #[test]


### PR DESCRIPTION
## Summary

This PR fixes checker-side array type propagation for generic PHP `array` hints.

Previously, the checker treated `array` too rigidly and often collapsed it to `array<int>`, which caused valid code to fail when the actual array held strings or objects. This showed up in three related cases:
- property access on array-of-objects elements
- string array elements being inferred as `Int`
- `: array` return hints losing the concrete element type through the return path

## What changed

- changed generic PHP `array` type hints in the checker from a hardcoded `array<int>` fallback to a generic array shape
- taught checker compatibility logic to accept concrete indexed/assoc arrays against generic array hints
- specialized generic `array` parameter hints from concrete call-site argument types when available
- specialized generic `: array` return hints from concrete inferred return types when they are consistently known
- refined property inference so object properties initialized from generic-array-returning helpers can keep the concrete array element type instead of staying overly generic

## User-visible effect

These cases now type-check correctly:
- `array $names` receiving `["foo", "bar"]`
- `paint($names[$i])` where `$names` is a string array
- `function loadEntries(): array { return [new Entry(...)] ; }`
- `$wad->entries[$i]->name` when `$entries` comes from a generic `: array` method return
- tuple-like array returns such as `getColor(): array` followed by `$color[0]`

## Issues closed

Closes #65  
Closes #66  
Closes #67

## Testing

Verified on:
- macOS ARM64
- Linux x86_64
- Linux ARM64

Ran:
- targeted checker/codegen regressions for generic `array` params and returns
- targeted regressions for array-of-objects property access
- `cargo test -- --include-ignored`
