### PR TITLE
Constant folding

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ User-defined constants are also supported via `const NAME = value;` and `define(
 ## How it works
 
 ```
-PHP source → Lexer → Parser (AST) → Conditional (ifdef/--define) → Resolver (include) → NameResolver (namespaces/use/FQNs) → Type Checker → Codegen → as + ld → native executable
+PHP source → Lexer → Parser (AST) → Conditional (ifdef/--define) → Resolver (include) → NameResolver (namespaces/use/FQNs) → Optimizer (constant folding) → Type Checker → Optimizer (dead-code pruning) → Codegen → as + ld → native executable
 ```
 
 The compiler emits human-readable assembly for the selected target. You can inspect the `.s` file to see exactly what your PHP becomes:
@@ -255,7 +255,17 @@ elephc hello.php
 cat hello.s
 ```
 
-If you add `--source-map`, elephc also writes `hello.map`, a compact JSON sidecar that maps emitted assembly lines back to PHP line/column pairs. If you add `--timings`, the compiler prints per-phase durations such as lexing, parsing, runtime-cache preparation, code generation, assembling, and linking.
+If you add `--source-map`, elephc also writes `hello.map`, a compact JSON sidecar that maps emitted assembly lines back to PHP line/column pairs. If you add `--timings`, the compiler prints per-phase durations such as lexing, parsing, early optimization, type checking, post-check pruning, runtime-cache preparation, code generation, assembling, and linking.
+
+### Current optimization passes
+
+elephc already performs a small but useful AST-level optimization pass before emitting assembly:
+
+- **Constant folding before type checking**: folds scalar arithmetic, bitwise ops, comparisons, logical ops, string-literal concatenation, scalar casts, ternaries, and null coalescing when the result is statically known.
+- **Control-flow pruning after type checking**: removes constant-dead `if` / `elseif` / `while (false)` / `for (...; false; ...)` branches, prunes constant `switch` prefixes and `match` arms, and trims unreachable statements after terminating constructs such as `return`, `throw`, `break`, and `continue`.
+- **Pure-expression cleanup**: drops unused expression statements and dead pure subexpressions when the surrounding expression already determines the result.
+
+The optimizer is intentionally conservative. It does not yet do global constant propagation, interprocedural optimization, or assembly-level peephole rewriting.
 
 ### Type system
 
@@ -298,6 +308,7 @@ src/
 ├── span.rs              # Source position tracking (line, col)
 ├── conditional.rs       # Build-time `ifdef` pass driven by --define
 ├── resolver.rs          # Include/require file resolution
+├── optimize.rs          # Constant folding and local dead-code pruning
 ├── names.rs             # Qualified/FQN name model + symbol mangling helpers
 ├── name_resolver/       # Namespace/use resolution to canonical names
 │

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -316,13 +316,15 @@ Proper type system for PHP compatibility.
 
 ## v0.20.x — Early optimization pass
 
-- [ ] Constant folding (`2 + 3` → `5` at compile time)
-- [ ] Dead code elimination
+- [x] Constant folding (`2 + 3` → `5` at compile time)
+- [x] Dead code elimination
 - [ ] Peephole optimization (redundant load/store elimination)
 - [x] Add regression benchmarks so optimization work is measured instead of anecdotal
 
 ## v0.21.x — Code quality and performance validation
 
+- [ ] Constant propagation across locals / statement boundaries
+- [ ] Dead code elimination v2 (CFG/basic-block aware pass beyond local AST pruning)
 - [ ] Register allocation (reduce stack spills)
 - [ ] Inline small functions
 - [ ] Tail-call optimization

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,11 +47,12 @@ How elephc works under the hood — from lexing to code generation and runtime s
 - [The Lexer](internals/the-lexer.md) — raw text to tokens
 - [The Parser](internals/the-parser.md) — tokens to AST with Pratt parsing
 - [The Type Checker](internals/the-type-checker.md) — compile-time type inference and validation
-- [The Code Generator](internals/the-codegen.md) — AST to target assembly (with an AArch64-focused walkthrough)
+- [The Optimizer](internals/the-optimizer.md) — constant folding and local dead-code elimination on the AST
+- [The Code Generator](internals/the-codegen.md) — optimized checked AST to target assembly (with an AArch64-focused walkthrough)
 - [The Runtime](internals/the-runtime.md) — hand-written assembly routines
 - [Memory Model](internals/memory-model.md) — stack frames, heap, reference counting
 - [Architecture](internals/architecture.md) — module map, calling conventions
 - [ARM64 Assembly](internals/arm64-assembly.md) — introduction to ARM64
 - [ARM64 Instructions](internals/arm64-instructions.md) — instruction reference
 
-For compile-time instrumentation and debug artifacts, the CLI also supports `--timings` to print per-phase compiler timings and `--source-map` to emit a sidecar `.map` file next to generated assembly.
+For compile-time instrumentation and debug artifacts, the CLI also supports `--timings` to print per-phase compiler timings, including the optimizer phases, and `--source-map` to emit a sidecar `.map` file next to generated assembly.

--- a/docs/getting-started/your-first-program.md
+++ b/docs/getting-started/your-first-program.md
@@ -91,10 +91,12 @@ When you run `elephc hello.php`, the compiler:
 1. **Lexes** the source into tokens
 2. **Parses** tokens into an AST (Abstract Syntax Tree)
 3. **Resolves** includes and namespaces
-4. **Type-checks** the program
-5. **Generates** assembly for the selected target
-6. **Assembles** the `.s` file with `as`
-7. **Links** the `.o` file with `ld` into a native executable
+4. **Folds constant expressions** that are already statically known
+5. **Type-checks** the program
+6. **Prunes dead constant control flow** after the checker has collected diagnostics
+7. **Generates** assembly for the selected target
+8. **Assembles** the `.s` file with `as`
+9. **Links** the `.o` file with `ld` into a native executable
 
 The intermediate `.s` and `.o` files are cleaned up automatically. You're left with a single executable.
 
@@ -110,7 +112,7 @@ elephc --timings hello.php
 elephc --emit-asm --source-map hello.php
 ```
 
-`--timings` reports phases such as lexing, parsing, type checking, runtime-cache preparation, code generation, assembling, and linking.
+`--timings` reports phases such as lexing, parsing, early optimization, type checking, post-check pruning, runtime-cache preparation, code generation, assembling, and linking.
 
 `--source-map` writes a `hello.map` JSON file next to `hello.s`. The map records which emitted assembly lines came from which PHP source lines and columns.
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -2,7 +2,7 @@
 title: "Architecture"
 description: "Module map, calling conventions, and pipeline diagram."
 sidebar:
-  order: 9
+  order: 10
 ---
 
 ## Compilation pipeline
@@ -46,6 +46,13 @@ PHP source (.php)
 └─────┬────────┘
       │
       ▼
+┌──────────────┐
+│  Optimizer   │  src/optimize.rs
+│   (fold)     │  Folds scalar constants and simplifies pure expressions
+│              │  before type checking.
+└─────┬────────┘
+      │
+      ▼
 ┌─────────┐
 │  Type    │  src/types/
 │  Checker │  traits.rs, checker/mod.rs, checker/builtins/, checker/functions/, warnings/
@@ -53,6 +60,13 @@ PHP source (.php)
 └────┬─────┘
      │
      ▼
+┌──────────────┐
+│  Optimizer   │  src/optimize.rs
+│  (prune)     │  Removes constant-dead control flow and unreachable
+│              │  pure statements after successful checking.
+└─────┬────────┘
+      │
+      ▼
 ┌─────────┐
 │ Codegen  │  src/codegen/
 │          │  mod.rs, expr.rs + expr/, stmt.rs + stmt/, functions/, abi/, platform/
@@ -92,6 +106,7 @@ src/
 ├── span.rs                    Source position (line, col)
 ├── conditional.rs             Build-time `ifdef` pass
 ├── resolver.rs                Include/require file resolution
+├── optimize.rs                Constant folding and local dead-code pruning
 ├── runtime_cache.rs           Cached shared runtime object preparation
 ├── source_map.rs              Assembly comment markers → JSON sidecar map
 ├── names.rs                   Qualified/FQN name model + assembly symbol mangling

--- a/docs/internals/arm64-assembly.md
+++ b/docs/internals/arm64-assembly.md
@@ -2,7 +2,7 @@
 title: "ARM64 Assembly"
 description: "Introduction to ARM64 assembly for compiler output."
 sidebar:
-  order: 10
+  order: 11
 ---
 
 ## What is assembly language?

--- a/docs/internals/arm64-instructions.md
+++ b/docs/internals/arm64-instructions.md
@@ -2,7 +2,7 @@
 title: "ARM64 Instructions"
 description: "ARM64 instruction reference used by elephc."
 sidebar:
-  order: 11
+  order: 12
 ---
 
 This is a reference for the ARM64 instructions elephc uses most often, organized by category. Each entry shows the instruction, what it does, and where elephc uses it.

--- a/docs/internals/how-elephc-works.md
+++ b/docs/internals/how-elephc-works.md
@@ -98,7 +98,25 @@ After includes are flattened, elephc resolves namespace-aware names. This pass a
 
 In this example there are no namespaces or imports, so the AST still passes through unchanged.
 
-## Phase 6: Type checking
+## Phase 6: Early optimization (constant folding)
+
+**File:** `src/optimize.rs`
+
+Before type checking, elephc runs a conservative AST simplification pass. This stage folds expressions whose result is already statically known without needing any type-environment information.
+
+Typical examples include:
+
+- `2 + 3 * 4` → `14`
+- `"hello " . "world"` → `"hello world"`
+- `(int)"42"` → `42`
+- `2 < 3 ? 8 : 9` → `8`
+- `null ?? "fallback"` → `"fallback"`
+
+The pass is deliberately local and side-effect aware. It simplifies scalar computations, but it does not speculate across calls, object/property access, or other expressions that may have runtime behavior.
+
+In our running example there is nothing to fold yet: the pass does not currently propagate `$x = 10` into the later `$x > 5` comparison.
+
+## Phase 7: Type checking
 
 **File:** `src/types/` — See [The Type Checker](the-type-checker.md) for details.
 
@@ -120,7 +138,26 @@ If you tried `$x = "hello"` after `$x = 10`, the type checker would reject it �
 
 On successful type checking, elephc also runs a warning pass that reports issues such as unused variables and unreachable code. On failing compilations, the parser and checker both try to recover conservatively so they can often report more than one independent error in a single run.
 
-## Phase 7: Code generation
+## Phase 8: Post-typecheck pruning
+
+**File:** `src/optimize.rs`
+
+After the checker succeeds, elephc runs a second optimization pass that is allowed to prune dead control flow without hiding diagnostics from the type checker.
+
+This pass currently handles cases such as:
+
+- `if`, `elseif`, and ternaries with constant conditions
+- `while (false)` and `for (...; false; ...)`
+- constant `match` expressions and prunable `switch` prefixes
+- unreachable statements after `return`, `throw`, `break`, or `continue`
+- dead code after exhaustive `if` / `else` and `switch` + `default` structures
+- pure expression statements and pure dead subexpressions that can be dropped safely
+
+This split is intentional: elephc folds obvious scalar expressions early, but waits until after type checking to remove whole blocks, so diagnostics still see the original checked structure.
+
+In our running example there is still nothing to prune, because `$x > 5` is not a compile-time constant at the AST level.
+
+## Phase 9: Code generation
 
 **File:** `src/codegen/` — See [The Code Generator](the-codegen.md) for details.
 
@@ -170,7 +207,7 @@ Key observations:
 - `echo "big\n"` → load string address + length, then `svc` to write to stdout
 - The string literal lives in the `.data` section, referenced by label `_str_0`
 
-## Phase 8: Runtime preparation, assembly, and linking
+## Phase 10: Runtime preparation, assembly, and linking
 
 **Tools:** native `as` and `ld` (or the equivalent system toolchain)
 
@@ -206,7 +243,7 @@ On Linux, elephc invokes the native assembler/linker for the requested target.
 
 The `.o` file is deleted after linking. The result is a standalone executable.
 
-## Phase 9: Execution
+## Phase 11: Execution
 
 ```bash
 ./file
@@ -232,8 +269,14 @@ The binary runs directly on the CPU. There is no PHP interpreter or VM at runtim
                     │
                     ▼ NameResolver (no-op here)
                     │
+                    ▼ Optimizer (fold constants, no-op here)
+    [Assign{x, 10}, If{Gt(Var(x), 5), [Echo("big\n")]}]
+                    │
                     ▼ Type Checker
     { x: Int } — all types consistent ✓
+                    │
+                    ▼ Optimizer (prune dead control flow, no-op here)
+    [Assign{x, 10}, If{Gt(Var(x), 5), [Echo("big\n")]}]
                     │
                     ▼ Code Generator
     "sub sp, sp, #32 / stp x29, x30, ... / mov x0, #10 / ..."

--- a/docs/internals/memory-model.md
+++ b/docs/internals/memory-model.md
@@ -2,7 +2,7 @@
 title: "Memory Model"
 description: "Stack frames, heap allocation, and memory management."
 sidebar:
-  order: 8
+  order: 9
 ---
 
 elephc manages memory without calling `malloc`/`free` for PHP values directly. Storage lives on the **stack** (automatic, per-function), in fixed BSS regions, or in a compiler-managed **heap buffer** with a free-list allocator, reference counting, and a targeted cycle collector for array/hash/object graphs. The final binary still links `libSystem` for OS and libc services.

--- a/docs/internals/the-codegen.md
+++ b/docs/internals/the-codegen.md
@@ -2,12 +2,12 @@
 title: "The Code Generator"
 description: "How typed AST nodes become native assembly for the selected target."
 sidebar:
-  order: 6
+  order: 7
 ---
 
 **Source:** `src/codegen/` — `mod.rs`, `expr.rs`, `expr/`, `stmt.rs`, `stmt/`, `functions/`, `ffi.rs`, `abi/`, `context.rs`, `data_section.rs`, `emit.rs`
 
-The code generator (codegen) is the heart of the compiler. It takes the typed AST and produces native assembly text for the selected target — the actual instructions the CPU will execute.
+The code generator (codegen) is the heart of the compiler. It takes the checked AST after the optimizer's local simplification passes and produces native assembly text for the selected target — the actual instructions the CPU will execute.
 
 elephc now supports more than one backend. AArch64 is still the clearest reference path in the codebase and in this document, while Linux `x86_64` is also a supported backend that goes through the same high-level lowering pipeline.
 
@@ -93,6 +93,8 @@ This means normal CLI builds no longer concatenate the runtime text into every o
 - link `file.o` against the cached runtime object
 
 The source-map file is intentionally simple. Today it stores a list of `(asm_line, php_line, php_col)` entries so tools and humans can correlate generated assembly back to the original PHP statements without needing full DWARF debug info.
+
+The optimizer intentionally stays at the AST level. By the time codegen runs, constant expressions and some dead control-flow have already been removed, but codegen still sees a normal checked program shape rather than a target-specific IR. Assembly-level peephole cleanup is future work.
 
 ## The Context
 

--- a/docs/internals/the-optimizer.md
+++ b/docs/internals/the-optimizer.md
@@ -1,0 +1,165 @@
+---
+title: "The Optimizer"
+description: "How elephc folds constants and prunes dead code before code generation."
+sidebar:
+  order: 6
+---
+
+**Source:** `src/optimize.rs`
+
+elephc's optimizer is intentionally simple and AST-focused. It does not build a separate IR or run heavyweight SSA passes. Instead, it performs a small set of local rewrites that already pay off in generated assembly quality and compile-time clarity.
+
+Today the optimizer is split into two passes:
+
+1. `fold_constants(program)` runs before type checking
+2. `prune_constant_control_flow(program)` runs after successful type checking and warning collection
+
+That split matters. Some rewrites are always safe on syntax alone, while others should only happen after diagnostics have already seen the checked program.
+
+## Why optimize at the AST level
+
+elephc goes straight from AST to target assembly. There is no middle IR for optimization to target, so the cheapest high-value place to simplify code is the AST itself.
+
+This gives us a few immediate wins:
+
+- less work for codegen
+- smaller and clearer generated assembly
+- fewer runtime helper calls for expressions whose result is already known
+- a conservative place to prune dead branches without committing to backend-specific machinery
+
+Examples:
+
+```php
+<?php
+echo 2 ** 3;
+echo "hello " . "world";
+echo (int)"42";
+```
+
+By the time codegen sees this, it can already emit constants instead of calling runtime helpers such as `pow`, `__rt_concat`, or numeric string conversion paths.
+
+## Pass 1: Constant folding
+
+`fold_constants()` walks the AST recursively and rewrites expressions whose result is statically decidable from their children alone.
+
+Current folding coverage includes:
+
+- scalar arithmetic: `+`, `-`, `*`, `/`, `%`, `**`
+- bitwise and shift ops on integers
+- unary `-`, `!`, and `~`
+- string-literal concatenation with `.`
+- strict comparisons and numeric comparisons
+- logical `&&` / `||` when both sides are scalar constants
+- spaceship `<=>`
+- `??` and ternary when the selected result is already known
+- scalar casts such as `(int)"42"` or `(bool)"0"` when the semantics are unambiguous
+- recursive folding inside:
+  - function and method bodies
+  - closures and arrow functions
+  - default parameter values
+  - property defaults
+  - constant declarations
+
+### Example
+
+```php
+<?php
+$x = (2 < 3) ? (2 ** 3) : (3 ** 4);
+echo $x . "\n";
+```
+
+After folding, the AST is effectively:
+
+```php
+<?php
+$x = 8;
+echo $x . "\n";
+```
+
+## Pass 2: Post-check pruning
+
+`prune_constant_control_flow()` runs only after type checking succeeds. This pass is allowed to remove dead branches and dead statements because diagnostics have already seen the checked structure.
+
+Current pruning coverage includes:
+
+- `if` / `elseif` / `else` chains with constant conditions
+- `while (false)`
+- `do { ... } while (false)` reduced to a single execution of the body
+- `for (...; false; ...)`, preserving the `init` clause but removing dead loop/update work
+- `match` expressions whose subject and patterns are statically decidable
+- `switch` pruning when early case prefixes are provably impossible
+- unreachable statements after:
+  - `return`
+  - `throw`
+  - `break`
+  - `continue`
+- dead code after exhaustive `if` / `else`
+- dead code after conservative exhaustive `switch ... default`
+- pure expression statements whose result is unused
+- pure dead subexpressions inside:
+  - ternaries
+  - `??`
+  - short-circuit `&&` / `||`
+
+### Example
+
+```php
+<?php
+if (true) {
+    echo "kept\n";
+} else {
+    echo pow(3, 4) . "\n";
+}
+```
+
+After pruning, the dead branch disappears entirely. That means codegen never emits the `pow` path.
+
+## Why there are two passes
+
+If elephc removed whole branches before type checking, it could accidentally hide useful diagnostics.
+
+For example, imagine:
+
+```php
+<?php
+if (false) {
+    $x = "hello";
+    $x = 123;
+}
+```
+
+From an optimization point of view that block is dead. From a compiler UX point of view, it may still be valuable for the checker and warning passes to see it before any aggressive pruning happens.
+
+So the current rule is:
+
+- fold obvious pure scalar expressions early
+- prune larger dead control-flow only after checking
+
+## Conservatism and side effects
+
+The optimizer is intentionally conservative about what counts as "pure".
+
+It does **not** assume purity for operations such as:
+
+- function calls
+- method calls
+- object creation
+- property access
+- array access
+- buffer allocation
+- increment/decrement
+- `throw`
+
+That conservatism is why the pass is safe to run by default: if an expression could have runtime behavior, the optimizer prefers to keep it.
+
+## What the optimizer does not do yet
+
+The current pass is local. It does not yet implement:
+
+- constant propagation across variables and statement boundaries
+- interprocedural optimization
+- backend-specific peephole cleanup
+- runtime dead stripping
+- register allocation
+
+Those remain roadmap items for later optimization work.

