### PR TITLE
Preserve require_once error locations

### DIFF
--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -5,6 +5,7 @@ use crate::span::Span;
 #[derive(Debug, Clone)]
 pub struct CompileError {
     pub span: Span,
+    pub file: Option<String>,
     pub message: String,
     pub related: Vec<CompileError>,
 }
@@ -19,9 +20,15 @@ impl CompileError {
     pub fn new(span: Span, message: &str) -> Self {
         Self {
             span,
+            file: None,
             message: message.to_string(),
             related: Vec::new(),
         }
+    }
+
+    pub fn with_file(mut self, file: impl Into<String>) -> Self {
+        self.file = Some(file.into());
+        self
     }
 
     pub fn from_many(mut errors: Vec<CompileError>) -> Self {
@@ -31,7 +38,9 @@ impl CompileError {
     }
 
     pub fn flatten(&self) -> Vec<CompileError> {
-        let mut all = vec![CompileError::new(self.span, &self.message)];
+        let mut first = self.clone();
+        first.related.clear();
+        let mut all = vec![first];
         for related in &self.related {
             all.extend(related.flatten());
         }
@@ -52,10 +61,13 @@ impl std::error::Error for CompileError {}
 
 impl std::fmt::Display for CompileError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.span.line > 0 {
-            write!(f, "[{}:{}] {}", self.span.line, self.span.col, self.message)
-        } else {
-            write!(f, "{}", self.message)
+        match (&self.file, self.span.line > 0) {
+            (Some(file), true) => {
+                write!(f, "[{}:{}:{}] {}", file, self.span.line, self.span.col, self.message)
+            }
+            (Some(file), false) => write!(f, "[{}] {}", file, self.message),
+            (None, true) => write!(f, "[{}:{}] {}", self.span.line, self.span.col, self.message),
+            (None, false) => write!(f, "{}", self.message),
         }
     }
 }

--- a/src/errors/report.rs
+++ b/src/errors/report.rs
@@ -1,13 +1,25 @@
 use super::{CompileError, CompileWarning};
 
 pub fn print_error(error: &CompileError) {
-    if error.span.line > 0 {
-        eprintln!(
-            "error[{}:{}]: {}",
-            error.span.line, error.span.col, error.message
-        );
-    } else {
-        eprintln!("error: {}", error.message);
+    match (&error.file, error.span.line > 0) {
+        (Some(file), true) => {
+            eprintln!(
+                "error[{}:{}:{}]: {}",
+                file, error.span.line, error.span.col, error.message
+            );
+        }
+        (Some(file), false) => {
+            eprintln!("error[{}]: {}", file, error.message);
+        }
+        (None, true) => {
+            eprintln!(
+                "error[{}:{}]: {}",
+                error.span.line, error.span.col, error.message
+            );
+        }
+        (None, false) => {
+            eprintln!("error: {}", error.message);
+        }
     }
     for related in &error.related {
         print_error(related);

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,7 +202,7 @@ fn main() {
     let tokens = match lexer::tokenize(&source) {
         Ok(tokens) => tokens,
         Err(e) => {
-            errors::report(&e);
+            errors::report(&e.with_file(filename.to_string()));
             process::exit(1);
         }
     };
@@ -210,7 +210,7 @@ fn main() {
     let parsed = match parser::parse(&tokens) {
         Ok(ast) => ast,
         Err(e) => {
-            errors::report(&e);
+            errors::report(&e.with_file(filename.to_string()));
             process::exit(1);
         }
     };

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -362,17 +362,9 @@ fn parse_file(path: &Path, include_span: Span) -> Result<Vec<Stmt>, CompileError
         )
     })?;
 
-    let tokens = lexer::tokenize(&source).map_err(|e| {
-        CompileError::new(
-            include_span,
-            &format!("Error in '{}': {}", path.display(), e.message),
-        )
-    })?;
+    let file = path.display().to_string();
 
-    parser::parse(&tokens).map_err(|e| {
-        CompileError::new(
-            include_span,
-            &format!("Error in '{}': {}", path.display(), e.message),
-        )
-    })
+    let tokens = lexer::tokenize(&source).map_err(|e| e.with_file(file.clone()))?;
+
+    parser::parse(&tokens).map_err(|e| e.with_file(file))
 }

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -4,6 +4,11 @@ use elephc::parser::parse_with_recovery;
 use elephc::types;
 use elephc::types::PhpType;
 use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static TEST_PROJECT_ID: AtomicUsize = AtomicUsize::new(0);
 
 fn check_source(src: &str) -> Result<(), String> {
     check_source_with_defines(src, &[])
@@ -24,6 +29,37 @@ fn check_source_full(src: &str) -> Result<elephc::types::CheckResult, elephc::er
     let ast = parse(&tokens)?;
     let ast = elephc::name_resolver::resolve(ast)?;
     types::check(&ast)
+}
+
+fn resolve_files_error(
+    files: &[(&str, &str)],
+    main_file: &str,
+) -> elephc::errors::CompileError {
+    let id = TEST_PROJECT_ID.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("elephc_error_test_{}_{}", std::process::id(), id));
+    fs::create_dir_all(&dir).unwrap();
+
+    for (path, content) in files {
+        let full_path = dir.join(path);
+        if let Some(parent) = full_path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&full_path, content).unwrap();
+    }
+
+    let php_path = dir.join(main_file);
+    let source = fs::read_to_string(&php_path).unwrap();
+    let base_dir = php_path.parent().unwrap();
+
+    let result = (|| -> Result<(), elephc::errors::CompileError> {
+        let tokens = tokenize(&source)?;
+        let ast = parse(&tokens)?;
+        let _ = elephc::resolver::resolve(ast, base_dir)?;
+        Ok(())
+    })();
+
+    let _ = fs::remove_dir_all(&dir);
+    result.expect_err("expected resolve to fail")
 }
 
 fn expect_error(src: &str, expected_substr: &str) {
@@ -749,6 +785,36 @@ fn test_error_has_column() {
     let result = tokenize("<?php @");
     let err = result.unwrap_err();
     assert!(err.span.col > 0, "Error should have a column number");
+}
+
+#[test]
+fn test_require_once_chain_preserves_included_file_error_location() {
+    let err = resolve_files_error(
+        &[
+            ("main.php", "<?php\nrequire_once 'a.php';\n"),
+            ("a.php", "<?php\nrequire_once 'nested/b.php';\n"),
+            ("nested/b.php", "<?php\nfunction broken() {\n    echo 1\n}\n"),
+        ],
+        "main.php",
+    );
+
+    assert_eq!(err.span.line, 4, "expected parser error to point into nested/b.php");
+    assert_ne!(err.span.line, 2, "error should not point back to the require_once line");
+    assert!(
+        Path::new(err.file.as_deref().expect("expected included file path")).ends_with("nested/b.php"),
+        "expected file path to reference nested/b.php, got {:?}",
+        err.file,
+    );
+    assert!(
+        err.message.contains("Expected ';'"),
+        "unexpected error message: {}",
+        err.message,
+    );
+    assert!(
+        err.to_string().contains("nested/b.php:4"),
+        "expected display output to include nested/b.php:4, got {}",
+        err,
+    );
 }
 
 // --- Float/math function errors ---


### PR DESCRIPTION
## Summary

Preserve real file and span information for parse and lexer errors coming from `require_once` / `include_once` chains.

## What changed

- stop rewriting included-file parse errors to the caller’s `require_once` span
- attach source file information to `CompileError`
- update error reporting to print `file:line:col` when available
- add a multi-file regression test covering a nested `require_once` chain

## Why

Errors inside included files were being attributed to the `require_once` site instead of the file that actually contained the broken code, which made multi-file projects much harder to debug.
