### PR TITLE
Feature/byref array method calls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,39 @@ jobs:
       - name: Set version from tag and commit
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
-          sed -i '' "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
-          echo "Set Cargo.toml version to ${VERSION}"
+          export VERSION
+          python3 - <<'PY'
+          from pathlib import Path
+          import os
+          import re
+
+          version = os.environ["VERSION"]
+
+          cargo_toml = Path("Cargo.toml")
+          cargo_toml.write_text(
+              re.sub(
+                  r'^version = ".*"$',
+                  f'version = "{version}"',
+                  cargo_toml.read_text(),
+                  count=1,
+                  flags=re.MULTILINE,
+              )
+          )
+
+          cargo_lock = Path("Cargo.lock")
+          cargo_lock.write_text(
+              re.sub(
+                  r'(\[\[package\]\]\nname = "elephc"\nversion = ")[^"]+(")',
+                  rf'\g<1>{version}\2',
+                  cargo_lock.read_text(),
+                  count=1,
+              )
+          )
+          PY
+          echo "Set Cargo.toml and Cargo.lock version to ${VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Cargo.toml
+          git add Cargo.toml Cargo.lock
           git commit -m "chore: bump version to ${VERSION}" || true
           git push origin HEAD:main
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "elephc"
-version = "0.18.2"
+version = "0.18.3"

--- a/tests/codegen/oop.rs
+++ b/tests/codegen/oop.rs
@@ -851,6 +851,28 @@ echo $value;
 }
 
 #[test]
+fn test_instance_method_preserves_multiple_byref_array_params() {
+    let out = compile_and_run(
+        r#"<?php
+class Foo {
+    public function bar(array &$a, array &$b): void {
+        $a[0] = 1;
+        $b[0] = 2;
+    }
+}
+
+$x = [0];
+$y = [0];
+$foo = new Foo();
+$foo->bar($x, $y);
+echo $x[0];
+echo $y[0];
+"#,
+    );
+    assert_eq!(out, "12");
+}
+
+#[test]
 fn test_first_class_callable_variadic_function_call() {
     let out = compile_and_run(
         r#"<?php


### PR DESCRIPTION
## Summary

Add a regression test for instance methods with multiple by-reference array parameters.

## What changed

- add end-to-end coverage for a method like `Foo::bar(array &$a, array &$b)`
- verify that both referenced arrays are mutated correctly through the same method call
- lock in the expected output for the original GitHub repro (`12`)

## Why

This protects against regressions in method-call codegen for multiple by-ref array arguments and documents that the reported issue now works correctly.