--- a/docs/internals/the-runtime.md
+++ b/docs/internals/the-runtime.md
@@ -2,14 +2,14 @@
 title: "The Runtime"
 description: "Hand-written assembly routines for strings, arrays, and I/O."
 sidebar:
-  order: 7
+  order: 8
 ---
 
 **Source:** `src/codegen/runtime/` — `mod.rs`, `data.rs`, `strings/`, `arrays/`, `buffers/`, `exceptions.rs`, `exceptions/`, `io/`, `system/`, `pointers/`
 
 The runtime is a collection of **hand-written assembly routines** that handle operations too complex for inline code generation. When the [code generator](the-codegen.md) needs to convert an integer to a string or concatenate two strings, it emits a `bl __rt_itoa` or `bl __rt_concat` — a call to a runtime routine.
 
-These routines are emitted as assembly functions at the end of every compiled program. They're not external libraries — they're part of the binary.
+These routines end up in every compiled binary. In the CLI flow they are usually pre-assembled into the cached runtime object rather than textually appended to each user `.s` file, but they are still part of the final executable rather than an external shared dependency.
 
 ## Why a runtime?
 
@@ -437,7 +437,7 @@ pub fn emit_runtime(emitter: &mut Emitter) {
 
 Notable runtime-only helpers emitted here include `__rt_exception_cleanup_frames`, `__rt_exception_matches`, `__rt_throw_current`, `__rt_heap_debug_fail`, `__rt_heap_kind`, `__rt_hash_insert_owned`, `__rt_hash_free_deep`, `__rt_array_column_ref`, `__rt_preg_strip`, `__rt_pcre_to_posix`, `__rt_str_to_cstr`, and `__rt_cstr_to_str` in addition to the more user-visible helpers.
 
-All routines are included in every binary, even if unused. This is simpler than dead-code elimination (a potential future optimization).
+All routines are included in every binary, even if unused. elephc already does AST-side dead-code pruning before codegen, but runtime-specific dead stripping is still future work.
 
 ## Runtime data
 

--- a/docs/internals/the-type-checker.md
+++ b/docs/internals/the-type-checker.md
@@ -206,6 +206,15 @@ After successful checking, elephc also runs a warning pass over the AST. Current
 
 Warnings are returned through `CheckResult` and printed by the CLI without failing the compilation.
 
+## Where the checker sits in the optimizer pipeline
+
+The type checker sits between two AST-level optimization passes in `src/optimize.rs`:
+
+- `fold_constants()` runs first and simplifies scalar expressions that are already statically decidable.
+- `prune_constant_control_flow()` runs only after successful checking and warning collection, so dead branches can be removed without suppressing type errors or warnings that should still be reported.
+
+That ordering is intentional. elephc is happy to rewrite `2 + 3` into `5` before checking, but it does not want an optimization pass to make broken code look valid by deleting it too early.
+
 ## The global environment
 
 Before checking user code, the type checker pre-populates the environment with built-in globals:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod errors;
 pub mod lexer;
 pub mod names;
 pub mod name_resolver;
+pub mod optimize;
 pub mod parser;
 pub mod resolver;
 pub mod span;

--- a/src/main.rs
+++ b/src/main.rs
@@ -336,6 +336,10 @@ fn main() {
     }
 
     let phase_started = Instant::now();
+    let ast = optimize::prune_constant_control_flow(ast);
+    timings.record_since("opt-post", phase_started);
+
+    let phase_started = Instant::now();
     let runtime_object = match runtime_cache::prepare_runtime_object(heap_size, target) {
         Ok(runtime_object) => runtime_object,
         Err(err) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod errors;
 mod lexer;
 mod name_resolver;
 mod names;
+mod optimize;
 mod parser;
 mod resolver;
 mod runtime_cache;
@@ -302,6 +303,10 @@ fn main() {
         }
     };
     timings.record_since("name-resolve", phase_started);
+
+    let phase_started = Instant::now();
+    let ast = optimize::fold_constants(ast);
+    timings.record_since("optimize", phase_started);
 
     let phase_started = Instant::now();
     let check_result = match types::check_with_target(&ast, target) {

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -900,6 +900,7 @@ fn prune_expr(expr: Expr) -> Expr {
             len: Box::new(prune_expr(*len)),
         },
     };
+    let kind = prune_unused_pure_subexpressions(kind);
     Expr { kind, span }
 }
 
@@ -973,6 +974,45 @@ fn callable_target_has_side_effects(target: &CallableTarget) -> bool {
     match target {
         CallableTarget::Function(_) | CallableTarget::StaticMethod { .. } => false,
         CallableTarget::Method { .. } => true,
+    }
+}
+
+fn prune_unused_pure_subexpressions(kind: ExprKind) -> ExprKind {
+    match kind {
+        ExprKind::Ternary {
+            condition,
+            then_expr,
+            else_expr,
+        } => match scalar_value(&condition) {
+            Some(value) if value.truthy() && !expr_has_side_effects(&else_expr) => then_expr.kind,
+            Some(value) if !value.truthy() && !expr_has_side_effects(&then_expr) => else_expr.kind,
+            _ => ExprKind::Ternary {
+                condition,
+                then_expr,
+                else_expr,
+            },
+        },
+        ExprKind::NullCoalesce { value, default } => match scalar_value(&value) {
+            Some(ScalarValue::Null) => default.kind,
+            Some(_) if !expr_has_side_effects(&default) => value.kind,
+            _ => ExprKind::NullCoalesce { value, default },
+        },
+        ExprKind::BinaryOp { left, op, right } => match op {
+            BinOp::And => match scalar_value(&left) {
+                Some(value) if !value.truthy() && !expr_has_side_effects(&right) => {
+                    ExprKind::BoolLiteral(false)
+                }
+                _ => ExprKind::BinaryOp { left, op, right },
+            },
+            BinOp::Or => match scalar_value(&left) {
+                Some(value) if value.truthy() && !expr_has_side_effects(&right) => {
+                    ExprKind::BoolLiteral(true)
+                }
+                _ => ExprKind::BinaryOp { left, op, right },
+            },
+            _ => ExprKind::BinaryOp { left, op, right },
+        },
+        other => other,
     }
 }
 
@@ -2073,6 +2113,44 @@ mod tests {
         };
         assert_eq!(body.len(), 1);
         assert_eq!(body[0], Stmt::echo(Expr::int_lit(7)));
+    }
+
+    #[test]
+    fn test_prune_ternary_drops_unused_pure_branch() {
+        let program = vec![Stmt::assign(
+            "x",
+            Expr::new(
+                ExprKind::Ternary {
+                    condition: Box::new(Expr::new(ExprKind::BoolLiteral(true), Span::dummy())),
+                    then_expr: Box::new(Expr::var("answer")),
+                    else_expr: Box::new(Expr::binop(Expr::int_lit(2), BinOp::Pow, Expr::int_lit(8))),
+                },
+                Span::dummy(),
+            ),
+        )];
+
+        let pruned = prune_constant_control_flow(program);
+
+        assert_eq!(pruned, vec![Stmt::assign("x", Expr::var("answer"))]);
+    }
+
+    #[test]
+    fn test_prune_short_circuit_drops_unused_pure_rhs() {
+        let program = vec![Stmt::echo(Expr::new(
+            ExprKind::BinaryOp {
+                left: Box::new(Expr::new(ExprKind::BoolLiteral(true), Span::dummy())),
+                op: BinOp::Or,
+                right: Box::new(Expr::binop(Expr::int_lit(2), BinOp::Pow, Expr::int_lit(8))),
+            },
+            Span::dummy(),
+        ))];
+
+        let pruned = prune_constant_control_flow(program);
+
+        assert_eq!(
+            pruned,
+            vec![Stmt::echo(Expr::new(ExprKind::BoolLiteral(true), Span::dummy()))]
+        );
     }
 
     #[test]

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -345,10 +345,14 @@ fn fold_expr(expr: Expr) -> Expr {
             try_fold_bit_not(&inner).unwrap_or_else(|| ExprKind::BitNot(Box::new(inner)))
         }
         ExprKind::Throw(inner) => ExprKind::Throw(Box::new(fold_expr(*inner))),
-        ExprKind::NullCoalesce { value, default } => ExprKind::NullCoalesce {
-            value: Box::new(fold_expr(*value)),
-            default: Box::new(fold_expr(*default)),
-        },
+        ExprKind::NullCoalesce { value, default } => {
+            let value = fold_expr(*value);
+            let default = fold_expr(*default);
+            try_fold_null_coalesce(&value, &default).unwrap_or_else(|| ExprKind::NullCoalesce {
+                value: Box::new(value),
+                default: Box::new(default),
+            })
+        }
         ExprKind::PreIncrement(name) => ExprKind::PreIncrement(name),
         ExprKind::PostIncrement(name) => ExprKind::PostIncrement(name),
         ExprKind::PreDecrement(name) => ExprKind::PreDecrement(name),
@@ -390,11 +394,18 @@ fn fold_expr(expr: Expr) -> Expr {
             condition,
             then_expr,
             else_expr,
-        } => ExprKind::Ternary {
-            condition: Box::new(fold_expr(*condition)),
-            then_expr: Box::new(fold_expr(*then_expr)),
-            else_expr: Box::new(fold_expr(*else_expr)),
-        },
+        } => {
+            let condition = fold_expr(*condition);
+            let then_expr = fold_expr(*then_expr);
+            let else_expr = fold_expr(*else_expr);
+            try_fold_ternary(&condition, &then_expr, &else_expr).unwrap_or_else(|| {
+                ExprKind::Ternary {
+                    condition: Box::new(condition),
+                    then_expr: Box::new(then_expr),
+                    else_expr: Box::new(else_expr),
+                }
+            })
+        }
         ExprKind::Cast { target, expr } => ExprKind::Cast {
             target,
             expr: Box::new(fold_expr(*expr)),
@@ -497,10 +508,7 @@ fn try_fold_negate(expr: &Expr) -> Option<ExprKind> {
 }
 
 fn try_fold_not(expr: &Expr) -> Option<ExprKind> {
-    match &expr.kind {
-        ExprKind::BoolLiteral(value) => Some(ExprKind::BoolLiteral(!value)),
-        _ => None,
-    }
+    Some(ExprKind::BoolLiteral(!scalar_value(expr)?.truthy()))
 }
 
 fn try_fold_bit_not(expr: &Expr) -> Option<ExprKind> {
@@ -520,6 +528,16 @@ fn try_fold_binary_op(op: &BinOp, left: &Expr, right: &Expr) -> Option<ExprKind>
         BinOp::BitAnd | BinOp::BitOr | BinOp::BitXor | BinOp::ShiftLeft | BinOp::ShiftRight => {
             try_fold_bitwise_binop(op, left, right)
         }
+        BinOp::And | BinOp::Or => try_fold_logical_binop(op, left, right),
+        BinOp::Eq
+        | BinOp::NotEq
+        | BinOp::StrictEq
+        | BinOp::StrictNotEq
+        | BinOp::Lt
+        | BinOp::Gt
+        | BinOp::LtEq
+        | BinOp::GtEq
+        | BinOp::Spaceship => try_fold_compare_binop(op, left, right),
         _ => None,
     }
 }
@@ -609,6 +627,53 @@ fn try_fold_bitwise_binop(op: &BinOp, left: &Expr, right: &Expr) -> Option<ExprK
     }
 }
 
+fn try_fold_logical_binop(op: &BinOp, left: &Expr, right: &Expr) -> Option<ExprKind> {
+    let left = scalar_value(left)?;
+    let right = scalar_value(right)?;
+    let result = match op {
+        BinOp::And => left.truthy() && right.truthy(),
+        BinOp::Or => left.truthy() || right.truthy(),
+        _ => return None,
+    };
+    Some(ExprKind::BoolLiteral(result))
+}
+
+fn try_fold_compare_binop(op: &BinOp, left: &Expr, right: &Expr) -> Option<ExprKind> {
+    match op {
+        BinOp::Eq => Some(ExprKind::BoolLiteral(loose_eq(left, right)?)),
+        BinOp::NotEq => Some(ExprKind::BoolLiteral(!loose_eq(left, right)?)),
+        BinOp::StrictEq => Some(ExprKind::BoolLiteral(strict_eq(left, right)?)),
+        BinOp::StrictNotEq => Some(ExprKind::BoolLiteral(!strict_eq(left, right)?)),
+        BinOp::Lt => Some(ExprKind::BoolLiteral(compare_numeric(left, right, |l, r| l < r)?)),
+        BinOp::Gt => Some(ExprKind::BoolLiteral(compare_numeric(left, right, |l, r| l > r)?)),
+        BinOp::LtEq => Some(ExprKind::BoolLiteral(compare_numeric(left, right, |l, r| l <= r)?)),
+        BinOp::GtEq => Some(ExprKind::BoolLiteral(compare_numeric(left, right, |l, r| l >= r)?)),
+        BinOp::Spaceship => Some(ExprKind::IntLiteral(spaceship_numeric(left, right)?)),
+        _ => None,
+    }
+}
+
+fn try_fold_null_coalesce(value: &Expr, default: &Expr) -> Option<ExprKind> {
+    let value = scalar_value(value)?;
+    let default = scalar_value(default)?;
+    if matches!(value, ScalarValue::Null) {
+        Some(default.into_expr_kind())
+    } else {
+        Some(value.into_expr_kind())
+    }
+}
+
+fn try_fold_ternary(condition: &Expr, then_expr: &Expr, else_expr: &Expr) -> Option<ExprKind> {
+    let condition = scalar_value(condition)?;
+    let then_expr = scalar_value(then_expr)?;
+    let else_expr = scalar_value(else_expr)?;
+    if condition.truthy() {
+        Some(then_expr.into_expr_kind())
+    } else {
+        Some(else_expr.into_expr_kind())
+    }
+}
+
 fn int_literal(expr: &Expr) -> Option<i64> {
     match expr.kind {
         ExprKind::IntLiteral(value) => Some(value),
@@ -621,6 +686,87 @@ fn numeric_literal(expr: &Expr) -> Option<f64> {
         ExprKind::IntLiteral(value) => Some(value as f64),
         ExprKind::FloatLiteral(value) => Some(value),
         _ => None,
+    }
+}
+
+fn scalar_value(expr: &Expr) -> Option<ScalarValue> {
+    match &expr.kind {
+        ExprKind::Null => Some(ScalarValue::Null),
+        ExprKind::BoolLiteral(value) => Some(ScalarValue::Bool(*value)),
+        ExprKind::IntLiteral(value) => Some(ScalarValue::Int(*value)),
+        ExprKind::FloatLiteral(value) => Some(ScalarValue::Float(*value)),
+        ExprKind::StringLiteral(value) => Some(ScalarValue::String(value.clone())),
+        _ => None,
+    }
+}
+
+fn strict_eq(left: &Expr, right: &Expr) -> Option<bool> {
+    let left = scalar_value(left)?;
+    let right = scalar_value(right)?;
+    Some(left == right)
+}
+
+fn loose_eq(left: &Expr, right: &Expr) -> Option<bool> {
+    let left = scalar_value(left)?;
+    let right = scalar_value(right)?;
+    match (&left, &right) {
+        (ScalarValue::Null, ScalarValue::Null) => Some(true),
+        (ScalarValue::Bool(left), ScalarValue::Bool(right)) => Some(left == right),
+        (ScalarValue::String(left), ScalarValue::String(right)) => Some(left == right),
+        (ScalarValue::Int(left), ScalarValue::Int(right)) => Some(left == right),
+        (ScalarValue::Float(left), ScalarValue::Float(right)) => Some(left == right),
+        (ScalarValue::Int(left), ScalarValue::Float(right)) => Some(*left as f64 == *right),
+        (ScalarValue::Float(left), ScalarValue::Int(right)) => Some(*left == *right as f64),
+        _ => None,
+    }
+}
+
+fn compare_numeric(left: &Expr, right: &Expr, cmp: impl FnOnce(f64, f64) -> bool) -> Option<bool> {
+    let left = numeric_literal(left)?;
+    let right = numeric_literal(right)?;
+    Some(cmp(left, right))
+}
+
+fn spaceship_numeric(left: &Expr, right: &Expr) -> Option<i64> {
+    let left = numeric_literal(left)?;
+    let right = numeric_literal(right)?;
+    Some(if left < right {
+        -1
+    } else if left > right {
+        1
+    } else {
+        0
+    })
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum ScalarValue {
+    Null,
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    String(String),
+}
+
+impl ScalarValue {
+    fn truthy(&self) -> bool {
+        match self {
+            ScalarValue::Null => false,
+            ScalarValue::Bool(value) => *value,
+            ScalarValue::Int(value) => *value != 0,
+            ScalarValue::Float(value) => *value != 0.0,
+            ScalarValue::String(value) => !value.is_empty() && value != "0",
+        }
+    }
+
+    fn into_expr_kind(self) -> ExprKind {
+        match self {
+            ScalarValue::Null => ExprKind::Null,
+            ScalarValue::Bool(value) => ExprKind::BoolLiteral(value),
+            ScalarValue::Int(value) => ExprKind::IntLiteral(value),
+            ScalarValue::Float(value) => ExprKind::FloatLiteral(value),
+            ScalarValue::String(value) => ExprKind::StringLiteral(value),
+        }
     }
 }
 
@@ -731,6 +877,106 @@ mod tests {
         assert_eq!(
             properties[0].default,
             Some(Expr::string_lit("hello world"))
+        );
+    }
+
+    #[test]
+    fn test_fold_strict_and_numeric_comparisons() {
+        let program = vec![
+            Stmt::echo(Expr::new(
+                ExprKind::BinaryOp {
+                    left: Box::new(Expr::int_lit(2)),
+                    op: BinOp::StrictEq,
+                    right: Box::new(Expr::int_lit(2)),
+                },
+                Span::dummy(),
+            )),
+            Stmt::echo(Expr::new(
+                ExprKind::BinaryOp {
+                    left: Box::new(Expr::float_lit(2.5)),
+                    op: BinOp::Lt,
+                    right: Box::new(Expr::float_lit(3.0)),
+                },
+                Span::dummy(),
+            )),
+            Stmt::echo(Expr::new(
+                ExprKind::BinaryOp {
+                    left: Box::new(Expr::int_lit(2)),
+                    op: BinOp::Spaceship,
+                    right: Box::new(Expr::int_lit(3)),
+                },
+                Span::dummy(),
+            )),
+        ];
+
+        let folded = fold_constants(program);
+
+        assert_eq!(
+            folded,
+            vec![
+                Stmt::echo(Expr::new(ExprKind::BoolLiteral(true), Span::dummy())),
+                Stmt::echo(Expr::new(ExprKind::BoolLiteral(true), Span::dummy())),
+                Stmt::echo(Expr::int_lit(-1)),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_fold_null_coalesce_and_ternary_only_for_scalar_constants() {
+        let program = vec![
+            Stmt::echo(Expr::new(
+                ExprKind::NullCoalesce {
+                    value: Box::new(Expr::new(ExprKind::Null, Span::dummy())),
+                    default: Box::new(Expr::string_lit("fallback")),
+                },
+                Span::dummy(),
+            )),
+            Stmt::echo(Expr::new(
+                ExprKind::Ternary {
+                    condition: Box::new(Expr::string_lit("0")),
+                    then_expr: Box::new(Expr::int_lit(10)),
+                    else_expr: Box::new(Expr::int_lit(20)),
+                },
+                Span::dummy(),
+            )),
+        ];
+
+        let folded = fold_constants(program);
+
+        assert_eq!(
+            folded,
+            vec![
+                Stmt::echo(Expr::string_lit("fallback")),
+                Stmt::echo(Expr::int_lit(20)),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_fold_logical_ops_and_not_using_php_truthiness() {
+        let program = vec![
+            Stmt::echo(Expr::new(
+                ExprKind::BinaryOp {
+                    left: Box::new(Expr::string_lit("0")),
+                    op: BinOp::Or,
+                    right: Box::new(Expr::string_lit("hello")),
+                },
+                Span::dummy(),
+            )),
+            Stmt::echo(Expr::new(
+                ExprKind::Not(Box::new(Expr::string_lit("0"))),
+                Span::dummy(),
+            )),
+        ];
+
+        let folded = fold_constants(program);
+
+        assert_eq!(
+            folded,
+            vec![
+                Stmt::echo(Expr::new(ExprKind::BoolLiteral(true), Span::dummy())),
+                Stmt::echo(Expr::new(ExprKind::BoolLiteral(true), Span::dummy())),
+            ]
         );
     }
 }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -1,0 +1,736 @@
+use crate::parser::ast::{
+    BinOp, CallableTarget, ClassMethod, ClassProperty, EnumCaseDecl, Expr, ExprKind, Program,
+    Stmt, StmtKind,
+};
+
+pub fn fold_constants(program: Program) -> Program {
+    program.into_iter().map(fold_stmt).collect()
+}
+
+fn fold_stmt(stmt: Stmt) -> Stmt {
+    let span = stmt.span;
+    let kind = match stmt.kind {
+        StmtKind::Echo(expr) => StmtKind::Echo(fold_expr(expr)),
+        StmtKind::Assign { name, value } => StmtKind::Assign {
+            name,
+            value: fold_expr(value),
+        },
+        StmtKind::If {
+            condition,
+            then_body,
+            elseif_clauses,
+            else_body,
+        } => StmtKind::If {
+            condition: fold_expr(condition),
+            then_body: fold_block(then_body),
+            elseif_clauses: elseif_clauses
+                .into_iter()
+                .map(|(condition, body)| (fold_expr(condition), fold_block(body)))
+                .collect(),
+            else_body: else_body.map(fold_block),
+        },
+        StmtKind::IfDef {
+            symbol,
+            then_body,
+            else_body,
+        } => StmtKind::IfDef {
+            symbol,
+            then_body: fold_block(then_body),
+            else_body: else_body.map(fold_block),
+        },
+        StmtKind::While { condition, body } => StmtKind::While {
+            condition: fold_expr(condition),
+            body: fold_block(body),
+        },
+        StmtKind::DoWhile { body, condition } => StmtKind::DoWhile {
+            body: fold_block(body),
+            condition: fold_expr(condition),
+        },
+        StmtKind::For {
+            init,
+            condition,
+            update,
+            body,
+        } => StmtKind::For {
+            init: init.map(|stmt| Box::new(fold_stmt(*stmt))),
+            condition: condition.map(fold_expr),
+            update: update.map(|stmt| Box::new(fold_stmt(*stmt))),
+            body: fold_block(body),
+        },
+        StmtKind::ArrayAssign {
+            array,
+            index,
+            value,
+        } => StmtKind::ArrayAssign {
+            array,
+            index: fold_expr(index),
+            value: fold_expr(value),
+        },
+        StmtKind::ArrayPush { array, value } => StmtKind::ArrayPush {
+            array,
+            value: fold_expr(value),
+        },
+        StmtKind::TypedAssign {
+            type_expr,
+            name,
+            value,
+        } => StmtKind::TypedAssign {
+            type_expr,
+            name,
+            value: fold_expr(value),
+        },
+        StmtKind::Foreach {
+            array,
+            key_var,
+            value_var,
+            body,
+        } => StmtKind::Foreach {
+            array: fold_expr(array),
+            key_var,
+            value_var,
+            body: fold_block(body),
+        },
+        StmtKind::Switch {
+            subject,
+            cases,
+            default,
+        } => StmtKind::Switch {
+            subject: fold_expr(subject),
+            cases: cases
+                .into_iter()
+                .map(|(exprs, body)| {
+                    (
+                        exprs.into_iter().map(fold_expr).collect(),
+                        fold_block(body),
+                    )
+                })
+                .collect(),
+            default: default.map(fold_block),
+        },
+        StmtKind::Include {
+            path,
+            once,
+            required,
+        } => StmtKind::Include {
+            path,
+            once,
+            required,
+        },
+        StmtKind::Throw(expr) => StmtKind::Throw(fold_expr(expr)),
+        StmtKind::Try {
+            try_body,
+            catches,
+            finally_body,
+        } => StmtKind::Try {
+            try_body: fold_block(try_body),
+            catches: catches
+                .into_iter()
+                .map(|catch| crate::parser::ast::CatchClause {
+                    exception_types: catch.exception_types,
+                    variable: catch.variable,
+                    body: fold_block(catch.body),
+                })
+                .collect(),
+            finally_body: finally_body.map(fold_block),
+        },
+        StmtKind::Break => StmtKind::Break,
+        StmtKind::Continue => StmtKind::Continue,
+        StmtKind::ExprStmt(expr) => StmtKind::ExprStmt(fold_expr(expr)),
+        StmtKind::NamespaceDecl { name } => StmtKind::NamespaceDecl { name },
+        StmtKind::NamespaceBlock { name, body } => StmtKind::NamespaceBlock {
+            name,
+            body: fold_block(body),
+        },
+        StmtKind::UseDecl { imports } => StmtKind::UseDecl { imports },
+        StmtKind::FunctionDecl {
+            name,
+            params,
+            variadic,
+            return_type,
+            body,
+        } => StmtKind::FunctionDecl {
+            name,
+            params: fold_params(params),
+            variadic,
+            return_type,
+            body: fold_block(body),
+        },
+        StmtKind::Return(expr) => StmtKind::Return(expr.map(fold_expr)),
+        StmtKind::ConstDecl { name, value } => StmtKind::ConstDecl {
+            name,
+            value: fold_expr(value),
+        },
+        StmtKind::ListUnpack { vars, value } => StmtKind::ListUnpack {
+            vars,
+            value: fold_expr(value),
+        },
+        StmtKind::Global { vars } => StmtKind::Global { vars },
+        StmtKind::StaticVar { name, init } => StmtKind::StaticVar {
+            name,
+            init: fold_expr(init),
+        },
+        StmtKind::ClassDecl {
+            name,
+            extends,
+            implements,
+            is_abstract,
+            is_readonly_class,
+            trait_uses,
+            properties,
+            methods,
+        } => StmtKind::ClassDecl {
+            name,
+            extends,
+            implements,
+            is_abstract,
+            is_readonly_class,
+            trait_uses,
+            properties: properties.into_iter().map(fold_property).collect(),
+            methods: methods.into_iter().map(fold_method).collect(),
+        },
+        StmtKind::EnumDecl {
+            name,
+            backing_type,
+            cases,
+        } => StmtKind::EnumDecl {
+            name,
+            backing_type,
+            cases: cases.into_iter().map(fold_enum_case).collect(),
+        },
+        StmtKind::PackedClassDecl { name, fields } => StmtKind::PackedClassDecl { name, fields },
+        StmtKind::InterfaceDecl {
+            name,
+            extends,
+            methods,
+        } => StmtKind::InterfaceDecl {
+            name,
+            extends,
+            methods: methods.into_iter().map(fold_method).collect(),
+        },
+        StmtKind::TraitDecl {
+            name,
+            trait_uses,
+            properties,
+            methods,
+        } => StmtKind::TraitDecl {
+            name,
+            trait_uses,
+            properties: properties.into_iter().map(fold_property).collect(),
+            methods: methods.into_iter().map(fold_method).collect(),
+        },
+        StmtKind::PropertyAssign {
+            object,
+            property,
+            value,
+        } => StmtKind::PropertyAssign {
+            object: Box::new(fold_expr(*object)),
+            property,
+            value: fold_expr(value),
+        },
+        StmtKind::PropertyArrayPush {
+            object,
+            property,
+            value,
+        } => StmtKind::PropertyArrayPush {
+            object: Box::new(fold_expr(*object)),
+            property,
+            value: fold_expr(value),
+        },
+        StmtKind::PropertyArrayAssign {
+            object,
+            property,
+            index,
+            value,
+        } => StmtKind::PropertyArrayAssign {
+            object: Box::new(fold_expr(*object)),
+            property,
+            index: fold_expr(index),
+            value: fold_expr(value),
+        },
+        StmtKind::ExternFunctionDecl {
+            name,
+            params,
+            return_type,
+            library,
+        } => StmtKind::ExternFunctionDecl {
+            name,
+            params,
+            return_type,
+            library,
+        },
+        StmtKind::ExternClassDecl { name, fields } => StmtKind::ExternClassDecl { name, fields },
+        StmtKind::ExternGlobalDecl { name, c_type } => {
+            StmtKind::ExternGlobalDecl { name, c_type }
+        }
+    };
+    Stmt { kind, span }
+}
+
+fn fold_block(body: Vec<Stmt>) -> Vec<Stmt> {
+    body.into_iter().map(fold_stmt).collect()
+}
+
+fn fold_params(
+    params: Vec<(String, Option<crate::parser::ast::TypeExpr>, Option<Expr>, bool)>,
+) -> Vec<(String, Option<crate::parser::ast::TypeExpr>, Option<Expr>, bool)> {
+    params
+        .into_iter()
+        .map(|(name, type_expr, default, is_ref)| {
+            (name, type_expr, default.map(fold_expr), is_ref)
+        })
+        .collect()
+}
+
+fn fold_property(property: ClassProperty) -> ClassProperty {
+    ClassProperty {
+        name: property.name,
+        visibility: property.visibility,
+        readonly: property.readonly,
+        default: property.default.map(fold_expr),
+        span: property.span,
+    }
+}
+
+fn fold_method(method: ClassMethod) -> ClassMethod {
+    ClassMethod {
+        name: method.name,
+        visibility: method.visibility,
+        is_static: method.is_static,
+        is_abstract: method.is_abstract,
+        has_body: method.has_body,
+        params: fold_params(method.params),
+        variadic: method.variadic,
+        return_type: method.return_type,
+        body: fold_block(method.body),
+        span: method.span,
+    }
+}
+
+fn fold_enum_case(case: EnumCaseDecl) -> EnumCaseDecl {
+    EnumCaseDecl {
+        name: case.name,
+        value: case.value.map(fold_expr),
+        span: case.span,
+    }
+}
+
+fn fold_expr(expr: Expr) -> Expr {
+    let span = expr.span;
+    let kind = match expr.kind {
+        ExprKind::StringLiteral(value) => ExprKind::StringLiteral(value),
+        ExprKind::IntLiteral(value) => ExprKind::IntLiteral(value),
+        ExprKind::FloatLiteral(value) => ExprKind::FloatLiteral(value),
+        ExprKind::Variable(name) => ExprKind::Variable(name),
+        ExprKind::BinaryOp { left, op, right } => {
+            let left = fold_expr(*left);
+            let right = fold_expr(*right);
+            try_fold_binary_op(&op, &left, &right).unwrap_or_else(|| ExprKind::BinaryOp {
+                left: Box::new(left),
+                op,
+                right: Box::new(right),
+            })
+        }
+        ExprKind::BoolLiteral(value) => ExprKind::BoolLiteral(value),
+        ExprKind::Null => ExprKind::Null,
+        ExprKind::Negate(inner) => {
+            let inner = fold_expr(*inner);
+            try_fold_negate(&inner).unwrap_or_else(|| ExprKind::Negate(Box::new(inner)))
+        }
+        ExprKind::Not(inner) => {
+            let inner = fold_expr(*inner);
+            try_fold_not(&inner).unwrap_or_else(|| ExprKind::Not(Box::new(inner)))
+        }
+        ExprKind::BitNot(inner) => {
+            let inner = fold_expr(*inner);
+            try_fold_bit_not(&inner).unwrap_or_else(|| ExprKind::BitNot(Box::new(inner)))
+        }
+        ExprKind::Throw(inner) => ExprKind::Throw(Box::new(fold_expr(*inner))),
+        ExprKind::NullCoalesce { value, default } => ExprKind::NullCoalesce {
+            value: Box::new(fold_expr(*value)),
+            default: Box::new(fold_expr(*default)),
+        },
+        ExprKind::PreIncrement(name) => ExprKind::PreIncrement(name),
+        ExprKind::PostIncrement(name) => ExprKind::PostIncrement(name),
+        ExprKind::PreDecrement(name) => ExprKind::PreDecrement(name),
+        ExprKind::PostDecrement(name) => ExprKind::PostDecrement(name),
+        ExprKind::FunctionCall { name, args } => ExprKind::FunctionCall {
+            name,
+            args: args.into_iter().map(fold_expr).collect(),
+        },
+        ExprKind::ArrayLiteral(items) => {
+            ExprKind::ArrayLiteral(items.into_iter().map(fold_expr).collect())
+        }
+        ExprKind::ArrayLiteralAssoc(items) => ExprKind::ArrayLiteralAssoc(
+            items.into_iter()
+                .map(|(key, value)| (fold_expr(key), fold_expr(value)))
+                .collect(),
+        ),
+        ExprKind::Match {
+            subject,
+            arms,
+            default,
+        } => ExprKind::Match {
+            subject: Box::new(fold_expr(*subject)),
+            arms: arms
+                .into_iter()
+                .map(|(patterns, value)| {
+                    (
+                        patterns.into_iter().map(fold_expr).collect(),
+                        fold_expr(value),
+                    )
+                })
+                .collect(),
+            default: default.map(|expr| Box::new(fold_expr(*expr))),
+        },
+        ExprKind::ArrayAccess { array, index } => ExprKind::ArrayAccess {
+            array: Box::new(fold_expr(*array)),
+            index: Box::new(fold_expr(*index)),
+        },
+        ExprKind::Ternary {
+            condition,
+            then_expr,
+            else_expr,
+        } => ExprKind::Ternary {
+            condition: Box::new(fold_expr(*condition)),
+            then_expr: Box::new(fold_expr(*then_expr)),
+            else_expr: Box::new(fold_expr(*else_expr)),
+        },
+        ExprKind::Cast { target, expr } => ExprKind::Cast {
+            target,
+            expr: Box::new(fold_expr(*expr)),
+        },
+        ExprKind::Closure {
+            params,
+            variadic,
+            body,
+            is_arrow,
+            captures,
+        } => ExprKind::Closure {
+            params: fold_params(params),
+            variadic,
+            body: fold_block(body),
+            is_arrow,
+            captures,
+        },
+        ExprKind::NamedArg { name, value } => ExprKind::NamedArg {
+            name,
+            value: Box::new(fold_expr(*value)),
+        },
+        ExprKind::Spread(inner) => ExprKind::Spread(Box::new(fold_expr(*inner))),
+        ExprKind::ClosureCall { var, args } => ExprKind::ClosureCall {
+            var,
+            args: args.into_iter().map(fold_expr).collect(),
+        },
+        ExprKind::ExprCall { callee, args } => ExprKind::ExprCall {
+            callee: Box::new(fold_expr(*callee)),
+            args: args.into_iter().map(fold_expr).collect(),
+        },
+        ExprKind::ConstRef(name) => ExprKind::ConstRef(name),
+        ExprKind::EnumCase {
+            enum_name,
+            case_name,
+        } => ExprKind::EnumCase {
+            enum_name,
+            case_name,
+        },
+        ExprKind::NewObject { class_name, args } => ExprKind::NewObject {
+            class_name,
+            args: args.into_iter().map(fold_expr).collect(),
+        },
+        ExprKind::PropertyAccess { object, property } => ExprKind::PropertyAccess {
+            object: Box::new(fold_expr(*object)),
+            property,
+        },
+        ExprKind::MethodCall {
+            object,
+            method,
+            args,
+        } => ExprKind::MethodCall {
+            object: Box::new(fold_expr(*object)),
+            method,
+            args: args.into_iter().map(fold_expr).collect(),
+        },
+        ExprKind::StaticMethodCall {
+            receiver,
+            method,
+            args,
+        } => ExprKind::StaticMethodCall {
+            receiver,
+            method,
+            args: args.into_iter().map(fold_expr).collect(),
+        },
+        ExprKind::FirstClassCallable(target) => {
+            ExprKind::FirstClassCallable(fold_callable_target(target))
+        }
+        ExprKind::This => ExprKind::This,
+        ExprKind::PtrCast { target_type, expr } => ExprKind::PtrCast {
+            target_type,
+            expr: Box::new(fold_expr(*expr)),
+        },
+        ExprKind::BufferNew { element_type, len } => ExprKind::BufferNew {
+            element_type,
+            len: Box::new(fold_expr(*len)),
+        },
+    };
+    Expr { kind, span }
+}
+
+fn fold_callable_target(target: CallableTarget) -> CallableTarget {
+    match target {
+        CallableTarget::Function(name) => CallableTarget::Function(name),
+        CallableTarget::StaticMethod { receiver, method } => {
+            CallableTarget::StaticMethod { receiver, method }
+        }
+        CallableTarget::Method { object, method } => CallableTarget::Method {
+            object: Box::new(fold_expr(*object)),
+            method,
+        },
+    }
+}
+
+fn try_fold_negate(expr: &Expr) -> Option<ExprKind> {
+    match &expr.kind {
+        ExprKind::IntLiteral(value) => value.checked_neg().map(ExprKind::IntLiteral),
+        ExprKind::FloatLiteral(value) => Some(ExprKind::FloatLiteral(-value)),
+        _ => None,
+    }
+}
+
+fn try_fold_not(expr: &Expr) -> Option<ExprKind> {
+    match &expr.kind {
+        ExprKind::BoolLiteral(value) => Some(ExprKind::BoolLiteral(!value)),
+        _ => None,
+    }
+}
+
+fn try_fold_bit_not(expr: &Expr) -> Option<ExprKind> {
+    match &expr.kind {
+        ExprKind::IntLiteral(value) => Some(ExprKind::IntLiteral(!value)),
+        _ => None,
+    }
+}
+
+fn try_fold_binary_op(op: &BinOp, left: &Expr, right: &Expr) -> Option<ExprKind> {
+    match op {
+        BinOp::Concat => try_fold_concat(left, right),
+        BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Pow => {
+            try_fold_numeric_binop(op, left, right)
+        }
+        BinOp::Mod => try_fold_int_mod(left, right),
+        BinOp::BitAnd | BinOp::BitOr | BinOp::BitXor | BinOp::ShiftLeft | BinOp::ShiftRight => {
+            try_fold_bitwise_binop(op, left, right)
+        }
+        _ => None,
+    }
+}
+
+fn try_fold_concat(left: &Expr, right: &Expr) -> Option<ExprKind> {
+    let ExprKind::StringLiteral(left) = &left.kind else {
+        return None;
+    };
+    let ExprKind::StringLiteral(right) = &right.kind else {
+        return None;
+    };
+    Some(ExprKind::StringLiteral(format!("{left}{right}")))
+}
+
+fn try_fold_numeric_binop(op: &BinOp, left: &Expr, right: &Expr) -> Option<ExprKind> {
+    if let (Some(left), Some(right)) = (int_literal(left), int_literal(right)) {
+        return try_fold_int_numeric_binop(op, left, right);
+    }
+
+    let (left, right) = (numeric_literal(left)?, numeric_literal(right)?);
+    if matches!(op, BinOp::Div) && right == 0.0 {
+        return None;
+    }
+    let result = match op {
+        BinOp::Add => left + right,
+        BinOp::Sub => left - right,
+        BinOp::Mul => left * right,
+        BinOp::Div => left / right,
+        BinOp::Pow => left.powf(right),
+        _ => return None,
+    };
+    if result.is_finite() {
+        Some(ExprKind::FloatLiteral(result))
+    } else {
+        None
+    }
+}
+
+fn try_fold_int_numeric_binop(op: &BinOp, left: i64, right: i64) -> Option<ExprKind> {
+    match op {
+        BinOp::Add => left.checked_add(right).map(ExprKind::IntLiteral),
+        BinOp::Sub => left.checked_sub(right).map(ExprKind::IntLiteral),
+        BinOp::Mul => left.checked_mul(right).map(ExprKind::IntLiteral),
+        BinOp::Div => {
+            if right == 0 {
+                None
+            } else {
+                Some(ExprKind::FloatLiteral(left as f64 / right as f64))
+            }
+        }
+        BinOp::Pow => {
+            let result = (left as f64).powf(right as f64);
+            if result.is_finite() {
+                Some(ExprKind::FloatLiteral(result))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn try_fold_int_mod(left: &Expr, right: &Expr) -> Option<ExprKind> {
+    let (left, right) = (int_literal(left)?, int_literal(right)?);
+    if right == 0 {
+        None
+    } else {
+        Some(ExprKind::IntLiteral(left % right))
+    }
+}
+
+fn try_fold_bitwise_binop(op: &BinOp, left: &Expr, right: &Expr) -> Option<ExprKind> {
+    let (left, right) = (int_literal(left)?, int_literal(right)?);
+    match op {
+        BinOp::BitAnd => Some(ExprKind::IntLiteral(left & right)),
+        BinOp::BitOr => Some(ExprKind::IntLiteral(left | right)),
+        BinOp::BitXor => Some(ExprKind::IntLiteral(left ^ right)),
+        BinOp::ShiftLeft => {
+            let shift = u32::try_from(right).ok()?;
+            left.checked_shl(shift).map(ExprKind::IntLiteral)
+        }
+        BinOp::ShiftRight => {
+            let shift = u32::try_from(right).ok()?;
+            left.checked_shr(shift).map(ExprKind::IntLiteral)
+        }
+        _ => None,
+    }
+}
+
+fn int_literal(expr: &Expr) -> Option<i64> {
+    match expr.kind {
+        ExprKind::IntLiteral(value) => Some(value),
+        _ => None,
+    }
+}
+
+fn numeric_literal(expr: &Expr) -> Option<f64> {
+    match expr.kind {
+        ExprKind::IntLiteral(value) => Some(value as f64),
+        ExprKind::FloatLiteral(value) => Some(value),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::ast::{ClassProperty, Visibility};
+    use crate::span::Span;
+
+    #[test]
+    fn test_fold_nested_integer_arithmetic() {
+        let program = vec![Stmt::new(
+            StmtKind::Echo(Expr::new(
+                ExprKind::BinaryOp {
+                    left: Box::new(Expr::new(
+                        ExprKind::BinaryOp {
+                            left: Box::new(Expr::int_lit(2)),
+                            op: BinOp::Add,
+                            right: Box::new(Expr::int_lit(3)),
+                        },
+                        Span::dummy(),
+                    )),
+                    op: BinOp::Mul,
+                    right: Box::new(Expr::int_lit(4)),
+                },
+                Span::dummy(),
+            )),
+            Span::dummy(),
+        )];
+
+        let folded = fold_constants(program);
+
+        assert_eq!(folded, vec![Stmt::echo(Expr::int_lit(20))]);
+    }
+
+    #[test]
+    fn test_fold_constant_pow_to_float_literal() {
+        let program = vec![Stmt::echo(Expr::new(
+            ExprKind::BinaryOp {
+                left: Box::new(Expr::int_lit(2)),
+                op: BinOp::Pow,
+                right: Box::new(Expr::int_lit(3)),
+            },
+            Span::dummy(),
+        ))];
+
+        let folded = fold_constants(program);
+
+        assert_eq!(
+            folded,
+            vec![Stmt::echo(Expr::new(
+                ExprKind::FloatLiteral(8.0),
+                Span::dummy(),
+            ))]
+        );
+    }
+
+    #[test]
+    fn test_skip_division_by_zero_fold() {
+        let expr = Expr::new(
+            ExprKind::BinaryOp {
+                left: Box::new(Expr::int_lit(5)),
+                op: BinOp::Div,
+                right: Box::new(Expr::int_lit(0)),
+            },
+            Span::dummy(),
+        );
+
+        let folded = fold_constants(vec![Stmt::echo(expr.clone())]);
+
+        assert_eq!(folded, vec![Stmt::echo(expr)]);
+    }
+
+    #[test]
+    fn test_fold_string_concat_and_property_default() {
+        let property = ClassProperty {
+            name: "label".to_string(),
+            visibility: Visibility::Public,
+            readonly: false,
+            default: Some(Expr::new(
+                ExprKind::BinaryOp {
+                    left: Box::new(Expr::string_lit("hello ")),
+                    op: BinOp::Concat,
+                    right: Box::new(Expr::string_lit("world")),
+                },
+                Span::dummy(),
+            )),
+            span: Span::dummy(),
+        };
+
+        let folded = fold_constants(vec![Stmt::new(
+            StmtKind::ClassDecl {
+                name: "Greeter".to_string(),
+                extends: None,
+                implements: Vec::new(),
+                is_abstract: false,
+                is_readonly_class: false,
+                trait_uses: Vec::new(),
+                properties: vec![property],
+                methods: Vec::new(),
+            },
+            Span::dummy(),
+        )]);
+
+        let StmtKind::ClassDecl { properties, .. } = &folded[0].kind else {
+            panic!("expected class declaration");
+        };
+        assert_eq!(
+            properties[0].default,
+            Some(Expr::string_lit("hello world"))
+        );
+    }
+}

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -1,6 +1,6 @@
 use crate::parser::ast::{
-    BinOp, CallableTarget, ClassMethod, ClassProperty, EnumCaseDecl, Expr, ExprKind, Program,
-    Stmt, StmtKind,
+    BinOp, CallableTarget, CastType, ClassMethod, ClassProperty, EnumCaseDecl, Expr, ExprKind,
+    Program, Stmt, StmtKind,
 };
 
 pub fn fold_constants(program: Program) -> Program {
@@ -406,10 +406,13 @@ fn fold_expr(expr: Expr) -> Expr {
                 }
             })
         }
-        ExprKind::Cast { target, expr } => ExprKind::Cast {
-            target,
-            expr: Box::new(fold_expr(*expr)),
-        },
+        ExprKind::Cast { target, expr } => {
+            let expr = fold_expr(*expr);
+            try_fold_cast(&target, &expr).unwrap_or_else(|| ExprKind::Cast {
+                target,
+                expr: Box::new(expr),
+            })
+        }
         ExprKind::Closure {
             params,
             variadic,
@@ -674,6 +677,51 @@ fn try_fold_ternary(condition: &Expr, then_expr: &Expr, else_expr: &Expr) -> Opt
     }
 }
 
+fn try_fold_cast(target: &CastType, expr: &Expr) -> Option<ExprKind> {
+    let value = scalar_value(expr)?;
+    match target {
+        CastType::Int => try_fold_cast_int(value),
+        CastType::Float => try_fold_cast_float(value),
+        CastType::String => try_fold_cast_string(value),
+        CastType::Bool => Some(ExprKind::BoolLiteral(value.truthy())),
+        CastType::Array => None,
+    }
+}
+
+fn try_fold_cast_int(value: ScalarValue) -> Option<ExprKind> {
+    match value {
+        ScalarValue::Null => Some(ExprKind::IntLiteral(0)),
+        ScalarValue::Bool(value) => Some(ExprKind::IntLiteral(i64::from(value))),
+        ScalarValue::Int(value) => Some(ExprKind::IntLiteral(value)),
+        ScalarValue::Float(value) => truncate_float_to_i64(value).map(ExprKind::IntLiteral),
+        ScalarValue::String(value) => parse_string_cast_int(&value).map(ExprKind::IntLiteral),
+    }
+}
+
+fn try_fold_cast_float(value: ScalarValue) -> Option<ExprKind> {
+    match value {
+        ScalarValue::Null => Some(ExprKind::FloatLiteral(0.0)),
+        ScalarValue::Bool(value) => Some(ExprKind::FloatLiteral(if value { 1.0 } else { 0.0 })),
+        ScalarValue::Int(value) => Some(ExprKind::FloatLiteral(value as f64)),
+        ScalarValue::Float(value) => Some(ExprKind::FloatLiteral(value)),
+        ScalarValue::String(value) => parse_string_cast_float(&value).map(ExprKind::FloatLiteral),
+    }
+}
+
+fn try_fold_cast_string(value: ScalarValue) -> Option<ExprKind> {
+    match value {
+        ScalarValue::Null => Some(ExprKind::StringLiteral(String::new())),
+        ScalarValue::Bool(value) => Some(ExprKind::StringLiteral(if value {
+            "1".to_string()
+        } else {
+            String::new()
+        })),
+        ScalarValue::Int(value) => Some(ExprKind::StringLiteral(value.to_string())),
+        ScalarValue::Float(_value) => None,
+        ScalarValue::String(value) => Some(ExprKind::StringLiteral(value)),
+    }
+}
+
 fn int_literal(expr: &Expr) -> Option<i64> {
     match expr.kind {
         ExprKind::IntLiteral(value) => Some(value),
@@ -768,6 +816,40 @@ impl ScalarValue {
             ScalarValue::String(value) => ExprKind::StringLiteral(value),
         }
     }
+}
+
+fn truncate_float_to_i64(value: f64) -> Option<i64> {
+    if !value.is_finite() {
+        return None;
+    }
+    let truncated = value.trunc();
+    if truncated < i64::MIN as f64 || truncated > i64::MAX as f64 {
+        return None;
+    }
+    Some(truncated as i64)
+}
+
+fn parse_string_cast_int(value: &str) -> Option<i64> {
+    if let Ok(parsed) = value.parse::<i64>() {
+        return Some(parsed);
+    }
+    if let Ok(parsed) = value.parse::<f64>() {
+        return truncate_float_to_i64(parsed);
+    }
+    if value.chars().all(|ch| ch.is_ascii_alphabetic()) {
+        return Some(0);
+    }
+    None
+}
+
+fn parse_string_cast_float(value: &str) -> Option<f64> {
+    if let Ok(parsed) = value.parse::<f64>() {
+        return Some(parsed);
+    }
+    if value.chars().all(|ch| ch.is_ascii_alphabetic()) {
+        return Some(0.0);
+    }
+    None
 }
 
 #[cfg(test)]
@@ -978,5 +1060,66 @@ mod tests {
                 Stmt::echo(Expr::new(ExprKind::BoolLiteral(true), Span::dummy())),
             ]
         );
+    }
+
+    #[test]
+    fn test_fold_scalar_casts_when_result_is_unambiguous() {
+        let program = vec![
+            Stmt::echo(Expr::new(
+                ExprKind::Cast {
+                    target: CastType::Int,
+                    expr: Box::new(Expr::float_lit(3.7)),
+                },
+                Span::dummy(),
+            )),
+            Stmt::echo(Expr::new(
+                ExprKind::Cast {
+                    target: CastType::Float,
+                    expr: Box::new(Expr::string_lit("3.14")),
+                },
+                Span::dummy(),
+            )),
+            Stmt::echo(Expr::new(
+                ExprKind::Cast {
+                    target: CastType::Bool,
+                    expr: Box::new(Expr::string_lit("0")),
+                },
+                Span::dummy(),
+            )),
+            Stmt::echo(Expr::new(
+                ExprKind::Cast {
+                    target: CastType::String,
+                    expr: Box::new(Expr::int_lit(42)),
+                },
+                Span::dummy(),
+            )),
+        ];
+
+        let folded = fold_constants(program);
+
+        assert_eq!(
+            folded,
+            vec![
+                Stmt::echo(Expr::int_lit(3)),
+                Stmt::echo(Expr::float_lit(3.14)),
+                Stmt::echo(Expr::new(ExprKind::BoolLiteral(false), Span::dummy())),
+                Stmt::echo(Expr::string_lit("42")),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_keep_ambiguous_string_casts_unfolded() {
+        let expr = Expr::new(
+            ExprKind::Cast {
+                target: CastType::Int,
+                expr: Box::new(Expr::string_lit("42abc")),
+            },
+            Span::dummy(),
+        );
+
+        let folded = fold_constants(vec![Stmt::echo(expr.clone())]);
+
+        assert_eq!(folded, vec![Stmt::echo(expr)]);
     }
 }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -278,7 +278,9 @@ fn prune_block(body: Vec<Stmt>) -> Vec<Stmt> {
     let mut pruned = Vec::new();
     for stmt in body {
         let pruned_stmt = prune_stmt(stmt);
-        let stops_here = pruned_stmt.last().is_some_and(stmt_exits_current_block);
+        let stops_here = pruned_stmt
+            .last()
+            .is_some_and(|stmt| !matches!(stmt_terminal_effect(stmt), TerminalEffect::FallsThrough));
         pruned.extend(pruned_stmt);
         if stops_here {
             break;
@@ -287,39 +289,107 @@ fn prune_block(body: Vec<Stmt>) -> Vec<Stmt> {
     pruned
 }
 
-fn block_exits_current_block(body: &[Stmt]) -> bool {
-    body.last().is_some_and(stmt_exits_current_block)
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TerminalEffect {
+    FallsThrough,
+    Breaks,
+    ExitsCurrentBlock,
+    TerminatesMixed,
 }
 
-fn stmt_exits_current_block(stmt: &Stmt) -> bool {
+fn block_terminal_effect(body: &[Stmt]) -> TerminalEffect {
+    body.last()
+        .map(stmt_terminal_effect)
+        .unwrap_or(TerminalEffect::FallsThrough)
+}
+
+fn stmt_terminal_effect(stmt: &Stmt) -> TerminalEffect {
     match &stmt.kind {
-        StmtKind::Return(_) | StmtKind::Throw(_) | StmtKind::Break | StmtKind::Continue => true,
+        StmtKind::Return(_) | StmtKind::Throw(_) | StmtKind::Continue => {
+            TerminalEffect::ExitsCurrentBlock
+        }
+        StmtKind::Break => TerminalEffect::Breaks,
         StmtKind::If {
             then_body,
             elseif_clauses,
             else_body,
             ..
-        } => {
-            block_exits_current_block(then_body)
-                && elseif_clauses
-                    .iter()
-                    .all(|(_, body)| block_exits_current_block(body))
-                && else_body
-                    .as_ref()
-                    .is_some_and(|body| block_exits_current_block(body))
-        }
+        } => combine_branch_effects(
+            std::iter::once(block_terminal_effect(then_body))
+                .chain(elseif_clauses.iter().map(|(_, body)| block_terminal_effect(body))),
+            else_body.as_ref().map(|body| block_terminal_effect(body)),
+        ),
         StmtKind::IfDef {
             then_body,
             else_body,
             ..
-        } => {
-            block_exits_current_block(then_body)
-                && else_body
-                    .as_ref()
-                    .is_some_and(|body| block_exits_current_block(body))
-        }
-        _ => false,
+        } => combine_branch_effects(
+            std::iter::once(block_terminal_effect(then_body)),
+            else_body.as_ref().map(|body| block_terminal_effect(body)),
+        ),
+        StmtKind::Switch { cases, default, .. } => switch_terminal_effect(cases, default),
+        _ => TerminalEffect::FallsThrough,
     }
+}
+
+fn combine_branch_effects(
+    branch_effects: impl Iterator<Item = TerminalEffect>,
+    else_effect: Option<TerminalEffect>,
+) -> TerminalEffect {
+    let Some(else_effect) = else_effect else {
+        return TerminalEffect::FallsThrough;
+    };
+
+    let mut saw_break = else_effect == TerminalEffect::Breaks;
+    let mut saw_exit = else_effect == TerminalEffect::ExitsCurrentBlock;
+    let mut saw_mixed = else_effect == TerminalEffect::TerminatesMixed;
+
+    for effect in branch_effects {
+        match effect {
+            TerminalEffect::FallsThrough => return TerminalEffect::FallsThrough,
+            TerminalEffect::Breaks => saw_break = true,
+            TerminalEffect::ExitsCurrentBlock => saw_exit = true,
+            TerminalEffect::TerminatesMixed => saw_mixed = true,
+        }
+    }
+
+    if saw_mixed || (saw_break && saw_exit) {
+        TerminalEffect::TerminatesMixed
+    } else if saw_exit {
+        TerminalEffect::ExitsCurrentBlock
+    } else if saw_break {
+        TerminalEffect::Breaks
+    } else {
+        TerminalEffect::FallsThrough
+    }
+}
+
+fn switch_terminal_effect(
+    cases: &[(Vec<Expr>, Vec<Stmt>)],
+    default: &Option<Vec<Stmt>>,
+) -> TerminalEffect {
+    let Some(default_body) = default.as_ref() else {
+        return TerminalEffect::FallsThrough;
+    };
+
+    let mut suffix_exits = block_terminal_effect(default_body) == TerminalEffect::ExitsCurrentBlock;
+    if !suffix_exits {
+        return TerminalEffect::FallsThrough;
+    }
+
+    for (_, body) in cases.iter().rev() {
+        suffix_exits = match block_terminal_effect(body) {
+            TerminalEffect::ExitsCurrentBlock => true,
+            TerminalEffect::FallsThrough => suffix_exits,
+            TerminalEffect::Breaks | TerminalEffect::TerminatesMixed => false,
+        };
+
+        if !suffix_exits {
+            return TerminalEffect::FallsThrough;
+        }
+    }
+
+    TerminalEffect::ExitsCurrentBlock
 }
 
 fn prune_stmt(stmt: Stmt) -> Vec<Stmt> {
@@ -1935,6 +2005,49 @@ mod tests {
         assert_eq!(body.len(), 1);
         let StmtKind::If { .. } = &body[0].kind else {
             panic!("expected if");
+        };
+    }
+
+    #[test]
+    fn test_prune_block_drops_statements_after_exhaustive_switch() {
+        let program = vec![Stmt::new(
+            StmtKind::FunctionDecl {
+                name: "answer".into(),
+                params: Vec::new(),
+                variadic: None,
+                return_type: None,
+                body: vec![
+                    Stmt::new(
+                        StmtKind::Switch {
+                            subject: Expr::var("flag"),
+                            cases: vec![(
+                                vec![Expr::int_lit(1)],
+                                vec![Stmt::new(
+                                    StmtKind::Return(Some(Expr::int_lit(7))),
+                                    Span::dummy(),
+                                )],
+                            )],
+                            default: Some(vec![Stmt::new(
+                                StmtKind::Return(Some(Expr::int_lit(8))),
+                                Span::dummy(),
+                            )]),
+                        },
+                        Span::dummy(),
+                    ),
+                    Stmt::echo(Expr::int_lit(9)),
+                ],
+            },
+            Span::dummy(),
+        )];
+
+        let pruned = prune_constant_control_flow(program);
+
+        let StmtKind::FunctionDecl { body, .. } = &pruned[0].kind else {
+            panic!("expected function");
+        };
+        assert_eq!(body.len(), 1);
+        let StmtKind::Switch { .. } = &body[0].kind else {
+            panic!("expected switch");
         };
     }
 

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -7,6 +7,10 @@ pub fn fold_constants(program: Program) -> Program {
     program.into_iter().map(fold_stmt).collect()
 }
 
+pub fn prune_constant_control_flow(program: Program) -> Program {
+    prune_block(program)
+}
+
 fn fold_stmt(stmt: Stmt) -> Stmt {
     let span = stmt.span;
     let kind = match stmt.kind {
@@ -268,6 +272,284 @@ fn fold_stmt(stmt: Stmt) -> Stmt {
 
 fn fold_block(body: Vec<Stmt>) -> Vec<Stmt> {
     body.into_iter().map(fold_stmt).collect()
+}
+
+fn prune_block(body: Vec<Stmt>) -> Vec<Stmt> {
+    let mut pruned = Vec::new();
+    for stmt in body {
+        pruned.extend(prune_stmt(stmt));
+    }
+    pruned
+}
+
+fn prune_stmt(stmt: Stmt) -> Vec<Stmt> {
+    let span = stmt.span;
+    match stmt.kind {
+        StmtKind::If {
+            condition,
+            then_body,
+            elseif_clauses,
+            else_body,
+        } => prune_if_chain(condition, then_body, elseif_clauses, else_body),
+        StmtKind::IfDef {
+            symbol,
+            then_body,
+            else_body,
+        } => vec![Stmt {
+            kind: StmtKind::IfDef {
+                symbol,
+                then_body: prune_block(then_body),
+                else_body: else_body.map(prune_block),
+            },
+            span,
+        }],
+        StmtKind::While { condition, body } => match scalar_value(&condition) {
+            Some(value) if !value.truthy() => Vec::new(),
+            _ => vec![Stmt {
+                kind: StmtKind::While {
+                    condition,
+                    body: prune_block(body),
+                },
+                span,
+            }],
+        },
+        StmtKind::DoWhile { body, condition } => match scalar_value(&condition) {
+            Some(value) if !value.truthy() => prune_block(body),
+            _ => vec![Stmt {
+                kind: StmtKind::DoWhile {
+                    body: prune_block(body),
+                    condition,
+                },
+                span,
+            }],
+        },
+        StmtKind::For {
+            init,
+            condition,
+            update,
+            body,
+        } => vec![Stmt {
+            kind: StmtKind::For {
+                init,
+                condition,
+                update,
+                body: prune_block(body),
+            },
+            span,
+        }],
+        StmtKind::Foreach {
+            array,
+            key_var,
+            value_var,
+            body,
+        } => vec![Stmt {
+            kind: StmtKind::Foreach {
+                array,
+                key_var,
+                value_var,
+                body: prune_block(body),
+            },
+            span,
+        }],
+        StmtKind::Switch {
+            subject,
+            cases,
+            default,
+        } => vec![Stmt {
+            kind: StmtKind::Switch {
+                subject,
+                cases: cases
+                    .into_iter()
+                    .map(|(exprs, body)| (exprs, prune_block(body)))
+                    .collect(),
+                default: default.map(prune_block),
+            },
+            span,
+        }],
+        StmtKind::Try {
+            try_body,
+            catches,
+            finally_body,
+        } => vec![Stmt {
+            kind: StmtKind::Try {
+                try_body: prune_block(try_body),
+                catches: catches
+                    .into_iter()
+                    .map(|catch| crate::parser::ast::CatchClause {
+                        exception_types: catch.exception_types,
+                        variable: catch.variable,
+                        body: prune_block(catch.body),
+                    })
+                    .collect(),
+                finally_body: finally_body.map(prune_block),
+            },
+            span,
+        }],
+        StmtKind::NamespaceBlock { name, body } => vec![Stmt {
+            kind: StmtKind::NamespaceBlock {
+                name,
+                body: prune_block(body),
+            },
+            span,
+        }],
+        StmtKind::FunctionDecl {
+            name,
+            params,
+            variadic,
+            return_type,
+            body,
+        } => vec![Stmt {
+            kind: StmtKind::FunctionDecl {
+                name,
+                params,
+                variadic,
+                return_type,
+                body: prune_block(body),
+            },
+            span,
+        }],
+        StmtKind::ClassDecl {
+            name,
+            extends,
+            implements,
+            is_abstract,
+            is_readonly_class,
+            trait_uses,
+            properties,
+            methods,
+        } => vec![Stmt {
+            kind: StmtKind::ClassDecl {
+                name,
+                extends,
+                implements,
+                is_abstract,
+                is_readonly_class,
+                trait_uses,
+                properties,
+                methods: methods.into_iter().map(prune_method).collect(),
+            },
+            span,
+        }],
+        StmtKind::EnumDecl {
+            name,
+            backing_type,
+            cases,
+        } => vec![Stmt {
+            kind: StmtKind::EnumDecl {
+                name,
+                backing_type,
+                cases,
+            },
+            span,
+        }],
+        StmtKind::PackedClassDecl { name, fields } => vec![Stmt {
+            kind: StmtKind::PackedClassDecl { name, fields },
+            span,
+        }],
+        StmtKind::InterfaceDecl {
+            name,
+            extends,
+            methods,
+        } => vec![Stmt {
+            kind: StmtKind::InterfaceDecl {
+                name,
+                extends,
+                methods: methods.into_iter().map(prune_method).collect(),
+            },
+            span,
+        }],
+        StmtKind::TraitDecl {
+            name,
+            trait_uses,
+            properties,
+            methods,
+        } => vec![Stmt {
+            kind: StmtKind::TraitDecl {
+                name,
+                trait_uses,
+                properties,
+                methods: methods.into_iter().map(prune_method).collect(),
+            },
+            span,
+        }],
+        kind => vec![Stmt { kind, span }],
+    }
+}
+
+fn prune_if_chain(
+    condition: Expr,
+    then_body: Vec<Stmt>,
+    elseif_clauses: Vec<(Expr, Vec<Stmt>)>,
+    else_body: Option<Vec<Stmt>>,
+) -> Vec<Stmt> {
+    match scalar_value(&condition) {
+        Some(value) if value.truthy() => prune_block(then_body),
+        Some(_) => prune_else_if_chain(elseif_clauses, else_body),
+        None => {
+            let span = condition.span;
+            let (kept_elseifs, kept_else) = prune_remaining_elseif_chain(elseif_clauses, else_body);
+
+            vec![Stmt {
+                kind: StmtKind::If {
+                    condition,
+                    then_body: prune_block(then_body),
+                    elseif_clauses: kept_elseifs,
+                    else_body: kept_else,
+                },
+                span,
+            }]
+        }
+    }
+}
+
+fn prune_else_if_chain(
+    elseif_clauses: Vec<(Expr, Vec<Stmt>)>,
+    else_body: Option<Vec<Stmt>>,
+) -> Vec<Stmt> {
+    let mut clauses = elseif_clauses.into_iter();
+    while let Some((condition, body)) = clauses.next() {
+        match scalar_value(&condition) {
+            Some(value) if value.truthy() => return prune_block(body),
+            Some(_) => continue,
+            None => {
+                let span = condition.span;
+                let remaining: Vec<_> = clauses.collect();
+                let (kept_elseifs, kept_else) = prune_remaining_elseif_chain(remaining, else_body);
+                return vec![Stmt {
+                    kind: StmtKind::If {
+                        condition,
+                        then_body: prune_block(body),
+                        elseif_clauses: kept_elseifs,
+                        else_body: kept_else,
+                    },
+                    span,
+                }];
+            }
+        }
+    }
+    else_body.map(prune_block).unwrap_or_default()
+}
+
+fn prune_remaining_elseif_chain(
+    elseif_clauses: Vec<(Expr, Vec<Stmt>)>,
+    else_body: Option<Vec<Stmt>>,
+) -> (Vec<(Expr, Vec<Stmt>)>, Option<Vec<Stmt>>) {
+    let mut kept = Vec::new();
+    for (condition, body) in elseif_clauses {
+        match scalar_value(&condition) {
+            Some(value) if value.truthy() => return (kept, Some(prune_block(body))),
+            Some(_) => {}
+            None => kept.push((condition, prune_block(body))),
+        }
+    }
+    (kept, else_body.map(prune_block))
+}
+
+fn prune_method(method: ClassMethod) -> ClassMethod {
+    ClassMethod {
+        body: prune_block(method.body),
+        ..method
+    }
 }
 
 fn fold_params(
@@ -1121,5 +1403,55 @@ mod tests {
         let folded = fold_constants(vec![Stmt::echo(expr.clone())]);
 
         assert_eq!(folded, vec![Stmt::echo(expr)]);
+    }
+
+    #[test]
+    fn test_prune_constant_if_chain() {
+        let program = vec![Stmt::new(
+            StmtKind::If {
+                condition: Expr::new(ExprKind::BoolLiteral(false), Span::dummy()),
+                then_body: vec![Stmt::echo(Expr::int_lit(1))],
+                elseif_clauses: vec![
+                    (
+                        Expr::new(ExprKind::BoolLiteral(false), Span::dummy()),
+                        vec![Stmt::echo(Expr::int_lit(2))],
+                    ),
+                    (
+                        Expr::new(ExprKind::BoolLiteral(true), Span::dummy()),
+                        vec![Stmt::echo(Expr::int_lit(3))],
+                    ),
+                ],
+                else_body: Some(vec![Stmt::echo(Expr::int_lit(4))]),
+            },
+            Span::dummy(),
+        )];
+
+        let pruned = prune_constant_control_flow(program);
+
+        assert_eq!(pruned, vec![Stmt::echo(Expr::int_lit(3))]);
+    }
+
+    #[test]
+    fn test_prune_while_false_and_do_while_false() {
+        let program = vec![
+            Stmt::new(
+                StmtKind::While {
+                    condition: Expr::new(ExprKind::BoolLiteral(false), Span::dummy()),
+                    body: vec![Stmt::echo(Expr::int_lit(1))],
+                },
+                Span::dummy(),
+            ),
+            Stmt::new(
+                StmtKind::DoWhile {
+                    body: vec![Stmt::echo(Expr::int_lit(2))],
+                    condition: Expr::new(ExprKind::BoolLiteral(false), Span::dummy()),
+                },
+                Span::dummy(),
+            ),
+        ];
+
+        let pruned = prune_constant_control_flow(program);
+
+        assert_eq!(pruned, vec![Stmt::echo(Expr::int_lit(2))]);
     }
 }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -278,7 +278,7 @@ fn prune_block(body: Vec<Stmt>) -> Vec<Stmt> {
     let mut pruned = Vec::new();
     for stmt in body {
         let pruned_stmt = prune_stmt(stmt);
-        let stops_here = pruned_stmt.last().is_some_and(stmt_transfers_control);
+        let stops_here = pruned_stmt.last().is_some_and(stmt_exits_current_block);
         pruned.extend(pruned_stmt);
         if stops_here {
             break;
@@ -287,11 +287,39 @@ fn prune_block(body: Vec<Stmt>) -> Vec<Stmt> {
     pruned
 }
 
-fn stmt_transfers_control(stmt: &Stmt) -> bool {
-    matches!(
-        stmt.kind,
-        StmtKind::Return(_) | StmtKind::Throw(_) | StmtKind::Break | StmtKind::Continue
-    )
+fn block_exits_current_block(body: &[Stmt]) -> bool {
+    body.last().is_some_and(stmt_exits_current_block)
+}
+
+fn stmt_exits_current_block(stmt: &Stmt) -> bool {
+    match &stmt.kind {
+        StmtKind::Return(_) | StmtKind::Throw(_) | StmtKind::Break | StmtKind::Continue => true,
+        StmtKind::If {
+            then_body,
+            elseif_clauses,
+            else_body,
+            ..
+        } => {
+            block_exits_current_block(then_body)
+                && elseif_clauses
+                    .iter()
+                    .all(|(_, body)| block_exits_current_block(body))
+                && else_body
+                    .as_ref()
+                    .is_some_and(|body| block_exits_current_block(body))
+        }
+        StmtKind::IfDef {
+            then_body,
+            else_body,
+            ..
+        } => {
+            block_exits_current_block(then_body)
+                && else_body
+                    .as_ref()
+                    .is_some_and(|body| block_exits_current_block(body))
+        }
+        _ => false,
+    }
 }
 
 fn prune_stmt(stmt: Stmt) -> Vec<Stmt> {
@@ -1867,6 +1895,47 @@ mod tests {
         };
         assert_eq!(body.len(), 1);
         assert!(matches!(body[0].kind, StmtKind::Return(_)));
+    }
+
+    #[test]
+    fn test_prune_block_drops_statements_after_exhaustive_if() {
+        let program = vec![Stmt::new(
+            StmtKind::FunctionDecl {
+                name: "answer".into(),
+                params: Vec::new(),
+                variadic: None,
+                return_type: None,
+                body: vec![
+                    Stmt::new(
+                        StmtKind::If {
+                            condition: Expr::var("flag"),
+                            then_body: vec![Stmt::new(
+                                StmtKind::Return(Some(Expr::int_lit(7))),
+                                Span::dummy(),
+                            )],
+                            elseif_clauses: Vec::new(),
+                            else_body: Some(vec![Stmt::new(
+                                StmtKind::Return(Some(Expr::int_lit(8))),
+                                Span::dummy(),
+                            )]),
+                        },
+                        Span::dummy(),
+                    ),
+                    Stmt::echo(Expr::int_lit(9)),
+                ],
+            },
+            Span::dummy(),
+        )];
+
+        let pruned = prune_constant_control_flow(program);
+
+        let StmtKind::FunctionDecl { body, .. } = &pruned[0].kind else {
+            panic!("expected function");
+        };
+        assert_eq!(body.len(), 1);
+        let StmtKind::If { .. } = &body[0].kind else {
+            panic!("expected if");
+        };
     }
 
     #[test]

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -559,10 +559,17 @@ fn prune_stmt(stmt: Stmt) -> Vec<Stmt> {
             },
             span,
         }],
-        StmtKind::ExprStmt(expr) => vec![Stmt {
-            kind: StmtKind::ExprStmt(prune_expr(expr)),
-            span,
-        }],
+        StmtKind::ExprStmt(expr) => {
+            let expr = prune_expr(expr);
+            if expr_has_side_effects(&expr) {
+                vec![Stmt {
+                    kind: StmtKind::ExprStmt(expr),
+                    span,
+                }]
+            } else {
+                Vec::new()
+            }
+        }
         StmtKind::EnumDecl {
             name,
             backing_type,
@@ -894,6 +901,79 @@ fn prune_expr(expr: Expr) -> Expr {
         },
     };
     Expr { kind, span }
+}
+
+fn expr_has_side_effects(expr: &Expr) -> bool {
+    match &expr.kind {
+        ExprKind::StringLiteral(_)
+        | ExprKind::IntLiteral(_)
+        | ExprKind::FloatLiteral(_)
+        | ExprKind::Variable(_)
+        | ExprKind::BoolLiteral(_)
+        | ExprKind::Null
+        | ExprKind::ConstRef(_)
+        | ExprKind::EnumCase { .. }
+        | ExprKind::This => false,
+        ExprKind::Negate(inner)
+        | ExprKind::Not(inner)
+        | ExprKind::BitNot(inner)
+        | ExprKind::Spread(inner) => expr_has_side_effects(inner),
+        ExprKind::BinaryOp { left, right, .. } => {
+            expr_has_side_effects(left) || expr_has_side_effects(right)
+        }
+        ExprKind::Throw(_)
+        | ExprKind::PreIncrement(_)
+        | ExprKind::PostIncrement(_)
+        | ExprKind::PreDecrement(_)
+        | ExprKind::PostDecrement(_)
+        | ExprKind::FunctionCall { .. }
+        | ExprKind::ClosureCall { .. }
+        | ExprKind::ExprCall { .. }
+        | ExprKind::NewObject { .. }
+        | ExprKind::MethodCall { .. }
+        | ExprKind::StaticMethodCall { .. }
+        | ExprKind::PropertyAccess { .. }
+        | ExprKind::ArrayAccess { .. }
+        | ExprKind::BufferNew { .. } => true,
+        ExprKind::NullCoalesce { value, default } => {
+            expr_has_side_effects(value) || expr_has_side_effects(default)
+        }
+        ExprKind::ArrayLiteral(items) => items.iter().any(expr_has_side_effects),
+        ExprKind::ArrayLiteralAssoc(items) => items
+            .iter()
+            .any(|(key, value)| expr_has_side_effects(key) || expr_has_side_effects(value)),
+        ExprKind::Match {
+            subject,
+            arms,
+            default,
+        } => {
+            expr_has_side_effects(subject)
+                || arms.iter().any(|(patterns, value)| {
+                    patterns.iter().any(expr_has_side_effects) || expr_has_side_effects(value)
+                })
+                || default.as_ref().is_some_and(|expr| expr_has_side_effects(expr))
+        }
+        ExprKind::Ternary {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            expr_has_side_effects(condition)
+                || expr_has_side_effects(then_expr)
+                || expr_has_side_effects(else_expr)
+        }
+        ExprKind::Cast { expr, .. } | ExprKind::PtrCast { expr, .. } => expr_has_side_effects(expr),
+        ExprKind::Closure { .. } => false,
+        ExprKind::NamedArg { value, .. } => expr_has_side_effects(value),
+        ExprKind::FirstClassCallable(target) => callable_target_has_side_effects(target),
+    }
+}
+
+fn callable_target_has_side_effects(target: &CallableTarget) -> bool {
+    match target {
+        CallableTarget::Function(_) | CallableTarget::StaticMethod { .. } => false,
+        CallableTarget::Method { .. } => true,
+    }
 }
 
 fn prune_callable_target(target: CallableTarget) -> CallableTarget {
@@ -1965,6 +2045,34 @@ mod tests {
         };
         assert_eq!(body.len(), 1);
         assert!(matches!(body[0].kind, StmtKind::Return(_)));
+    }
+
+    #[test]
+    fn test_prune_drops_pure_expr_stmt() {
+        let program = vec![Stmt::new(
+            StmtKind::FunctionDecl {
+                name: "answer".into(),
+                params: Vec::new(),
+                variadic: None,
+                return_type: None,
+                body: vec![
+                    Stmt::new(
+                        StmtKind::ExprStmt(Expr::binop(Expr::int_lit(2), BinOp::Pow, Expr::int_lit(8))),
+                        Span::dummy(),
+                    ),
+                    Stmt::echo(Expr::int_lit(7)),
+                ],
+            },
+            Span::dummy(),
+        )];
+
+        let pruned = prune_constant_control_flow(program);
+
+        let StmtKind::FunctionDecl { body, .. } = &pruned[0].kind else {
+            panic!("expected function");
+        };
+        assert_eq!(body.len(), 1);
+        assert_eq!(body[0], Stmt::echo(Expr::int_lit(7)));
     }
 
     #[test]

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -328,15 +328,20 @@ fn prune_stmt(stmt: Stmt) -> Vec<Stmt> {
             condition,
             update,
             body,
-        } => vec![Stmt {
-            kind: StmtKind::For {
-                init,
-                condition,
-                update,
-                body: prune_block(body),
-            },
-            span,
-        }],
+        } => match condition.as_ref().and_then(scalar_value) {
+            Some(value) if !value.truthy() => init
+                .map(|stmt| prune_stmt(*stmt))
+                .unwrap_or_default(),
+            _ => vec![Stmt {
+                kind: StmtKind::For {
+                    init,
+                    condition,
+                    update,
+                    body: prune_block(body),
+                },
+                span,
+            }],
+        },
         StmtKind::Foreach {
             array,
             key_var,
@@ -1453,5 +1458,22 @@ mod tests {
         let pruned = prune_constant_control_flow(program);
 
         assert_eq!(pruned, vec![Stmt::echo(Expr::int_lit(2))]);
+    }
+
+    #[test]
+    fn test_prune_for_false_keeps_init_only() {
+        let program = vec![Stmt::new(
+            StmtKind::For {
+                init: Some(Box::new(Stmt::assign("i", Expr::int_lit(1)))),
+                condition: Some(Expr::new(ExprKind::BoolLiteral(false), Span::dummy())),
+                update: Some(Box::new(Stmt::assign("i", Expr::int_lit(2)))),
+                body: vec![Stmt::echo(Expr::int_lit(3))],
+            },
+            Span::dummy(),
+        )];
+
+        let pruned = prune_constant_control_flow(program);
+
+        assert_eq!(pruned, vec![Stmt::assign("i", Expr::int_lit(1))]);
     }
 }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -285,6 +285,17 @@ fn prune_block(body: Vec<Stmt>) -> Vec<Stmt> {
 fn prune_stmt(stmt: Stmt) -> Vec<Stmt> {
     let span = stmt.span;
     match stmt.kind {
+        StmtKind::Echo(expr) => vec![Stmt {
+            kind: StmtKind::Echo(prune_expr(expr)),
+            span,
+        }],
+        StmtKind::Assign { name, value } => vec![Stmt {
+            kind: StmtKind::Assign {
+                name,
+                value: prune_expr(value),
+            },
+            span,
+        }],
         StmtKind::If {
             condition,
             then_body,
@@ -303,7 +314,9 @@ fn prune_stmt(stmt: Stmt) -> Vec<Stmt> {
             },
             span,
         }],
-        StmtKind::While { condition, body } => match scalar_value(&condition) {
+        StmtKind::While { condition, body } => {
+            let condition = prune_expr(condition);
+            match scalar_value(&condition) {
             Some(value) if !value.truthy() => Vec::new(),
             _ => vec![Stmt {
                 kind: StmtKind::While {
@@ -312,8 +325,11 @@ fn prune_stmt(stmt: Stmt) -> Vec<Stmt> {
                 },
                 span,
             }],
-        },
-        StmtKind::DoWhile { body, condition } => match scalar_value(&condition) {
+        }
+        }
+        StmtKind::DoWhile { body, condition } => {
+            let condition = prune_expr(condition);
+            match scalar_value(&condition) {
             Some(value) if !value.truthy() => prune_block(body),
             _ => vec![Stmt {
                 kind: StmtKind::DoWhile {
@@ -322,26 +338,30 @@ fn prune_stmt(stmt: Stmt) -> Vec<Stmt> {
                 },
                 span,
             }],
-        },
+        }
+        }
         StmtKind::For {
             init,
             condition,
             update,
             body,
-        } => match condition.as_ref().and_then(scalar_value) {
-            Some(value) if !value.truthy() => init
-                .map(|stmt| prune_stmt(*stmt))
-                .unwrap_or_default(),
-            _ => vec![Stmt {
-                kind: StmtKind::For {
-                    init,
-                    condition,
-                    update,
-                    body: prune_block(body),
-                },
-                span,
-            }],
-        },
+        } => {
+            let init = prune_for_clause(init);
+            let condition = condition.map(prune_expr);
+            let update = prune_for_clause(update);
+            match condition.as_ref().and_then(scalar_value) {
+                Some(value) if !value.truthy() => init.map(|stmt| vec![*stmt]).unwrap_or_default(),
+                _ => vec![Stmt {
+                    kind: StmtKind::For {
+                        init,
+                        condition,
+                        update,
+                        body: prune_block(body),
+                    },
+                    span,
+                }],
+            }
+        }
         StmtKind::Foreach {
             array,
             key_var,
@@ -349,7 +369,7 @@ fn prune_stmt(stmt: Stmt) -> Vec<Stmt> {
             body,
         } => vec![Stmt {
             kind: StmtKind::Foreach {
-                array,
+                array: prune_expr(array),
                 key_var,
                 value_var,
                 body: prune_block(body),
@@ -360,17 +380,7 @@ fn prune_stmt(stmt: Stmt) -> Vec<Stmt> {
             subject,
             cases,
             default,
-        } => vec![Stmt {
-            kind: StmtKind::Switch {
-                subject,
-                cases: cases
-                    .into_iter()
-                    .map(|(exprs, body)| (exprs, prune_block(body)))
-                    .collect(),
-                default: default.map(prune_block),
-            },
-            span,
-        }],
+        } => prune_switch_stmt(subject, cases, default, span),
         StmtKind::Try {
             try_body,
             catches,
@@ -413,6 +423,10 @@ fn prune_stmt(stmt: Stmt) -> Vec<Stmt> {
             },
             span,
         }],
+        StmtKind::Return(expr) => vec![Stmt {
+            kind: StmtKind::Return(expr.map(prune_expr)),
+            span,
+        }],
         StmtKind::ClassDecl {
             name,
             extends,
@@ -433,6 +447,10 @@ fn prune_stmt(stmt: Stmt) -> Vec<Stmt> {
                 properties,
                 methods: methods.into_iter().map(prune_method).collect(),
             },
+            span,
+        }],
+        StmtKind::ExprStmt(expr) => vec![Stmt {
+            kind: StmtKind::ExprStmt(prune_expr(expr)),
             span,
         }],
         StmtKind::EnumDecl {
@@ -487,6 +505,7 @@ fn prune_if_chain(
     elseif_clauses: Vec<(Expr, Vec<Stmt>)>,
     else_body: Option<Vec<Stmt>>,
 ) -> Vec<Stmt> {
+    let condition = prune_expr(condition);
     match scalar_value(&condition) {
         Some(value) if value.truthy() => prune_block(then_body),
         Some(_) => prune_else_if_chain(elseif_clauses, else_body),
@@ -513,6 +532,7 @@ fn prune_else_if_chain(
 ) -> Vec<Stmt> {
     let mut clauses = elseif_clauses.into_iter();
     while let Some((condition, body)) = clauses.next() {
+        let condition = prune_expr(condition);
         match scalar_value(&condition) {
             Some(value) if value.truthy() => return prune_block(body),
             Some(_) => continue,
@@ -541,6 +561,7 @@ fn prune_remaining_elseif_chain(
 ) -> (Vec<(Expr, Vec<Stmt>)>, Option<Vec<Stmt>>) {
     let mut kept = Vec::new();
     for (condition, body) in elseif_clauses {
+        let condition = prune_expr(condition);
         match scalar_value(&condition) {
             Some(value) if value.truthy() => return (kept, Some(prune_block(body))),
             Some(_) => {}
@@ -554,6 +575,340 @@ fn prune_method(method: ClassMethod) -> ClassMethod {
     ClassMethod {
         body: prune_block(method.body),
         ..method
+    }
+}
+
+fn prune_for_clause(stmt: Option<Box<Stmt>>) -> Option<Box<Stmt>> {
+    let stmt = stmt?;
+    prune_stmt(*stmt).into_iter().next().map(Box::new)
+}
+
+fn prune_switch_stmt(
+    subject: Expr,
+    cases: Vec<(Vec<Expr>, Vec<Stmt>)>,
+    default: Option<Vec<Stmt>>,
+    span: crate::span::Span,
+) -> Vec<Stmt> {
+    let subject = prune_expr(subject);
+    let cases: Vec<(Vec<Expr>, Vec<Stmt>)> = cases
+        .into_iter()
+        .map(|(patterns, body)| (patterns.into_iter().map(prune_expr).collect(), prune_block(body)))
+        .collect();
+    let default = default.map(prune_block);
+
+    let Some(subject_value) = scalar_value(&subject) else {
+        return vec![Stmt {
+            kind: StmtKind::Switch {
+                subject,
+                cases,
+                default,
+            },
+            span,
+        }];
+    };
+
+    for (index, (patterns, _)) in cases.iter().enumerate() {
+        match classify_case_patterns(&subject_value, patterns, CaseComparison::LooseSwitch) {
+            CaseMatch::Matches | CaseMatch::Unknown => {
+                return vec![Stmt {
+                    kind: StmtKind::Switch {
+                        subject,
+                        cases: cases[index..].to_vec(),
+                        default,
+                    },
+                    span,
+                }];
+            }
+            CaseMatch::NoMatch => {}
+        }
+    }
+
+    if default.is_some() {
+        vec![Stmt {
+            kind: StmtKind::Switch {
+                subject,
+                cases: Vec::new(),
+                default,
+            },
+            span,
+        }]
+    } else {
+        Vec::new()
+    }
+}
+
+fn prune_expr(expr: Expr) -> Expr {
+    let span = expr.span;
+    let kind = match expr.kind {
+        ExprKind::StringLiteral(value) => ExprKind::StringLiteral(value),
+        ExprKind::IntLiteral(value) => ExprKind::IntLiteral(value),
+        ExprKind::FloatLiteral(value) => ExprKind::FloatLiteral(value),
+        ExprKind::Variable(name) => ExprKind::Variable(name),
+        ExprKind::BinaryOp { left, op, right } => ExprKind::BinaryOp {
+            left: Box::new(prune_expr(*left)),
+            op,
+            right: Box::new(prune_expr(*right)),
+        },
+        ExprKind::BoolLiteral(value) => ExprKind::BoolLiteral(value),
+        ExprKind::Null => ExprKind::Null,
+        ExprKind::Negate(inner) => ExprKind::Negate(Box::new(prune_expr(*inner))),
+        ExprKind::Not(inner) => ExprKind::Not(Box::new(prune_expr(*inner))),
+        ExprKind::BitNot(inner) => ExprKind::BitNot(Box::new(prune_expr(*inner))),
+        ExprKind::Throw(inner) => ExprKind::Throw(Box::new(prune_expr(*inner))),
+        ExprKind::NullCoalesce { value, default } => ExprKind::NullCoalesce {
+            value: Box::new(prune_expr(*value)),
+            default: Box::new(prune_expr(*default)),
+        },
+        ExprKind::PreIncrement(name) => ExprKind::PreIncrement(name),
+        ExprKind::PostIncrement(name) => ExprKind::PostIncrement(name),
+        ExprKind::PreDecrement(name) => ExprKind::PreDecrement(name),
+        ExprKind::PostDecrement(name) => ExprKind::PostDecrement(name),
+        ExprKind::FunctionCall { name, args } => ExprKind::FunctionCall {
+            name,
+            args: args.into_iter().map(prune_expr).collect(),
+        },
+        ExprKind::ArrayLiteral(items) => {
+            ExprKind::ArrayLiteral(items.into_iter().map(prune_expr).collect())
+        }
+        ExprKind::ArrayLiteralAssoc(items) => ExprKind::ArrayLiteralAssoc(
+            items.into_iter()
+                .map(|(key, value)| (prune_expr(key), prune_expr(value)))
+                .collect(),
+        ),
+        ExprKind::Match {
+            subject,
+            arms,
+            default,
+        } => {
+            let subject = prune_expr(*subject);
+            let arms: Vec<(Vec<Expr>, Expr)> = arms
+                .into_iter()
+                .map(|(patterns, value)| {
+                    (
+                        patterns.into_iter().map(prune_expr).collect(),
+                        prune_expr(value),
+                    )
+                })
+                .collect();
+            let default = default.map(|expr| Box::new(prune_expr(*expr)));
+            try_prune_match_expr(subject, arms, default)
+        }
+        ExprKind::ArrayAccess { array, index } => ExprKind::ArrayAccess {
+            array: Box::new(prune_expr(*array)),
+            index: Box::new(prune_expr(*index)),
+        },
+        ExprKind::Ternary {
+            condition,
+            then_expr,
+            else_expr,
+        } => ExprKind::Ternary {
+            condition: Box::new(prune_expr(*condition)),
+            then_expr: Box::new(prune_expr(*then_expr)),
+            else_expr: Box::new(prune_expr(*else_expr)),
+        },
+        ExprKind::Cast { target, expr } => ExprKind::Cast {
+            target,
+            expr: Box::new(prune_expr(*expr)),
+        },
+        ExprKind::Closure {
+            params,
+            variadic,
+            body,
+            is_arrow,
+            captures,
+        } => ExprKind::Closure {
+            params,
+            variadic,
+            body: prune_block(body),
+            is_arrow,
+            captures,
+        },
+        ExprKind::NamedArg { name, value } => ExprKind::NamedArg {
+            name,
+            value: Box::new(prune_expr(*value)),
+        },
+        ExprKind::Spread(inner) => ExprKind::Spread(Box::new(prune_expr(*inner))),
+        ExprKind::ClosureCall { var, args } => ExprKind::ClosureCall {
+            var,
+            args: args.into_iter().map(prune_expr).collect(),
+        },
+        ExprKind::ExprCall { callee, args } => ExprKind::ExprCall {
+            callee: Box::new(prune_expr(*callee)),
+            args: args.into_iter().map(prune_expr).collect(),
+        },
+        ExprKind::ConstRef(name) => ExprKind::ConstRef(name),
+        ExprKind::EnumCase {
+            enum_name,
+            case_name,
+        } => ExprKind::EnumCase {
+            enum_name,
+            case_name,
+        },
+        ExprKind::NewObject { class_name, args } => ExprKind::NewObject {
+            class_name,
+            args: args.into_iter().map(prune_expr).collect(),
+        },
+        ExprKind::PropertyAccess { object, property } => ExprKind::PropertyAccess {
+            object: Box::new(prune_expr(*object)),
+            property,
+        },
+        ExprKind::MethodCall {
+            object,
+            method,
+            args,
+        } => ExprKind::MethodCall {
+            object: Box::new(prune_expr(*object)),
+            method,
+            args: args.into_iter().map(prune_expr).collect(),
+        },
+        ExprKind::StaticMethodCall {
+            receiver,
+            method,
+            args,
+        } => ExprKind::StaticMethodCall {
+            receiver,
+            method,
+            args: args.into_iter().map(prune_expr).collect(),
+        },
+        ExprKind::FirstClassCallable(target) => {
+            ExprKind::FirstClassCallable(prune_callable_target(target))
+        }
+        ExprKind::This => ExprKind::This,
+        ExprKind::PtrCast { target_type, expr } => ExprKind::PtrCast {
+            target_type,
+            expr: Box::new(prune_expr(*expr)),
+        },
+        ExprKind::BufferNew { element_type, len } => ExprKind::BufferNew {
+            element_type,
+            len: Box::new(prune_expr(*len)),
+        },
+    };
+    Expr { kind, span }
+}
+
+fn prune_callable_target(target: CallableTarget) -> CallableTarget {
+    match target {
+        CallableTarget::Function(name) => CallableTarget::Function(name),
+        CallableTarget::StaticMethod { receiver, method } => {
+            CallableTarget::StaticMethod { receiver, method }
+        }
+        CallableTarget::Method { object, method } => CallableTarget::Method {
+            object: Box::new(prune_expr(*object)),
+            method,
+        },
+    }
+}
+
+fn try_prune_match_expr(
+    subject: Expr,
+    arms: Vec<(Vec<Expr>, Expr)>,
+    default: Option<Box<Expr>>,
+) -> ExprKind {
+    let Some(subject_value) = scalar_value(&subject) else {
+        return ExprKind::Match {
+            subject: Box::new(subject),
+            arms,
+            default,
+        };
+    };
+
+    for (index, (patterns, result)) in arms.iter().enumerate() {
+        match classify_case_patterns(&subject_value, patterns, CaseComparison::Strict) {
+            CaseMatch::Matches => return result.kind.clone(),
+            CaseMatch::NoMatch => {}
+            CaseMatch::Unknown => {
+                return ExprKind::Match {
+                    subject: Box::new(subject),
+                    arms: arms[index..].to_vec(),
+                    default,
+                };
+            }
+        }
+    }
+
+    if let Some(default) = default {
+        default.kind
+    } else {
+        ExprKind::Match {
+            subject: Box::new(subject),
+            arms: Vec::new(),
+            default: None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CaseMatch {
+    Matches,
+    NoMatch,
+    Unknown,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CaseComparison {
+    Strict,
+    LooseSwitch,
+}
+
+fn classify_case_patterns(
+    subject: &ScalarValue,
+    patterns: &[Expr],
+    comparison: CaseComparison,
+) -> CaseMatch {
+    let mut has_unknown = false;
+    for pattern in patterns {
+        match pattern_matches_scalar(subject, pattern, comparison) {
+            Some(true) => return CaseMatch::Matches,
+            Some(false) => {}
+            None => has_unknown = true,
+        }
+    }
+    if has_unknown {
+        CaseMatch::Unknown
+    } else {
+        CaseMatch::NoMatch
+    }
+}
+
+fn pattern_matches_scalar(
+    subject: &ScalarValue,
+    pattern: &Expr,
+    comparison: CaseComparison,
+) -> Option<bool> {
+    let pattern = scalar_value(pattern)?;
+    match comparison {
+        CaseComparison::Strict => compare_scalar_strict(subject, &pattern),
+        CaseComparison::LooseSwitch => compare_scalar_switch(subject, &pattern),
+    }
+}
+
+fn compare_scalar_strict(left: &ScalarValue, right: &ScalarValue) -> Option<bool> {
+    match (left, right) {
+        (ScalarValue::Null, ScalarValue::Null) => Some(true),
+        (ScalarValue::Bool(left), ScalarValue::Bool(right)) => Some(left == right),
+        (ScalarValue::Int(left), ScalarValue::Int(right)) => Some(left == right),
+        (ScalarValue::String(left), ScalarValue::String(right)) => Some(left == right),
+        (ScalarValue::Float(left), ScalarValue::Float(right)) => Some(left == right),
+        _ => Some(false),
+    }
+}
+
+fn compare_scalar_switch(left: &ScalarValue, right: &ScalarValue) -> Option<bool> {
+    match (left, right) {
+        (ScalarValue::String(left), ScalarValue::String(right)) => Some(left == right),
+        (ScalarValue::Float(left), ScalarValue::Float(right)) => Some(left == right),
+        (ScalarValue::String(_), _) | (_, ScalarValue::String(_)) => None,
+        (ScalarValue::Float(_), _) | (_, ScalarValue::Float(_)) => None,
+        _ => Some(scalar_dispatch_int(left)? == scalar_dispatch_int(right)?),
+    }
+}
+
+fn scalar_dispatch_int(value: &ScalarValue) -> Option<i64> {
+    match value {
+        ScalarValue::Null => Some(0),
+        ScalarValue::Bool(value) => Some(i64::from(*value)),
+        ScalarValue::Int(value) => Some(*value),
+        ScalarValue::Float(_) | ScalarValue::String(_) => None,
     }
 }
 
@@ -1475,5 +1830,73 @@ mod tests {
         let pruned = prune_constant_control_flow(program);
 
         assert_eq!(pruned, vec![Stmt::assign("i", Expr::int_lit(1))]);
+    }
+
+    #[test]
+    fn test_prune_match_expr_to_selected_arm() {
+        let program = vec![Stmt::assign(
+            "x",
+            Expr::new(
+                ExprKind::Match {
+                    subject: Box::new(Expr::int_lit(3)),
+                    arms: vec![
+                        (vec![Expr::int_lit(1)], Expr::int_lit(10)),
+                        (vec![Expr::int_lit(3)], Expr::int_lit(20)),
+                    ],
+                    default: Some(Box::new(Expr::int_lit(30))),
+                },
+                Span::dummy(),
+            ),
+        )];
+
+        let pruned = prune_constant_control_flow(program);
+
+        assert_eq!(pruned, vec![Stmt::assign("x", Expr::int_lit(20))]);
+    }
+
+    #[test]
+    fn test_prune_match_uses_strict_case_comparison() {
+        let program = vec![Stmt::assign(
+            "x",
+            Expr::new(
+                ExprKind::Match {
+                    subject: Box::new(Expr::new(ExprKind::BoolLiteral(true), Span::dummy())),
+                    arms: vec![(vec![Expr::int_lit(1)], Expr::int_lit(10))],
+                    default: Some(Box::new(Expr::int_lit(20))),
+                },
+                Span::dummy(),
+            ),
+        )];
+
+        let pruned = prune_constant_control_flow(program);
+
+        assert_eq!(pruned, vec![Stmt::assign("x", Expr::int_lit(20))]);
+    }
+
+    #[test]
+    fn test_prune_switch_drops_leading_non_matching_cases() {
+        let program = vec![Stmt::new(
+            StmtKind::Switch {
+                subject: Expr::int_lit(3),
+                cases: vec![
+                    (vec![Expr::int_lit(1)], vec![Stmt::echo(Expr::int_lit(10))]),
+                    (
+                        vec![Expr::int_lit(3)],
+                        vec![Stmt::echo(Expr::int_lit(20)), Stmt::new(StmtKind::Break, Span::dummy())],
+                    ),
+                ],
+                default: Some(vec![Stmt::echo(Expr::int_lit(30))]),
+            },
+            Span::dummy(),
+        )];
+
+        let pruned = prune_constant_control_flow(program);
+
+        assert_eq!(pruned.len(), 1);
+        let StmtKind::Switch { cases, .. } = &pruned[0].kind else {
+            panic!("expected switch");
+        };
+        assert_eq!(cases.len(), 1);
+        assert_eq!(cases[0].0, vec![Expr::int_lit(3)]);
     }
 }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -277,9 +277,21 @@ fn fold_block(body: Vec<Stmt>) -> Vec<Stmt> {
 fn prune_block(body: Vec<Stmt>) -> Vec<Stmt> {
     let mut pruned = Vec::new();
     for stmt in body {
-        pruned.extend(prune_stmt(stmt));
+        let pruned_stmt = prune_stmt(stmt);
+        let stops_here = pruned_stmt.last().is_some_and(stmt_transfers_control);
+        pruned.extend(pruned_stmt);
+        if stops_here {
+            break;
+        }
     }
     pruned
+}
+
+fn stmt_transfers_control(stmt: &Stmt) -> bool {
+    matches!(
+        stmt.kind,
+        StmtKind::Return(_) | StmtKind::Throw(_) | StmtKind::Break | StmtKind::Continue
+    )
 }
 
 fn prune_stmt(stmt: Stmt) -> Vec<Stmt> {
@@ -1830,6 +1842,58 @@ mod tests {
         let pruned = prune_constant_control_flow(program);
 
         assert_eq!(pruned, vec![Stmt::assign("i", Expr::int_lit(1))]);
+    }
+
+    #[test]
+    fn test_prune_block_drops_statements_after_return() {
+        let program = vec![Stmt::new(
+            StmtKind::FunctionDecl {
+                name: "answer".into(),
+                params: Vec::new(),
+                variadic: None,
+                return_type: None,
+                body: vec![
+                    Stmt::new(StmtKind::Return(Some(Expr::int_lit(7))), Span::dummy()),
+                    Stmt::echo(Expr::int_lit(9)),
+                ],
+            },
+            Span::dummy(),
+        )];
+
+        let pruned = prune_constant_control_flow(program);
+
+        let StmtKind::FunctionDecl { body, .. } = &pruned[0].kind else {
+            panic!("expected function");
+        };
+        assert_eq!(body.len(), 1);
+        assert!(matches!(body[0].kind, StmtKind::Return(_)));
+    }
+
+    #[test]
+    fn test_prune_switch_case_body_drops_statements_after_break() {
+        let program = vec![Stmt::new(
+            StmtKind::Switch {
+                subject: Expr::int_lit(1),
+                cases: vec![(
+                    vec![Expr::int_lit(1)],
+                    vec![
+                        Stmt::new(StmtKind::Break, Span::dummy()),
+                        Stmt::echo(Expr::int_lit(9)),
+                    ],
+                )],
+                default: None,
+            },
+            Span::dummy(),
+        )];
+
+        let pruned = prune_constant_control_flow(program);
+
+        let StmtKind::Switch { cases, .. } = &pruned[0].kind else {
+            panic!("expected switch");
+        };
+        assert_eq!(cases.len(), 1);
+        assert_eq!(cases[0].1.len(), 1);
+        assert!(matches!(cases[0].1[0].kind, StmtKind::Break));
     }
 
     #[test]

--- a/tests/codegen/mod.rs
+++ b/tests/codegen/mod.rs
@@ -26,3 +26,4 @@ mod pointers;
 mod ffi;
 mod oop;
 mod types;
+mod optimizer;

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -444,3 +444,43 @@ switch (1) {
 
     let _ = fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn test_constant_folding_prunes_dead_statements_after_exhaustive_if_from_user_assembly() {
+    let dir = make_cli_test_dir("elephc_constant_folding_exhaustive_if_dce");
+    let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(
+        r#"<?php
+function answer($flag) {
+    if ($flag) {
+        return 7;
+    } else {
+        return 8;
+    }
+    echo 2 ** 8;
+}
+echo answer(true);
+"#,
+        &dir,
+        8_388_608,
+        false,
+        false,
+    );
+
+    assert!(
+        !user_asm.contains("pow"),
+        "dead statements after exhaustive if should not remain in user assembly:\n{}",
+        user_asm
+    );
+
+    let out = assemble_and_run(
+        &user_asm,
+        get_runtime_obj(),
+        &dir,
+        &required_libraries,
+        &default_link_paths(),
+        &[],
+    );
+    assert_eq!(out, "7");
+
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -552,3 +552,38 @@ echo answer(1);
 
     let _ = fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn test_constant_folding_prunes_unused_pure_ternary_branch_from_user_assembly() {
+    let dir = make_cli_test_dir("elephc_constant_folding_ternary_dead_branch");
+    let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(
+        r#"<?php
+function answer() {
+    return 7;
+}
+echo true ? answer() : (2 ** 8);
+"#,
+        &dir,
+        8_388_608,
+        false,
+        false,
+    );
+
+    assert!(
+        !user_asm.contains("pow"),
+        "unused pure ternary branch should not remain in user assembly:\n{}",
+        user_asm
+    );
+
+    let out = assemble_and_run(
+        &user_asm,
+        get_runtime_obj(),
+        &dir,
+        &required_libraries,
+        &default_link_paths(),
+        &[],
+    );
+    assert_eq!(out, "7");
+
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -369,3 +369,78 @@ switch (3) {
 
     let _ = fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn test_constant_folding_prunes_dead_statements_after_return_from_user_assembly() {
+    let dir = make_cli_test_dir("elephc_constant_folding_return_dce");
+    let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(
+        r#"<?php
+function answer() {
+    return 7;
+    echo 2 ** 8;
+}
+echo answer();
+"#,
+        &dir,
+        8_388_608,
+        false,
+        false,
+    );
+
+    assert!(
+        !user_asm.contains("pow"),
+        "dead statements after return should not remain in user assembly:\n{}",
+        user_asm
+    );
+
+    let out = assemble_and_run(
+        &user_asm,
+        get_runtime_obj(),
+        &dir,
+        &required_libraries,
+        &default_link_paths(),
+        &[],
+    );
+    assert_eq!(out, "7");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_constant_folding_prunes_dead_statements_after_break_from_user_assembly() {
+    let dir = make_cli_test_dir("elephc_constant_folding_break_dce");
+    let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(
+        r#"<?php
+switch (1) {
+    case 1:
+        echo 7;
+        break;
+        echo 2 ** 8;
+    default:
+        echo 9;
+}
+"#,
+        &dir,
+        8_388_608,
+        false,
+        false,
+    );
+
+    assert!(
+        !user_asm.contains("pow"),
+        "dead statements after break should not remain in user assembly:\n{}",
+        user_asm
+    );
+
+    let out = assemble_and_run(
+        &user_asm,
+        get_runtime_obj(),
+        &dir,
+        &required_libraries,
+        &default_link_paths(),
+        &[],
+    );
+    assert_eq!(out, "7");
+
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -60,3 +60,74 @@ fn test_constant_folding_string_concat_removes_runtime_concat_call() {
 
     let _ = fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn test_constant_folding_null_coalesce_removes_runtime_concat_call() {
+    let dir = make_cli_test_dir("elephc_constant_folding_null_coalesce");
+    let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(
+        r#"<?php echo null ?? ("hello " . "world");"#,
+        &dir,
+        8_388_608,
+        false,
+        false,
+    );
+
+    assert!(
+        !user_asm.contains("__rt_concat"),
+        "constant-folded null coalesce should not leave __rt_concat in user assembly:\n{}",
+        user_asm
+    );
+
+    let out = assemble_and_run(
+        &user_asm,
+        get_runtime_obj(),
+        &dir,
+        &required_libraries,
+        &default_link_paths(),
+        &[],
+    );
+    assert_eq!(out, "hello world");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_constant_folding_ternary_removes_pow_call_from_user_assembly() {
+    let dir = make_cli_test_dir("elephc_constant_folding_ternary");
+    let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(
+        r#"<?php echo (2 < 3) ? (2 ** 3) : (3 ** 4);"#,
+        &dir,
+        8_388_608,
+        false,
+        false,
+    );
+
+    assert!(
+        !user_asm.contains("pow"),
+        "constant-folded ternary should not leave a pow call in user assembly:\n{}",
+        user_asm
+    );
+
+    let out = assemble_and_run(
+        &user_asm,
+        get_runtime_obj(),
+        &dir,
+        &required_libraries,
+        &default_link_paths(),
+        &[],
+    );
+    assert_eq!(out, "8");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_constant_folding_truthiness_and_spaceship_runtime() {
+    let out = compile_and_run(
+        r#"<?php
+echo !("0");
+echo (2 <=> 3) + 2;
+"#,
+    );
+    assert_eq!(out, "11");
+}

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -1,0 +1,62 @@
+use crate::support::*;
+
+#[test]
+fn test_constant_folding_nested_integer_arithmetic_runtime() {
+    let out = compile_and_run("<?php echo (2 + 3) * 4;");
+    assert_eq!(out, "20");
+}
+
+#[test]
+fn test_constant_folding_pow_removes_pow_call_from_user_assembly() {
+    let dir = make_cli_test_dir("elephc_constant_folding_pow");
+    let (user_asm, _runtime_asm, required_libraries) =
+        compile_source_to_asm_with_options("<?php echo 2 ** 3;", &dir, 8_388_608, false, false);
+
+    assert!(
+        !user_asm.contains("pow"),
+        "constant-folded pow expression should not leave a pow call in user assembly:\n{}",
+        user_asm
+    );
+
+    let out = assemble_and_run(
+        &user_asm,
+        get_runtime_obj(),
+        &dir,
+        &required_libraries,
+        &default_link_paths(),
+        &[],
+    );
+    assert_eq!(out, "8");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_constant_folding_string_concat_removes_runtime_concat_call() {
+    let dir = make_cli_test_dir("elephc_constant_folding_concat");
+    let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(
+        r#"<?php echo "hello " . "world";"#,
+        &dir,
+        8_388_608,
+        false,
+        false,
+    );
+
+    assert!(
+        !user_asm.contains("__rt_concat"),
+        "constant-folded concat expression should not call __rt_concat in user assembly:\n{}",
+        user_asm
+    );
+
+    let out = assemble_and_run(
+        &user_asm,
+        get_runtime_obj(),
+        &dir,
+        &required_libraries,
+        &default_link_paths(),
+        &[],
+    );
+    assert_eq!(out, "hello world");
+
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -254,3 +254,39 @@ echo 3;
 
     let _ = fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn test_constant_folding_prunes_for_false_body_and_update_from_user_assembly() {
+    let dir = make_cli_test_dir("elephc_constant_folding_for_prune");
+    let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(
+        r#"<?php
+$n = 8;
+for ($i = 1; false; $i = 2 ** $n) {
+    echo 2 ** $n;
+}
+echo $i;
+"#,
+        &dir,
+        8_388_608,
+        false,
+        false,
+    );
+
+    assert!(
+        !user_asm.contains("pow"),
+        "for(false) body and update should be pruned from user assembly:\n{}",
+        user_asm
+    );
+
+    let out = assemble_and_run(
+        &user_asm,
+        get_runtime_obj(),
+        &dir,
+        &required_libraries,
+        &default_link_paths(),
+        &[],
+    );
+    assert_eq!(out, "1");
+
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -407,6 +407,33 @@ echo answer();
 }
 
 #[test]
+fn test_constant_folding_prunes_pure_expr_statements_from_user_assembly() {
+    let dir = make_cli_test_dir("elephc_constant_folding_pure_expr_stmt_dce");
+    let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(
+        r#"<?php
+strlen(...);
+echo 7;
+"#,
+        &dir,
+        8_388_608,
+        false,
+        false,
+    );
+
+    let out = assemble_and_run(
+        &user_asm,
+        get_runtime_obj(),
+        &dir,
+        &required_libraries,
+        &default_link_paths(),
+        &[],
+    );
+    assert_eq!(out, "7");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn test_constant_folding_prunes_dead_statements_after_break_from_user_assembly() {
     let dir = make_cli_test_dir("elephc_constant_folding_break_dce");
     let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -290,3 +290,82 @@ echo $i;
 
     let _ = fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn test_constant_folding_prunes_match_to_selected_arm_in_user_assembly() {
+    let dir = make_cli_test_dir("elephc_constant_folding_match_prune");
+    let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(
+        r#"<?php
+$n = 8;
+echo match (3) {
+    1 => 2 ** $n,
+    3 => 7,
+    default => 9,
+};
+"#,
+        &dir,
+        8_388_608,
+        false,
+        false,
+    );
+
+    assert!(
+        !user_asm.contains("pow"),
+        "constant match should not leave dead arms in user assembly:\n{}",
+        user_asm
+    );
+
+    let out = assemble_and_run(
+        &user_asm,
+        get_runtime_obj(),
+        &dir,
+        &required_libraries,
+        &default_link_paths(),
+        &[],
+    );
+    assert_eq!(out, "7");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_constant_folding_prunes_switch_leading_cases_from_user_assembly() {
+    let dir = make_cli_test_dir("elephc_constant_folding_switch_prune");
+    let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(
+        r#"<?php
+$n = 8;
+switch (3) {
+    case 1:
+        echo 2 ** $n;
+        break;
+    case 3:
+        echo 7;
+        break;
+    default:
+        echo 9;
+}
+"#,
+        &dir,
+        8_388_608,
+        false,
+        false,
+    );
+
+    assert!(
+        !user_asm.contains("pow"),
+        "constant switch should not leave dead leading cases in user assembly:\n{}",
+        user_asm
+    );
+
+    let out = assemble_and_run(
+        &user_asm,
+        get_runtime_obj(),
+        &dir,
+        &required_libraries,
+        &default_link_paths(),
+        &[],
+    );
+    assert_eq!(out, "7");
+
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -131,3 +131,53 @@ echo (2 <=> 3) + 2;
     );
     assert_eq!(out, "11");
 }
+
+#[test]
+fn test_constant_folding_int_cast_removes_runtime_atoi_call() {
+    let dir = make_cli_test_dir("elephc_constant_folding_cast_int");
+    let (user_asm, _runtime_asm, required_libraries) =
+        compile_source_to_asm_with_options("<?php echo (int)\"42\";", &dir, 8_388_608, false, false);
+
+    assert!(
+        !user_asm.contains("__rt_atoi"),
+        "constant-folded int cast should not leave __rt_atoi in user assembly:\n{}",
+        user_asm
+    );
+
+    let out = assemble_and_run(
+        &user_asm,
+        get_runtime_obj(),
+        &dir,
+        &required_libraries,
+        &default_link_paths(),
+        &[],
+    );
+    assert_eq!(out, "42");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_constant_folding_string_cast_removes_runtime_itoa_call() {
+    let dir = make_cli_test_dir("elephc_constant_folding_cast_string");
+    let (user_asm, _runtime_asm, required_libraries) =
+        compile_source_to_asm_with_options("<?php echo (string)42;", &dir, 8_388_608, false, false);
+
+    assert!(
+        !user_asm.contains("__rt_itoa"),
+        "constant-folded string cast should not leave __rt_itoa in user assembly:\n{}",
+        user_asm
+    );
+
+    let out = assemble_and_run(
+        &user_asm,
+        get_runtime_obj(),
+        &dir,
+        &required_libraries,
+        &default_link_paths(),
+        &[],
+    );
+    assert_eq!(out, "42");
+
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -181,3 +181,76 @@ fn test_constant_folding_string_cast_removes_runtime_itoa_call() {
 
     let _ = fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn test_constant_folding_prunes_constant_if_branch_from_user_assembly() {
+    let dir = make_cli_test_dir("elephc_constant_folding_if_prune");
+    let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(
+        r#"<?php
+$n = 8;
+if (false) {
+    echo 2 ** $n;
+} else {
+    echo 3;
+}
+"#,
+        &dir,
+        8_388_608,
+        false,
+        false,
+    );
+
+    assert!(
+        !user_asm.contains("pow"),
+        "constant false if-branch should be pruned from user assembly:\n{}",
+        user_asm
+    );
+
+    let out = assemble_and_run(
+        &user_asm,
+        get_runtime_obj(),
+        &dir,
+        &required_libraries,
+        &default_link_paths(),
+        &[],
+    );
+    assert_eq!(out, "3");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_constant_folding_prunes_while_false_body_from_user_assembly() {
+    let dir = make_cli_test_dir("elephc_constant_folding_while_prune");
+    let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(
+        r#"<?php
+$n = 8;
+while (false) {
+    echo 2 ** $n;
+}
+echo 3;
+"#,
+        &dir,
+        8_388_608,
+        false,
+        false,
+    );
+
+    assert!(
+        !user_asm.contains("pow"),
+        "while(false) body should be pruned from user assembly:\n{}",
+        user_asm
+    );
+
+    let out = assemble_and_run(
+        &user_asm,
+        get_runtime_obj(),
+        &dir,
+        &required_libraries,
+        &default_link_paths(),
+        &[],
+    );
+    assert_eq!(out, "3");
+
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -484,3 +484,44 @@ echo answer(true);
 
     let _ = fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn test_constant_folding_prunes_dead_statements_after_exhaustive_switch_from_user_assembly() {
+    let dir = make_cli_test_dir("elephc_constant_folding_exhaustive_switch_dce");
+    let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(
+        r#"<?php
+function answer($flag) {
+    switch ($flag) {
+        case 1:
+            return 7;
+        default:
+            return 8;
+    }
+    echo 2 ** 8;
+}
+echo answer(1);
+"#,
+        &dir,
+        8_388_608,
+        false,
+        false,
+    );
+
+    assert!(
+        !user_asm.contains("pow"),
+        "dead statements after exhaustive switch should not remain in user assembly:\n{}",
+        user_asm
+    );
+
+    let out = assemble_and_run(
+        &user_asm,
+        get_runtime_obj(),
+        &dir,
+        &required_libraries,
+        &default_link_paths(),
+        &[],
+    );
+    assert_eq!(out, "7");
+
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/tests/codegen/support/compiler.rs
+++ b/tests/codegen/support/compiler.rs
@@ -32,8 +32,9 @@ pub(crate) fn compile_source_to_asm_with_defines(
     let resolved = elephc::name_resolver::resolve(resolved).expect("name resolve failed");
     let resolved = elephc::optimize::fold_constants(resolved);
     let check_result = elephc::types::check_with_target(&resolved, target()).expect("type check failed");
+    let optimized = elephc::optimize::prune_constant_control_flow(resolved);
     let (user_asm, runtime_asm) = elephc::codegen::generate(
-        &resolved,
+        &optimized,
         &check_result.global_env,
         &check_result.functions,
         &check_result.interfaces,

--- a/tests/codegen/support/compiler.rs
+++ b/tests/codegen/support/compiler.rs
@@ -30,6 +30,7 @@ pub(crate) fn compile_source_to_asm_with_defines(
     let ast = elephc::conditional::apply(ast, defines);
     let resolved = elephc::resolver::resolve(ast, dir).expect("resolve failed");
     let resolved = elephc::name_resolver::resolve(resolved).expect("name resolve failed");
+    let resolved = elephc::optimize::fold_constants(resolved);
     let check_result = elephc::types::check_with_target(&resolved, target()).expect("type check failed");
     let (user_asm, runtime_asm) = elephc::codegen::generate(
         &resolved,

--- a/tests/codegen/support/projects.rs
+++ b/tests/codegen/support/projects.rs
@@ -129,6 +129,7 @@ pub(crate) fn compile_and_run_files_with_defines(
     let ast = elephc::conditional::apply(ast, &define_set);
     let resolved = elephc::resolver::resolve(ast, base_dir).expect("resolve failed");
     let resolved = elephc::name_resolver::resolve(resolved).expect("name resolve failed");
+    let resolved = elephc::optimize::fold_constants(resolved);
     let check_result =
         elephc::types::check_with_target(&resolved, target()).expect("type check failed");
     let (user_asm, _runtime_asm) = elephc::codegen::generate(
@@ -197,6 +198,7 @@ pub(crate) fn compile_files_fails_with_defines(
         let ast = elephc::conditional::apply(ast, &define_set);
         let resolved = elephc::resolver::resolve(ast, base_dir)?;
         let resolved = elephc::name_resolver::resolve(resolved)?;
+        let resolved = elephc::optimize::fold_constants(resolved);
         elephc::types::check_with_target(&resolved, target())?;
         Ok(())
     })();
@@ -216,6 +218,7 @@ pub(crate) fn compile_and_run_with_stdin(source: &str, stdin_data: &str) -> Stri
     let ast = elephc::parser::parse(&tokens).expect("parse failed");
     let resolved = elephc::resolver::resolve(ast, &dir).expect("resolve failed");
     let resolved = elephc::name_resolver::resolve(resolved).expect("name resolve failed");
+    let resolved = elephc::optimize::fold_constants(resolved);
     let check_result = elephc::types::check_with_target(&resolved, target()).expect("type check failed");
     let (user_asm, _runtime_asm) = elephc::codegen::generate(
         &resolved,
@@ -308,6 +311,7 @@ pub(crate) fn compile_and_run_in_dir(source: &str) -> (String, std::path::PathBu
     let ast = elephc::parser::parse(&tokens).expect("parse failed");
     let resolved = elephc::resolver::resolve(ast, &dir).expect("resolve failed");
     let resolved = elephc::name_resolver::resolve(resolved).expect("name resolve failed");
+    let resolved = elephc::optimize::fold_constants(resolved);
     let check_result = elephc::types::check_with_target(&resolved, target()).expect("type check failed");
     let (user_asm, _runtime_asm) = elephc::codegen::generate(
         &resolved,

--- a/tests/codegen/support/projects.rs
+++ b/tests/codegen/support/projects.rs
@@ -132,8 +132,9 @@ pub(crate) fn compile_and_run_files_with_defines(
     let resolved = elephc::optimize::fold_constants(resolved);
     let check_result =
         elephc::types::check_with_target(&resolved, target()).expect("type check failed");
+    let optimized = elephc::optimize::prune_constant_control_flow(resolved);
     let (user_asm, _runtime_asm) = elephc::codegen::generate(
-        &resolved,
+        &optimized,
         &check_result.global_env,
         &check_result.functions,
         &check_result.interfaces,
@@ -220,8 +221,9 @@ pub(crate) fn compile_and_run_with_stdin(source: &str, stdin_data: &str) -> Stri
     let resolved = elephc::name_resolver::resolve(resolved).expect("name resolve failed");
     let resolved = elephc::optimize::fold_constants(resolved);
     let check_result = elephc::types::check_with_target(&resolved, target()).expect("type check failed");
+    let optimized = elephc::optimize::prune_constant_control_flow(resolved);
     let (user_asm, _runtime_asm) = elephc::codegen::generate(
-        &resolved,
+        &optimized,
         &check_result.global_env,
         &check_result.functions,
         &check_result.interfaces,
@@ -313,8 +315,9 @@ pub(crate) fn compile_and_run_in_dir(source: &str) -> (String, std::path::PathBu
     let resolved = elephc::name_resolver::resolve(resolved).expect("name resolve failed");
     let resolved = elephc::optimize::fold_constants(resolved);
     let check_result = elephc::types::check_with_target(&resolved, target()).expect("type check failed");
+    let optimized = elephc::optimize::prune_constant_control_flow(resolved);
     let (user_asm, _runtime_asm) = elephc::codegen::generate(
-        &resolved,
+        &optimized,
         &check_result.global_env,
         &check_result.functions,
         &check_result.interfaces,

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -20,6 +20,7 @@ fn check_source_with_defines(src: &str, defines: &[&str]) -> Result<(), String> 
     let define_set: HashSet<String> = defines.iter().map(|define| (*define).to_string()).collect();
     let ast = elephc::conditional::apply(ast, &define_set);
     let ast = elephc::name_resolver::resolve(ast).map_err(|e| e.message.clone())?;
+    let ast = elephc::optimize::fold_constants(ast);
     types::check(&ast).map_err(|e| e.message.clone())?;
     Ok(())
 }
@@ -28,6 +29,7 @@ fn check_source_full(src: &str) -> Result<elephc::types::CheckResult, elephc::er
     let tokens = tokenize(src).map_err(|e| elephc::errors::CompileError::new(e.span, &e.message))?;
     let ast = parse(&tokens)?;
     let ast = elephc::name_resolver::resolve(ast)?;
+    let ast = elephc::optimize::fold_constants(ast);
     types::check(&ast)
 }
 
@@ -1165,6 +1167,7 @@ fn test_null_coalesce_widens_function_return_type_in_checker() {
     let tokens = tokenize("<?php function fallback_pi($x) { return $x ?? 3.14159; }")
         .expect("tokenize failed");
     let ast = parse(&tokens).expect("parse failed");
+    let ast = elephc::optimize::fold_constants(ast);
     let check_result = types::check(&ast).expect("type check failed");
 
     let sig = check_result


### PR DESCRIPTION
## Summary

Add the first AST-level optimization pass to elephc and document it across the compiler docs.

This PR introduces:
- constant folding before type checking
- post-check pruning of constant-dead control flow
- local dead-code elimination for unreachable statements and pure unused expressions
- documentation updates covering the optimizer pipeline and current optimization scope

## What changed

### Optimizer
- add `src/optimize.rs` as a dedicated AST optimization pass
- run `fold_constants()` before type checking
- run `prune_constant_control_flow()` after successful type checking and warning collection

### Constant folding
- fold scalar arithmetic, bitwise ops, comparisons, logical ops, concat, casts, ternary, null coalescing, and other recursively decidable scalar expressions
- fold inside function/method bodies, closures, property defaults, constant declarations, and default parameter expressions

### Dead-code pruning
- prune constant-dead `if` / `elseif` / `while (false)` / `for (...; false; ...)`
- prune constant `match` arms and conservative `switch` prefixes
- remove unreachable statements after `return`, `throw`, `break`, and `continue`
- remove dead code after exhaustive `if` / `else` and conservative exhaustive `switch + default`
- drop pure unused expression statements and dead pure subexpressions inside ternary / `??` / short-circuit expressions

### Documentation
- add a new internals page for the optimizer
- update README, docs index, pipeline docs, architecture docs, type-checker docs, codegen docs, and roadmap to reflect the new optimization pipeline and current scope

## Why

This gives elephc a real “early optimization” stage before any backend-specific work:
- simpler ASTs reach codegen
- obvious runtime helper calls disappear when results are compile-time known
- dead branches and unreachable statements no longer generate assembly
- the docs now accurately describe the real compiler pipeline

## Testing

Ran:
- targeted optimizer unit tests
- targeted codegen regression tests
- filtered Linux x86_64 and Linux ARM64 optimizer test runs via `scripts/`
- `cargo build`
- `cargo test -- --include-ignored`

## Notes

The optimizer is intentionally conservative and still local to the AST.

It does not yet do:
- constant propagation across locals / statement boundaries
- interprocedural optimization
- peephole optimization
- runtime dead stripping

