### PR TITLE
feature/control flow normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ User-defined constants are also supported via `const NAME = value;` and `define(
 ## How it works
 
 ```
-PHP source → Lexer → Parser (AST) → Conditional (ifdef/--define) → Resolver (include) → NameResolver (namespaces/use/FQNs) → Optimizer (constant folding) → Type Checker → Optimizer (constant propagation) → Optimizer (control-flow pruning) → Optimizer (dead-code elimination) → Codegen → as + ld → native executable
+PHP source → Lexer → Parser (AST) → Conditional (ifdef/--define) → Resolver (include) → NameResolver (namespaces/use/FQNs) → Optimizer (constant folding) → Type Checker → Optimizer (constant propagation) → Optimizer (control-flow pruning) → Optimizer (control-flow normalization) → Optimizer (dead-code elimination) → Codegen → as + ld → native executable
 ```
 
 The compiler emits human-readable assembly for the selected target. You can inspect the `.s` file to see exactly what your PHP becomes:
@@ -255,7 +255,7 @@ elephc hello.php
 cat hello.s
 ```
 
-If you add `--source-map`, elephc also writes `hello.map`, a compact JSON sidecar that maps emitted assembly lines back to PHP line/column pairs. If you add `--timings`, the compiler prints per-phase durations such as lexing, parsing, early optimization, type checking, constant propagation, post-check pruning, runtime-cache preparation, code generation, assembling, and linking.
+If you add `--source-map`, elephc also writes `hello.map`, a compact JSON sidecar that maps emitted assembly lines back to PHP line/column pairs. If you add `--timings`, the compiler prints per-phase durations such as lexing, parsing, early optimization, type checking, constant propagation, post-check pruning, control-flow normalization, dead-code elimination, runtime-cache preparation, code generation, assembling, and linking.
 
 ### Current optimization passes
 
@@ -264,10 +264,11 @@ elephc already performs a small but useful AST-level optimization pipeline befor
 - **Constant folding before type checking**: folds scalar arithmetic, bitwise ops, comparisons, logical ops, string-literal concatenation, scalar casts, ternaries, and null coalescing when the result is statically known.
 - **Constant propagation after type checking**: forwards scalar local values through straight-line code, across conservative agreeing `if` / `switch` / `try` merges, through uniform local `?:` / `match` assignments, through fixed scalar destructuring like `[$a, $b] = [2, 3]`, and across simple loops when untouched locals or stable `for` init assignments can be proven safe even with conservative nested `switch`, `try/catch/finally`, `foreach`, other simple nested loop writes, local array mutations like `$items[] = $i` / `$items[0] = $i`, local property writes like `$box->last = $i` / `$box->items[] = $i`, or targeted local invalidations like `unset($tmp)`, which in turn unlocks more folding in later expressions such as `$x ** $y`.
 - **Control-flow pruning after type checking**: removes constant-dead `if` / `elseif` / `while (false)` / `for (...; false; ...)` branches, materializes constant `switch` execution, prunes `match` arms, and trims unreachable statements after terminating constructs such as `return`, `throw`, `break`, and `continue`.
-- **Dead-code elimination after pruning**: removes empty control shells, simplifies single-path conditionals, hoists safe non-throwing `try` prefixes, and drops unused pure expression statements and dead pure subexpressions when the surrounding expression already determines the result.
+- **Control-flow normalization after pruning**: canonicalizes equivalent residual shapes such as nested `elseif` chains, merged `if` heads/tails, single-case or fallthrough-only `switch` shells, canonical multi-catch handlers, folded outer `finally` wrappers, and identical `if` branches so later passes see fewer structurally different but semantically identical trees.
+- **Dead-code elimination after normalization**: removes empty control shells, simplifies single-path conditionals, hoists safe non-throwing `try` prefixes, and drops unused pure expression statements and dead pure subexpressions when the surrounding expression already determines the result.
 - **Local effect summaries for purity / may-throw reasoning**: tracks known pure and non-throwing builtins, user functions, static methods, private `$this` methods, closures, first-class callables, and merged callable aliases through `if` / `switch` / `try` control flow so the optimizer can simplify `try` regions and prune dead handlers more precisely.
 
-The optimizer is intentionally conservative. It does not yet do global constant propagation, aggressive whole-program optimization, or assembly-level peephole rewriting, but it does compute lightweight effect summaries for known call targets so AST rewrites can stay more precise without becoming risky.
+The optimizer is intentionally conservative. It does not yet do CFG-wide fixed-point propagation, aggressive whole-program optimization, or assembly-level peephole rewriting, but it does compute lightweight effect summaries for known call targets so AST rewrites can stay more precise without becoming risky.
 
 ### Type system
 
@@ -310,7 +311,7 @@ src/
 ├── span.rs              # Source position tracking (line, col)
 ├── conditional.rs       # Build-time `ifdef` pass driven by --define
 ├── resolver.rs          # Include/require file resolution
-├── optimize.rs          # AST optimizer: constant folding, control-flow pruning, dead-code elimination
+├── optimize.rs          # AST optimizer: folding, propagation, pruning, normalization, dead-code elimination
 ├── names.rs             # Qualified/FQN name model + symbol mangling helpers
 ├── name_resolver/       # Namespace/use resolution to canonical names
 │

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -321,11 +321,12 @@ Proper type system for PHP compatibility.
 - [ ] Dead code elimination v2 (CFG/basic-block aware pass beyond local AST pruning)
 - [x] Purity / may-throw analysis so AST optimizations can reason more precisely about safe hoisting and branch removal
 - [ ] Exception-aware dead code elimination beyond conservative `try` / `catch` / `finally` heuristics
-- [ ] Control-flow normalization pass for flattening redundant nested `if` / `switch` / `try` shells after pruning
-- [ ] Alias-aware constant propagation so local callables and scalar values can stay precise across `if` / `switch` / `try` merges
+- [x] Control-flow normalization pass for flattening redundant nested `if` / `switch` / `try` shells after pruning
+- [x] Alias-aware constant propagation so local callables and scalar values can stay precise across `if` / `switch` / `try` merges
 - [ ] Constant propagation v2 — fixed-point / CFG-aware propagation through loops and wider control-flow beyond the current conservative local env model
 - [ ] Memory-model-aware propagation for heap-backed locals and targeted runtime invalidations beyond `unset($var)` and the currently modeled local writes
 - [ ] Purity / may-throw v2 for dynamic instance dispatch, richer property/array reads, and less pessimistic builtin modeling
+- [ ] Control-flow normalization v2 — broader canonicalization of nested block/control shells before CFG-aware optimization passes
 - [ ] Register allocation (reduce stack spills)
 - [ ] Inline small functions
 - [ ] Tail-call optimization

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ How elephc works under the hood — from lexing to code generation and runtime s
 - [The Lexer](internals/the-lexer.md) — raw text to tokens
 - [The Parser](internals/the-parser.md) — tokens to AST with Pratt parsing
 - [The Type Checker](internals/the-type-checker.md) — compile-time type inference and validation
-- [The Optimizer](internals/the-optimizer.md) — constant folding, purity / may-throw reasoning, control-flow pruning, and dead-code elimination on the AST
+- [The Optimizer](internals/the-optimizer.md) — constant folding, constant propagation, purity / may-throw reasoning, control-flow pruning, normalization, and dead-code elimination on the AST
 - [The Code Generator](internals/the-codegen.md) — optimized checked AST to target assembly (with an AArch64-focused walkthrough)
 - [The Runtime](internals/the-runtime.md) — hand-written assembly routines
 - [Memory Model](internals/memory-model.md) — stack frames, heap, reference counting

--- a/docs/getting-started/your-first-program.md
+++ b/docs/getting-started/your-first-program.md
@@ -112,7 +112,7 @@ elephc --timings hello.php
 elephc --emit-asm --source-map hello.php
 ```
 
-`--timings` reports phases such as lexing, parsing, early optimization, type checking, post-check pruning, runtime-cache preparation, code generation, assembling, and linking.
+`--timings` reports phases such as lexing, parsing, early optimization, type checking, constant propagation, post-check pruning, control-flow normalization, dead-code elimination, runtime-cache preparation, code generation, assembling, and linking.
 
 `--source-map` writes a `hello.map` JSON file next to `hello.s`. The map records which emitted assembly lines came from which PHP source lines and columns.
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -62,6 +62,13 @@ PHP source (.php)
      ▼
 ┌──────────────┐
 │  Optimizer   │  src/optimize.rs
+│ (propagate)  │  Propagates scalar locals conservatively after
+│              │  successful checking.
+└─────┬────────┘
+      │
+      ▼
+┌──────────────┐
+│  Optimizer   │  src/optimize.rs
 │  (prune)     │  Removes constant-dead control flow after successful
 │              │  checking.
 └─────┬────────┘
@@ -69,8 +76,15 @@ PHP source (.php)
       ▼
 ┌──────────────┐
 │  Optimizer   │  src/optimize.rs
-│   (DCE)      │  Cleans up redundant control shells, hoists safe
-│              │  non-throwing `try` prefixes, and drops dead leftovers.
+│ (normalize)  │  Canonicalizes equivalent control-flow shells into
+│              │  simpler AST shapes.
+└─────┬────────┘
+      │
+      ▼
+┌──────────────┐
+│  Optimizer   │  src/optimize.rs
+│   (DCE)      │  Drops leftover unreachable or non-observable
+│              │  statements from the normalized AST.
 └─────┬────────┘
       │
       ▼
@@ -113,7 +127,7 @@ src/
 ├── span.rs                    Source position (line, col)
 ├── conditional.rs             Build-time `ifdef` pass
 ├── resolver.rs                Include/require file resolution
-├── optimize.rs                Constant folding, control-flow pruning, dead-code elimination
+├── optimize.rs                Constant folding, constant propagation, control-flow pruning, normalization, dead-code elimination
 ├── runtime_cache.rs           Cached shared runtime object preparation
 ├── source_map.rs              Assembly comment markers → JSON sidecar map
 ├── names.rs                   Qualified/FQN name model + assembly symbol mangling

--- a/docs/internals/how-elephc-works.md
+++ b/docs/internals/how-elephc-works.md
@@ -154,7 +154,15 @@ This pass is still conservative, but it can already:
 - preserve unrelated scalar locals across simple loops when the loop's local writes are conservatively known, including simple nested `switch`, `try/catch/finally`, `foreach`, other simple nested loop shapes, local array writes such as `$items[] = $i` / `$items[0] = $i`, local property writes such as `$box->last = $i` / `$box->items[] = $i`, and targeted local invalidations like `unset($tmp)`, while also keeping stable scalar values introduced by `for` init clauses
 - re-run folding after substitutions so expressions like `$x ** $y` can collapse to a literal
 
-In our running example, this still does not change the program, because `$x = 10` at the statement level is not yet propagated into the later comparison shape that would let the whole `if` collapse.
+In our running example, this *does* change the program. The pass can forward `$x = 10` into the later comparison, re-run folding, and effectively turn the condition into `true`:
+
+```php
+<?php
+$x = 10;
+if (true) {
+    echo "big\n";
+}
+```
 
 ## Phase 9: Post-typecheck control-flow pruning
 
@@ -175,29 +183,51 @@ This pass also consults the optimizer's local effect summaries. Those summaries 
 
 This split is intentional: elephc folds obvious scalar expressions early, but waits until after type checking to remove whole blocks, so diagnostics still see the original checked structure.
 
-In our running example there is still nothing to prune, because `$x > 5` is not yet a compile-time constant at the AST level.
+In our running example, the `if (true)` shell is now pruned away:
 
-## Phase 10: Dead-code elimination and structural cleanup
+```php
+<?php
+$x = 10;
+echo "big\n";
+```
+
+## Phase 10: Control-flow normalization
 
 **File:** `src/optimize.rs`
 
-After control-flow pruning, elephc runs a final AST cleanup pass. This pass does not try to prove new constants; instead, it simplifies the shapes left behind by earlier rewrites.
+After control-flow pruning, elephc canonicalizes the remaining control-flow shells. This pass does not try to prove new constants; it rewrites structurally equivalent shapes into simpler, more uniform AST forms so later passes see fewer special cases.
+
+This pass currently handles cases such as:
+
+- canonicalizing `elseif` chains into nested `else { if (...) { ... } }`
+- merging compatible `if` heads/tails and collapsing identical `if` branches
+- merging identical adjacent `switch` cases and folding pure fallthrough labels
+- rewriting safe single-case `switch` shells to `if`
+- merging adjacent identical `catch` handlers into canonical multi-catch clauses with deduplicated, stably ordered type lists
+- folding an outer `finally` into an inner `try` when the wrapper is structurally redundant
+
+## Phase 11: Dead-code elimination
+
+**File:** `src/optimize.rs`
+
+After normalization, elephc runs a final dead-code-elimination pass over the already-canonical AST.
 
 This pass currently handles cases such as:
 
 - removing empty `if`, `switch`, `ifdef`, and degenerate `try` shells
-- collapsing single-path conditionals such as `if ($a) { if ($b) { ... } }`
+- trimming unreachable statements after `return`, `throw`, `break`, or `continue`
 - materializing constant `switch` execution into the exact statement tail that would run
 - hoisting safe non-throwing prefixes out of `try` blocks
 - simplifying non-throwing `try` / `catch` and some non-throwing `try` / `finally` fallthrough cases
+- dropping pure expression statements and other leftover non-observable statements exposed by earlier passes
 
-This is also where the optimizer does its final local dead-code cleanup before codegen sees the AST.
+In our running example there is nothing else to remove: the remaining assignment and `echo` stay as they are.
 
-## Phase 11: Code generation
+## Phase 12: Code generation
 
 **File:** `src/codegen/` — See [The Code Generator](the-codegen.md) for details.
 
-The code generator walks the typed AST and emits assembly for the selected target. For ordinary control flow this is mostly straight-line branches and labels; for `try` / `catch` / `finally`, the compiler additionally emits handler records and resume labels around `_setjmp` / `_longjmp`-based exception unwinding. The walkthrough below shows the AArch64 form of our simple example (simplified, with comments):
+The code generator walks the typed AST and emits assembly for the selected target. For ordinary control flow this is mostly straight-line branches and labels; for `try` / `catch` / `finally`, the compiler additionally emits handler records and resume labels around `_setjmp` / `_longjmp`-based exception unwinding. By this point our running example has already lost the `if` shell, so the AArch64 form is simpler than the original source (simplified, with comments):
 
 ```asm
 .global _main
@@ -213,20 +243,13 @@ _main:
     mov x0, #10
     stur x0, [x29, #-8]
 
-    ; -- if ($x > 5) --
-    ldur x0, [x29, #-8]         ; load $x
-    cmp x0, #5                   ; compare with 5
-    b.le _end_if_1               ; skip body if $x <= 5
-
-    ; -- echo "big\n" --
+    ; -- echo "big\n" (the if shell was pruned earlier) --
     adrp x1, _str_0@PAGE
     add x1, x1, _str_0@PAGEOFF
     mov x2, #4                   ; length = 4 ("big" + newline)
     mov x0, #1                   ; fd = stdout
     mov x16, #4                  ; syscall = write
     svc #0x80                    ; call kernel
-
-_end_if_1:
     ; -- epilogue: exit(0) --
     mov x0, #0
     mov x16, #1
@@ -239,11 +262,11 @@ _str_0: .ascii "big\n"
 Key observations:
 
 - `$x = 10` → `mov x0, #10` then `stur` to the stack at offset -8 from the frame pointer
-- `if ($x > 5)` → `cmp` + `b.le` (branch if **not** greater — the condition is inverted)
+- the `if ($x > 5)` check no longer exists by codegen time because propagation + pruning removed it
 - `echo "big\n"` → load string address + length, then `svc` to write to stdout
 - The string literal lives in the `.data` section, referenced by label `_str_0`
 
-## Phase 12: Runtime preparation, assembly, and linking
+## Phase 13: Runtime preparation, assembly, and linking
 
 **Tools:** native `as` and `ld` (or the equivalent system toolchain)
 
@@ -279,7 +302,7 @@ On Linux, elephc invokes the native assembler/linker for the requested target.
 
 The `.o` file is deleted after linking. The result is a standalone executable.
 
-## Phase 12: Execution
+## Phase 14: Execution
 
 ```bash
 ./file
@@ -311,17 +334,20 @@ The binary runs directly on the CPU. There is no PHP interpreter or VM at runtim
                     ▼ Type Checker
     { x: Int } — all types consistent ✓
                     │
-                    ▼ Optimizer (constant propagation, no-op here)
-    [Assign{x, 10}, If{Gt(Var(x), 5), [Echo("big\n")]}]
+                    ▼ Optimizer (constant propagation)
+    [Assign{x, 10}, If{true, [Echo("big\n")]}]
                     │
-                    ▼ Optimizer (prune dead control flow, no-op here)
-    [Assign{x, 10}, If{Gt(Var(x), 5), [Echo("big\n")]}]
+                    ▼ Optimizer (prune dead control flow)
+    [Assign{x, 10}, Echo("big\n")]
+                    │
+                    ▼ Optimizer (normalize control flow, no-op here)
+    [Assign{x, 10}, Echo("big\n")]
                     │
                     ▼ Optimizer (dead-code elimination, no-op here)
-    [Assign{x, 10}, If{Gt(Var(x), 5), [Echo("big\n")]}]
+    [Assign{x, 10}, Echo("big\n")]
                     │
                     ▼ Code Generator
-    "sub sp, sp, #32 / stp x29, x30, ... / mov x0, #10 / ..."
+    "sub sp, sp, #32 / stp x29, x30, ... / mov x0, #10 / adrp x1, _str_0 / ..."
                     │
                     ▼ Runtime Cache
     ~/.cache/elephc/runtime-v<version>-<target>-heap<size>.o

--- a/docs/internals/the-optimizer.md
+++ b/docs/internals/the-optimizer.md
@@ -169,7 +169,7 @@ Current normalization coverage includes:
 - adjacent `switch` cases with identical bodies merged into a single multi-pattern case
 - pure fallthrough `switch` labels folded into the next non-empty case body
 - single live `switch` cases rewritten to `if` when the loose comparison can be reconstructed safely
-- adjacent `catch` clauses with the same body and variable merged into a single multi-type catch
+- adjacent `catch` clauses with the same body and variable merged into a single deduplicated multi-type catch
 - constant `switch` execution materialized into the exact statement tail that would run, preserving fallthrough and `break`
 - non-throwing `try` / `catch` simplification
 - safe hoisting of non-throwing, fallthrough prefixes out of `try` blocks

--- a/docs/internals/the-optimizer.md
+++ b/docs/internals/the-optimizer.md
@@ -172,6 +172,7 @@ Current normalization coverage includes:
 - adjacent `catch` clauses with the same body and variable merged into a single deduplicated, stably ordered multi-type catch
 - constant `switch` execution materialized into the exact statement tail that would run, preserving fallthrough and `break`
 - non-throwing `try` / `catch` simplification
+- outer `finally` blocks folded into a single inner `try` when they wrap exactly one inner `try` that does not already have its own `finally`
 - safe hoisting of non-throwing, fallthrough prefixes out of `try` blocks
 - conservative flattening of `try` / `finally` when the `try` body cannot throw and the body falls through
 ### Example

--- a/docs/internals/the-optimizer.md
+++ b/docs/internals/the-optimizer.md
@@ -169,7 +169,7 @@ Current normalization coverage includes:
 - adjacent `switch` cases with identical bodies merged into a single multi-pattern case
 - pure fallthrough `switch` labels folded into the next non-empty case body
 - single live `switch` cases rewritten to `if` when the loose comparison can be reconstructed safely
-- adjacent `catch` clauses with the same body and variable merged into a single deduplicated multi-type catch
+- adjacent `catch` clauses with the same body and variable merged into a single deduplicated, stably ordered multi-type catch
 - constant `switch` execution materialized into the exact statement tail that would run, preserving fallthrough and `break`
 - non-throwing `try` / `catch` simplification
 - safe hoisting of non-throwing, fallthrough prefixes out of `try` blocks

--- a/docs/internals/the-optimizer.md
+++ b/docs/internals/the-optimizer.md
@@ -166,6 +166,7 @@ Current normalization coverage includes:
 - adjacent `if` chain heads with identical bodies merged into one `if ($a || $b) { ... }` shape
 - adjacent `if` chain tails with identical fallback merged into one `if (!$a && $b) { ... } else { ... }` shape
 - longer `if` chains repeatedly normalized until these shapes saturate
+- adjacent `switch` cases with identical bodies merged into a single multi-pattern case
 - single live `switch` cases rewritten to `if` when the loose comparison can be reconstructed safely
 - adjacent `catch` clauses with the same body and variable merged into a single multi-type catch
 - constant `switch` execution materialized into the exact statement tail that would run, preserving fallthrough and `break`

--- a/docs/internals/the-optimizer.md
+++ b/docs/internals/the-optimizer.md
@@ -9,12 +9,13 @@ sidebar:
 
 elephc's optimizer is intentionally simple and AST-focused. It does not build a separate IR or run heavyweight SSA passes. Instead, it performs a small set of local rewrites that already pay off in generated assembly quality and compile-time clarity.
 
-Today the optimizer is split into four passes:
+Today the optimizer is split into five passes:
 
 1. `fold_constants(program)` runs before type checking
 2. `propagate_constants(program)` runs after successful type checking
 3. `prune_constant_control_flow(program)` runs after propagation and warning collection
-4. `eliminate_dead_code(program)` runs after pruning and performs cleanup / structural simplification on the already-pruned AST
+4. `normalize_control_flow(program)` runs after pruning and rewrites structurally equivalent control-flow shells into simpler AST shapes
+5. `eliminate_dead_code(program)` runs after normalization and removes leftover unreachable or non-observable statements from the already-normalized AST
 
 That split matters. Some rewrites are always safe on syntax alone, while others should only happen after diagnostics have already seen the checked program.
 
@@ -151,11 +152,11 @@ Current pruning coverage includes:
   - `??`
   - short-circuit `&&` / `||`
 
-## Pass 4: Dead-code elimination and structural cleanup
+## Pass 4: Control-flow normalization
 
-`eliminate_dead_code()` runs after the pruning pass. At this point the AST already has constant-dead branches removed, so the job becomes "clean up the shells and leftovers" rather than "decide which branch is dead".
+`normalize_control_flow()` runs after the pruning pass. At this point the AST already has constant-dead branches removed, so the job becomes "reshape the remaining control flow into simpler but equivalent forms" rather than "decide which branch is dead".
 
-Current cleanup coverage includes:
+Current normalization coverage includes:
 
 - empty `ifdef`, `if`, `switch`, and degenerate `try` shells
 - single-path conditionals such as:
@@ -165,8 +166,6 @@ Current cleanup coverage includes:
 - non-throwing `try` / `catch` simplification
 - safe hoisting of non-throwing, fallthrough prefixes out of `try` blocks
 - conservative flattening of `try` / `finally` when the `try` body cannot throw and the body falls through
-- pure expression statements that are left behind after earlier pruning
-
 ### Example
 
 ```php
@@ -181,6 +180,21 @@ try {
 
 The leading `echo "a";` is known not to throw, so the optimizer can hoist it out of the `try` and leave only the actually-throwing tail protected by the handler.
 
+## Pass 5: Dead-code elimination
+
+`eliminate_dead_code()` now runs after normalization. At this point the AST has already had constant-dead branches removed and redundant control-flow shells compacted, so the job becomes "drop the leftovers" rather than "reshape the program".
+
+Current dead-code-elimination coverage includes:
+
+- unreachable statements after:
+  - `return`
+  - `throw`
+  - `break`
+  - `continue`
+- statements after exhaustive `try/catch` and `try/finally` exits
+- pure expression statements whose result is unused
+- pure expression statements that become exposed by earlier normalization
+
 ### Example
 
 ```php
@@ -192,7 +206,7 @@ if (true) {
 }
 ```
 
-After pruning, the dead branch disappears entirely. That means codegen never emits the `pow` path.
+After pruning and normalization, the dead branch disappears entirely. The final dead-code pass then has less structural noise to inspect, and codegen never emits the `pow` path.
 
 ## Effect summaries: purity and `may_throw`
 

--- a/docs/internals/the-optimizer.md
+++ b/docs/internals/the-optimizer.md
@@ -164,6 +164,7 @@ Current normalization coverage includes:
   - nested single-path `if` chains collapsed into one condition with `&&`
 - `elseif` chains canonicalized into nested `else { if (...) { ... } }` form
 - single live `switch` cases rewritten to `if` when the loose comparison can be reconstructed safely
+- adjacent `catch` clauses with the same body and variable merged into a single multi-type catch
 - constant `switch` execution materialized into the exact statement tail that would run, preserving fallthrough and `break`
 - non-throwing `try` / `catch` simplification
 - safe hoisting of non-throwing, fallthrough prefixes out of `try` blocks

--- a/docs/internals/the-optimizer.md
+++ b/docs/internals/the-optimizer.md
@@ -163,6 +163,7 @@ Current normalization coverage includes:
   - `if ($cond) {} else { ... }` → `if (!$cond) { ... }`
   - nested single-path `if` chains collapsed into one condition with `&&`
 - `elseif` chains canonicalized into nested `else { if (...) { ... } }` form
+- single live `switch` cases rewritten to `if` when the loose comparison can be reconstructed safely
 - constant `switch` execution materialized into the exact statement tail that would run, preserving fallthrough and `break`
 - non-throwing `try` / `catch` simplification
 - safe hoisting of non-throwing, fallthrough prefixes out of `try` blocks

--- a/docs/internals/the-optimizer.md
+++ b/docs/internals/the-optimizer.md
@@ -19,7 +19,7 @@ Today the optimizer is split into five passes:
 
 That split matters. Some rewrites are always safe on syntax alone, while others should only happen after diagnostics have already seen the checked program.
 
-Alongside those four passes, the optimizer also builds lightweight local **effect summaries**. These summaries answer two questions conservatively:
+Alongside those five passes, the optimizer also builds lightweight local **effect summaries**. These summaries answer two questions conservatively:
 
 - does this expression have observable side effects?
 - can this expression throw?
@@ -260,7 +260,7 @@ try {
 
 Because every `match` arm produces the same known pure / non-throwing callable, the optimizer can prove that the `catch` path is dead and avoid emitting the `pow` branch at all.
 
-## Why there are four passes
+## Why there are five passes
 
 If elephc removed whole branches before type checking, it could accidentally hide useful diagnostics.
 
@@ -281,6 +281,7 @@ So the current rule is:
 - fold obvious pure scalar expressions early
 - propagate known scalar locals only after checking
 - prune larger dead control-flow only after checking
+- normalize the remaining control-flow into simpler equivalent shapes
 - run structural dead-code cleanup only after those earlier passes have already simplified the tree
 
 ## Conservatism and side effects
@@ -301,11 +302,12 @@ That conservatism is why the pass is safe to run by default: if an expression co
 
 ## What the optimizer does not do yet
 
-The current pass is local. It does not yet implement:
+The current optimizer is still intentionally local. It does not yet implement:
 
-- constant propagation across variables and statement boundaries
-- richer alias-aware propagation across general locals and merges
+- CFG-aware or fixed-point constant propagation across wider loops and general path merges
+- richer memory-model-aware propagation across heap-backed locals and broader aliasing situations
 - deeper exception-aware dead-code elimination beyond conservative `try` heuristics
+- broader control-flow normalization beyond the current local AST shell rewrites
 - backend-specific peephole cleanup
 - runtime dead stripping
 - register allocation

--- a/docs/internals/the-optimizer.md
+++ b/docs/internals/the-optimizer.md
@@ -163,6 +163,7 @@ Current normalization coverage includes:
   - `if ($cond) {} else { ... }` → `if (!$cond) { ... }`
   - nested single-path `if` chains collapsed into one condition with `&&`
 - `elseif` chains canonicalized into nested `else { if (...) { ... } }` form
+- adjacent `if` chain heads with identical bodies merged into one `if ($a || $b) { ... }` shape
 - single live `switch` cases rewritten to `if` when the loose comparison can be reconstructed safely
 - adjacent `catch` clauses with the same body and variable merged into a single multi-type catch
 - constant `switch` execution materialized into the exact statement tail that would run, preserving fallthrough and `break`

--- a/docs/internals/the-optimizer.md
+++ b/docs/internals/the-optimizer.md
@@ -167,6 +167,7 @@ Current normalization coverage includes:
 - adjacent `if` chain tails with identical fallback merged into one `if (!$a && $b) { ... } else { ... }` shape
 - longer `if` chains repeatedly normalized until these shapes saturate
 - adjacent `switch` cases with identical bodies merged into a single multi-pattern case
+- pure fallthrough `switch` labels folded into the next non-empty case body
 - single live `switch` cases rewritten to `if` when the loose comparison can be reconstructed safely
 - adjacent `catch` clauses with the same body and variable merged into a single multi-type catch
 - constant `switch` execution materialized into the exact statement tail that would run, preserving fallthrough and `break`

--- a/docs/internals/the-optimizer.md
+++ b/docs/internals/the-optimizer.md
@@ -165,6 +165,7 @@ Current normalization coverage includes:
 - `elseif` chains canonicalized into nested `else { if (...) { ... } }` form
 - adjacent `if` chain heads with identical bodies merged into one `if ($a || $b) { ... }` shape
 - adjacent `if` chain tails with identical fallback merged into one `if (!$a && $b) { ... } else { ... }` shape
+- longer `if` chains repeatedly normalized until these shapes saturate
 - single live `switch` cases rewritten to `if` when the loose comparison can be reconstructed safely
 - adjacent `catch` clauses with the same body and variable merged into a single multi-type catch
 - constant `switch` execution materialized into the exact statement tail that would run, preserving fallthrough and `break`

--- a/docs/internals/the-optimizer.md
+++ b/docs/internals/the-optimizer.md
@@ -162,6 +162,7 @@ Current normalization coverage includes:
 - single-path conditionals such as:
   - `if ($cond) {} else { ... }` → `if (!$cond) { ... }`
   - nested single-path `if` chains collapsed into one condition with `&&`
+- `if` statements whose `then` and `else` bodies normalize to the same block collapsed into “evaluate the condition only if observable, then run the shared block once”
 - `elseif` chains canonicalized into nested `else { if (...) { ... } }` form
 - adjacent `if` chain heads with identical bodies merged into one `if ($a || $b) { ... }` shape
 - adjacent `if` chain tails with identical fallback merged into one `if (!$a && $b) { ... } else { ... }` shape

--- a/docs/internals/the-optimizer.md
+++ b/docs/internals/the-optimizer.md
@@ -162,6 +162,7 @@ Current normalization coverage includes:
 - single-path conditionals such as:
   - `if ($cond) {} else { ... }` → `if (!$cond) { ... }`
   - nested single-path `if` chains collapsed into one condition with `&&`
+- `elseif` chains canonicalized into nested `else { if (...) { ... } }` form
 - constant `switch` execution materialized into the exact statement tail that would run, preserving fallthrough and `break`
 - non-throwing `try` / `catch` simplification
 - safe hoisting of non-throwing, fallthrough prefixes out of `try` blocks

--- a/docs/internals/the-optimizer.md
+++ b/docs/internals/the-optimizer.md
@@ -164,6 +164,7 @@ Current normalization coverage includes:
   - nested single-path `if` chains collapsed into one condition with `&&`
 - `elseif` chains canonicalized into nested `else { if (...) { ... } }` form
 - adjacent `if` chain heads with identical bodies merged into one `if ($a || $b) { ... }` shape
+- adjacent `if` chain tails with identical fallback merged into one `if (!$a && $b) { ... } else { ... }` shape
 - single live `switch` cases rewritten to `if` when the loose comparison can be reconstructed safely
 - adjacent `catch` clauses with the same body and variable merged into a single multi-type catch
 - constant `switch` execution materialized into the exact statement tail that would run, preserving fallthrough and `break`

--- a/docs/internals/the-type-checker.md
+++ b/docs/internals/the-type-checker.md
@@ -208,11 +208,12 @@ Warnings are returned through `CheckResult` and printed by the CLI without faili
 
 ## Where the checker sits in the optimizer pipeline
 
-The type checker sits between an early folding pass and two post-check cleanup passes in `src/optimize.rs`:
+The type checker sits between an early folding pass and three post-check cleanup passes in `src/optimize.rs`:
 
 - `fold_constants()` runs first and simplifies scalar expressions that are already statically decidable.
 - `prune_constant_control_flow()` runs only after successful checking and warning collection, so dead branches can be removed without suppressing type errors or warnings that should still be reported.
-- `eliminate_dead_code()` runs after pruning and performs structural cleanup on the already-checked, already-pruned AST.
+- `normalize_control_flow()` runs after pruning and rewrites structurally equivalent control-flow shells into simpler AST shapes.
+- `eliminate_dead_code()` runs after normalization and removes the leftover unreachable or non-observable statements.
 
 That ordering is intentional. elephc is happy to rewrite `2 + 3` into `5` before checking, but it does not want an optimization pass to make broken code look valid by deleting it too early.
 

--- a/docs/internals/the-type-checker.md
+++ b/docs/internals/the-type-checker.md
@@ -208,9 +208,10 @@ Warnings are returned through `CheckResult` and printed by the CLI without faili
 
 ## Where the checker sits in the optimizer pipeline
 
-The type checker sits between an early folding pass and three post-check cleanup passes in `src/optimize.rs`:
+The type checker sits between an early folding pass and four post-check cleanup passes in `src/optimize.rs`:
 
 - `fold_constants()` runs first and simplifies scalar expressions that are already statically decidable.
+- `propagate_constants()` runs after successful checking and pushes known scalar locals through conservative straight-line and merge shapes.
 - `prune_constant_control_flow()` runs only after successful checking and warning collection, so dead branches can be removed without suppressing type errors or warnings that should still be reported.
 - `normalize_control_flow()` runs after pruning and rewrites structurally equivalent control-flow shells into simpler AST shapes.
 - `eliminate_dead_code()` runs after normalization and removes the leftover unreachable or non-observable statements.

--- a/src/main.rs
+++ b/src/main.rs
@@ -345,6 +345,10 @@ fn main() {
     timings.record_since("opt-post", phase_started);
 
     let phase_started = Instant::now();
+    let ast = optimize::normalize_control_flow(ast);
+    timings.record_since("opt-norm", phase_started);
+
+    let phase_started = Instant::now();
     let ast = optimize::eliminate_dead_code(ast);
     timings.record_since("dce", phase_started);
 

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -1856,6 +1856,21 @@ fn build_if_stmt(
                             span,
                         };
                     }
+
+                    if inner_elseifs.is_empty() && inner_else.as_ref() == Some(&then_body) {
+                        return Stmt {
+                            kind: StmtKind::If {
+                                condition: combine_if_conditions(
+                                    invert_condition(condition),
+                                    inner_condition.clone(),
+                                ),
+                                then_body: inner_then_body.clone(),
+                                elseif_clauses: Vec::new(),
+                                else_body: Some(then_body),
+                            },
+                            span,
+                        };
+                    }
                 }
             }
         }
@@ -7162,6 +7177,59 @@ mod tests {
                 assert_eq!(then_body, &shared_body);
                 assert!(elseif_clauses.is_empty());
                 assert_eq!(else_body, &Some(vec![Stmt::echo(Expr::int_lit(9))]));
+            }
+            other => panic!("expected normalized if, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_normalize_control_flow_merges_identical_if_chain_tail_into_inverted_and() {
+        let shared_tail = vec![Stmt::echo(Expr::int_lit(9))];
+        let program = vec![Stmt::new(
+            StmtKind::If {
+                condition: Expr::var("a"),
+                then_body: shared_tail.clone(),
+                elseif_clauses: Vec::new(),
+                else_body: Some(vec![Stmt::new(
+                    StmtKind::If {
+                        condition: Expr::var("b"),
+                        then_body: vec![Stmt::echo(Expr::int_lit(7))],
+                        elseif_clauses: Vec::new(),
+                        else_body: Some(shared_tail.clone()),
+                    },
+                    Span::dummy(),
+                )]),
+            },
+            Span::dummy(),
+        )];
+
+        let pruned = normalize_control_flow(program);
+
+        assert_eq!(pruned.len(), 1);
+        match &pruned[0].kind {
+            StmtKind::If {
+                condition,
+                then_body,
+                elseif_clauses,
+                else_body,
+            } => {
+                assert_eq!(
+                    *condition,
+                    Expr::new(
+                        ExprKind::BinaryOp {
+                            left: Box::new(Expr::new(
+                                ExprKind::Not(Box::new(Expr::var("a"))),
+                                Span::dummy(),
+                            )),
+                            op: BinOp::And,
+                            right: Box::new(Expr::var("b")),
+                        },
+                        Span::dummy(),
+                    )
+                );
+                assert_eq!(then_body, &vec![Stmt::echo(Expr::int_lit(7))]);
+                assert!(elseif_clauses.is_empty());
+                assert_eq!(else_body, &Some(shared_tail));
             }
             other => panic!("expected normalized if, got {:?}", other),
         }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -448,6 +448,18 @@ fn combine_if_conditions(left: Expr, right: Expr) -> Expr {
     ))
 }
 
+fn combine_if_chain_conditions(left: Expr, right: Expr) -> Expr {
+    let span = left.span;
+    prune_expr(Expr::new(
+        ExprKind::BinaryOp {
+            left: Box::new(left),
+            op: BinOp::Or,
+            right: Box::new(right),
+        },
+        span,
+    ))
+}
+
 fn build_switch_match_condition(subject: &Expr, patterns: &[Expr]) -> Option<Expr> {
     if patterns.is_empty() {
         return None;
@@ -1820,24 +1832,53 @@ fn build_if_stmt(
     else_body: Option<Vec<Stmt>>,
     span: crate::span::Span,
 ) -> Stmt {
-    if elseif_clauses.is_empty() && else_body.is_none() && then_body.len() == 1 {
-        if let StmtKind::If {
-            condition: inner_condition,
-            then_body: inner_then_body,
-            elseif_clauses: inner_elseifs,
-            else_body: inner_else,
-        } = &then_body[0].kind
-        {
-            if inner_elseifs.is_empty() && inner_else.is_none() {
-                return Stmt {
-                    kind: StmtKind::If {
-                        condition: combine_if_conditions(condition, inner_condition.clone()),
-                        then_body: inner_then_body.clone(),
-                        elseif_clauses: Vec::new(),
-                        else_body: None,
-                    },
-                    span,
-                };
+    if elseif_clauses.is_empty() {
+        if let Some(else_body_ref) = else_body.as_ref() {
+            if else_body_ref.len() == 1 {
+                if let StmtKind::If {
+                    condition: inner_condition,
+                    then_body: inner_then_body,
+                    elseif_clauses: inner_elseifs,
+                    else_body: inner_else,
+                } = &else_body_ref[0].kind
+                {
+                    if inner_elseifs.is_empty() && *inner_then_body == then_body {
+                        return Stmt {
+                            kind: StmtKind::If {
+                                condition: combine_if_chain_conditions(
+                                    condition,
+                                    inner_condition.clone(),
+                                ),
+                                then_body,
+                                elseif_clauses: Vec::new(),
+                                else_body: inner_else.clone(),
+                            },
+                            span,
+                        };
+                    }
+                }
+            }
+        }
+
+        if else_body.is_none() && then_body.len() == 1 {
+            if let StmtKind::If {
+                condition: inner_condition,
+                then_body: inner_then_body,
+                elseif_clauses: inner_elseifs,
+                else_body: inner_else,
+            } = &then_body[0].kind
+            {
+                if inner_elseifs.is_empty() && inner_else.is_none() {
+                    return Stmt {
+                        kind: StmtKind::If {
+                            condition: combine_if_conditions(condition, inner_condition.clone()),
+                            then_body: inner_then_body.clone(),
+                            elseif_clauses: Vec::new(),
+                            else_body: None,
+                        },
+                        span,
+                    };
+                }
             }
         }
     }
@@ -7074,6 +7115,56 @@ mod tests {
         assert_eq!(then_body, &vec![Stmt::echo(Expr::int_lit(2))]);
         assert!(elseif_clauses.is_empty());
         assert_eq!(else_body, &Some(vec![Stmt::echo(Expr::int_lit(3))]));
+    }
+
+    #[test]
+    fn test_normalize_control_flow_merges_identical_if_chain_bodies_into_or_condition() {
+        let shared_body = vec![Stmt::echo(Expr::int_lit(7))];
+        let program = vec![Stmt::new(
+            StmtKind::If {
+                condition: Expr::var("a"),
+                then_body: shared_body.clone(),
+                elseif_clauses: Vec::new(),
+                else_body: Some(vec![Stmt::new(
+                    StmtKind::If {
+                        condition: Expr::var("b"),
+                        then_body: shared_body.clone(),
+                        elseif_clauses: Vec::new(),
+                        else_body: Some(vec![Stmt::echo(Expr::int_lit(9))]),
+                    },
+                    Span::dummy(),
+                )]),
+            },
+            Span::dummy(),
+        )];
+
+        let pruned = normalize_control_flow(program);
+
+        assert_eq!(pruned.len(), 1);
+        match &pruned[0].kind {
+            StmtKind::If {
+                condition,
+                then_body,
+                elseif_clauses,
+                else_body,
+            } => {
+                assert_eq!(
+                    *condition,
+                    Expr::new(
+                        ExprKind::BinaryOp {
+                            left: Box::new(Expr::var("a")),
+                            op: BinOp::Or,
+                            right: Box::new(Expr::var("b")),
+                        },
+                        Span::dummy(),
+                    )
+                );
+                assert_eq!(then_body, &shared_body);
+                assert!(elseif_clauses.is_empty());
+                assert_eq!(else_body, &Some(vec![Stmt::echo(Expr::int_lit(9))]));
+            }
+            other => panic!("expected normalized if, got {:?}", other),
+        }
     }
 
     #[test]

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -2,6 +2,7 @@ use crate::parser::ast::{
     BinOp, CallableTarget, CastType, ClassMethod, ClassProperty, EnumCaseDecl, Expr, ExprKind,
     Program, Stmt, StmtKind,
 };
+use crate::names::Name;
 use crate::termination::{block_terminal_effect, stmt_terminal_effect, TerminalEffect};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
@@ -342,14 +343,26 @@ fn normalize_optional_block(body: Option<Vec<Stmt>>) -> Option<Vec<Stmt>> {
     body.filter(|body| !body.is_empty())
 }
 
+fn normalize_exception_types(exception_types: Vec<Name>) -> Vec<Name> {
+    let mut normalized = Vec::new();
+    for exception_type in exception_types {
+        if !normalized.contains(&exception_type) {
+            normalized.push(exception_type);
+        }
+    }
+    normalized
+}
+
 fn normalize_catch_clauses(
     catches: Vec<crate::parser::ast::CatchClause>,
 ) -> Vec<crate::parser::ast::CatchClause> {
     let mut normalized: Vec<crate::parser::ast::CatchClause> = Vec::new();
-    for catch in catches {
+    for mut catch in catches {
+        catch.exception_types = normalize_exception_types(catch.exception_types);
         if let Some(last) = normalized.last_mut() {
             if last.variable == catch.variable && last.body == catch.body {
                 last.exception_types.extend(catch.exception_types);
+                last.exception_types = normalize_exception_types(std::mem::take(&mut last.exception_types));
                 continue;
             }
         }
@@ -7586,6 +7599,59 @@ mod tests {
         assert_eq!(
             catches[0].exception_types,
             vec![Name::unqualified("A"), Name::unqualified("B")]
+        );
+        assert_eq!(catches[0].variable.as_deref(), Some("e"));
+        assert_eq!(catches[0].body, vec![Stmt::echo(Expr::int_lit(7))]);
+    }
+
+    #[test]
+    fn test_normalize_control_flow_deduplicates_merged_catch_exception_types() {
+        let program = vec![Stmt::new(
+            StmtKind::Try {
+                try_body: vec![Stmt::new(
+                    StmtKind::ExprStmt(Expr::new(
+                        ExprKind::Throw(Box::new(Expr::new(
+                            ExprKind::NewObject {
+                                class_name: Name::unqualified("Exception"),
+                                args: Vec::new(),
+                            },
+                            Span::dummy(),
+                        ))),
+                        Span::dummy(),
+                    )),
+                    Span::dummy(),
+                )],
+                catches: vec![
+                    crate::parser::ast::CatchClause {
+                        exception_types: vec![Name::unqualified("A"), Name::unqualified("B")],
+                        variable: Some("e".into()),
+                        body: vec![Stmt::echo(Expr::int_lit(7))],
+                    },
+                    crate::parser::ast::CatchClause {
+                        exception_types: vec![Name::unqualified("B"), Name::unqualified("C")],
+                        variable: Some("e".into()),
+                        body: vec![Stmt::echo(Expr::int_lit(7))],
+                    },
+                ],
+                finally_body: None,
+            },
+            Span::dummy(),
+        )];
+
+        let pruned = normalize_control_flow(program);
+
+        assert_eq!(pruned.len(), 1);
+        let StmtKind::Try { catches, .. } = &pruned[0].kind else {
+            panic!("expected normalized try");
+        };
+        assert_eq!(catches.len(), 1);
+        assert_eq!(
+            catches[0].exception_types,
+            vec![
+                Name::unqualified("A"),
+                Name::unqualified("B"),
+                Name::unqualified("C")
+            ]
         );
         assert_eq!(catches[0].variable.as_deref(), Some("e"));
         assert_eq!(catches[0].body, vec![Stmt::echo(Expr::int_lit(7))]);

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -358,6 +358,22 @@ fn normalize_catch_clauses(
     normalized
 }
 
+fn normalize_switch_cases(cases: Vec<(Vec<Expr>, Vec<Stmt>)>) -> Vec<(Vec<Expr>, Vec<Stmt>)> {
+    let mut normalized: Vec<(Vec<Expr>, Vec<Stmt>)> = Vec::new();
+    for (patterns, body) in cases {
+        if !body.is_empty() {
+            if let Some((last_patterns, last_body)) = normalized.last_mut() {
+                if *last_body == body {
+                    last_patterns.extend(patterns);
+                    continue;
+                }
+            }
+        }
+        normalized.push((patterns, body));
+    }
+    normalized
+}
+
 fn invert_condition(condition: Expr) -> Expr {
     let span = condition.span;
     prune_expr(Expr::new(ExprKind::Not(Box::new(condition)), span))
@@ -3703,10 +3719,14 @@ fn prune_switch_stmt(
     span: crate::span::Span,
 ) -> Vec<Stmt> {
     let subject = prune_expr(subject);
-    let cases: Vec<(Vec<Expr>, Vec<Stmt>)> = cases
-        .into_iter()
-        .map(|(patterns, body)| (patterns.into_iter().map(prune_expr).collect(), prune_block(body)))
-        .collect();
+    let cases = normalize_switch_cases(
+        cases
+            .into_iter()
+            .map(|(patterns, body)| {
+                (patterns.into_iter().map(prune_expr).collect(), prune_block(body))
+            })
+            .collect(),
+    );
     let default = normalize_optional_block(default.map(prune_block));
 
     if cases.iter().all(|(_, body)| body.is_empty()) && default.is_none() {
@@ -7388,6 +7408,52 @@ mod tests {
                 assert_eq!(else_body, &Some(vec![Stmt::echo(Expr::int_lit(9))]));
             }
             other => panic!("expected normalized if, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_normalize_control_flow_merges_adjacent_identical_switch_cases() {
+        let shared_body = vec![
+            Stmt::echo(Expr::int_lit(7)),
+            Stmt::new(StmtKind::Break, Span::dummy()),
+        ];
+        let program = vec![Stmt::new(
+            StmtKind::Switch {
+                subject: Expr::var("x"),
+                cases: vec![
+                    (vec![Expr::int_lit(1)], shared_body.clone()),
+                    (vec![Expr::int_lit(2)], shared_body.clone()),
+                    (
+                        vec![Expr::int_lit(3)],
+                        vec![Stmt::echo(Expr::int_lit(9)), Stmt::new(StmtKind::Break, Span::dummy())],
+                    ),
+                ],
+                default: None,
+            },
+            Span::dummy(),
+        )];
+
+        let pruned = normalize_control_flow(program);
+
+        assert_eq!(pruned.len(), 1);
+        match &pruned[0].kind {
+            StmtKind::Switch {
+                subject,
+                cases,
+                default,
+            } => {
+                assert_eq!(*subject, Expr::var("x"));
+                assert_eq!(cases.len(), 2);
+                assert_eq!(cases[0].0, vec![Expr::int_lit(1), Expr::int_lit(2)]);
+                assert_eq!(cases[0].1, shared_body);
+                assert_eq!(cases[1].0, vec![Expr::int_lit(3)]);
+                assert_eq!(
+                    cases[1].1,
+                    vec![Stmt::echo(Expr::int_lit(9)), Stmt::new(StmtKind::Break, Span::dummy())]
+                );
+                assert!(default.is_none());
+            }
+            other => panic!("expected normalized switch, got {:?}", other),
         }
     }
 

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -22,6 +22,17 @@ pub fn propagate_constants(program: Program) -> Program {
     propagate_block(program, HashMap::new()).0
 }
 
+pub fn normalize_control_flow(program: Program) -> Program {
+    let (function_effects, static_method_effects, private_instance_method_effects) =
+        compute_program_callable_effects(&program);
+    with_callable_effects(
+        function_effects,
+        static_method_effects,
+        private_instance_method_effects,
+        || prune_block(program),
+    )
+}
+
 pub fn prune_constant_control_flow(program: Program) -> Program {
     let (function_effects, static_method_effects, private_instance_method_effects) =
         compute_program_callable_effects(&program);
@@ -42,7 +53,7 @@ pub fn eliminate_dead_code(program: Program) -> Program {
         function_effects,
         static_method_effects,
         private_instance_method_effects,
-        || prune_block(program),
+        || dce_block(program),
     )
 }
 
@@ -2542,6 +2553,21 @@ fn prune_block(body: Vec<Stmt>) -> Vec<Stmt> {
     pruned
 }
 
+fn dce_block(body: Vec<Stmt>) -> Vec<Stmt> {
+    let mut eliminated = Vec::new();
+    for stmt in body {
+        let dce_stmt = dce_stmt(stmt);
+        let stops_here = dce_stmt
+            .last()
+            .is_some_and(|stmt| !matches!(stmt_terminal_effect(stmt), TerminalEffect::FallsThrough));
+        eliminated.extend(dce_stmt);
+        if stops_here {
+            break;
+        }
+    }
+    eliminated
+}
+
 fn prune_stmt(stmt: Stmt) -> Vec<Stmt> {
     let span = stmt.span;
     match stmt.kind {
@@ -2821,6 +2847,347 @@ fn prune_stmt(stmt: Stmt) -> Vec<Stmt> {
     }
 }
 
+fn dce_stmt(stmt: Stmt) -> Vec<Stmt> {
+    let span = stmt.span;
+    match stmt.kind {
+        StmtKind::Echo(expr) => vec![Stmt {
+            kind: StmtKind::Echo(prune_expr(expr)),
+            span,
+        }],
+        StmtKind::Assign { name, value } => vec![Stmt {
+            kind: StmtKind::Assign {
+                name,
+                value: prune_expr(value),
+            },
+            span,
+        }],
+        StmtKind::TypedAssign {
+            name,
+            type_expr,
+            value,
+        } => vec![Stmt {
+            kind: StmtKind::TypedAssign {
+                name,
+                type_expr,
+                value: prune_expr(value),
+            },
+            span,
+        }],
+        StmtKind::PropertyAssign {
+            object,
+            property,
+            value,
+        } => vec![Stmt {
+            kind: StmtKind::PropertyAssign {
+                object: Box::new(prune_expr(*object)),
+                property,
+                value: prune_expr(value),
+            },
+            span,
+        }],
+        StmtKind::PropertyArrayAssign {
+            object,
+            property,
+            index,
+            value,
+        } => vec![Stmt {
+            kind: StmtKind::PropertyArrayAssign {
+                object: Box::new(prune_expr(*object)),
+                property,
+                index: prune_expr(index),
+                value: prune_expr(value),
+            },
+            span,
+        }],
+        StmtKind::PropertyArrayPush {
+            object,
+            property,
+            value,
+        } => vec![Stmt {
+            kind: StmtKind::PropertyArrayPush {
+                object: Box::new(prune_expr(*object)),
+                property,
+                value: prune_expr(value),
+            },
+            span,
+        }],
+        StmtKind::ArrayAssign { array, index, value } => vec![Stmt {
+            kind: StmtKind::ArrayAssign {
+                array,
+                index: prune_expr(index),
+                value: prune_expr(value),
+            },
+            span,
+        }],
+        StmtKind::ArrayPush { array, value } => vec![Stmt {
+            kind: StmtKind::ArrayPush {
+                array,
+                value: prune_expr(value),
+            },
+            span,
+        }],
+        StmtKind::ListUnpack { vars, value } => vec![Stmt {
+            kind: StmtKind::ListUnpack {
+                vars,
+                value: prune_expr(value),
+            },
+            span,
+        }],
+        StmtKind::StaticVar { name, init } => vec![Stmt {
+            kind: StmtKind::StaticVar {
+                name,
+                init: prune_expr(init),
+            },
+            span,
+        }],
+        StmtKind::ConstDecl { name, value } => vec![Stmt {
+            kind: StmtKind::ConstDecl {
+                name,
+                value: prune_expr(value),
+            },
+            span,
+        }],
+        StmtKind::If {
+            condition,
+            then_body,
+            elseif_clauses,
+            else_body,
+        } => vec![Stmt {
+            kind: StmtKind::If {
+                condition: prune_expr(condition),
+                then_body: dce_block(then_body),
+                elseif_clauses: elseif_clauses
+                    .into_iter()
+                    .map(|(condition, body)| (prune_expr(condition), dce_block(body)))
+                    .collect(),
+                else_body: normalize_optional_block(else_body.map(dce_block)),
+            },
+            span,
+        }],
+        StmtKind::IfDef {
+            symbol,
+            then_body,
+            else_body,
+        } => {
+            let then_body = dce_block(then_body);
+            let else_body = normalize_optional_block(else_body.map(dce_block));
+            if then_body.is_empty() && else_body.is_none() {
+                Vec::new()
+            } else {
+                vec![Stmt {
+                    kind: StmtKind::IfDef {
+                        symbol,
+                        then_body,
+                        else_body,
+                    },
+                    span,
+                }]
+            }
+        }
+        StmtKind::While { condition, body } => vec![Stmt {
+            kind: StmtKind::While {
+                condition: prune_expr(condition),
+                body: dce_block(body),
+            },
+            span,
+        }],
+        StmtKind::DoWhile { body, condition } => vec![Stmt {
+            kind: StmtKind::DoWhile {
+                body: dce_block(body),
+                condition: prune_expr(condition),
+            },
+            span,
+        }],
+        StmtKind::For {
+            init,
+            condition,
+            update,
+            body,
+        } => vec![Stmt {
+            kind: StmtKind::For {
+                init: init.and_then(|stmt| dce_stmt(*stmt).into_iter().next().map(Box::new)),
+                condition: condition.map(prune_expr),
+                update: update.and_then(|stmt| dce_stmt(*stmt).into_iter().next().map(Box::new)),
+                body: dce_block(body),
+            },
+            span,
+        }],
+        StmtKind::Foreach {
+            array,
+            key_var,
+            value_var,
+            body,
+        } => vec![Stmt {
+            kind: StmtKind::Foreach {
+                array: prune_expr(array),
+                key_var,
+                value_var,
+                body: dce_block(body),
+            },
+            span,
+        }],
+        StmtKind::Switch {
+            subject,
+            cases,
+            default,
+        } => vec![Stmt {
+            kind: StmtKind::Switch {
+                subject: prune_expr(subject),
+                cases: cases
+                    .into_iter()
+                    .map(|(patterns, body)| {
+                        (
+                            patterns.into_iter().map(prune_expr).collect(),
+                            dce_block(body),
+                        )
+                    })
+                    .collect(),
+                default: normalize_optional_block(default.map(dce_block)),
+            },
+            span,
+        }],
+        StmtKind::Try {
+            try_body,
+            catches,
+            finally_body,
+        } => vec![Stmt {
+            kind: StmtKind::Try {
+                try_body: dce_block(try_body),
+                catches: catches
+                    .into_iter()
+                    .map(|catch| crate::parser::ast::CatchClause {
+                        exception_types: catch.exception_types,
+                        variable: catch.variable,
+                        body: dce_block(catch.body),
+                    })
+                    .collect(),
+                finally_body: normalize_optional_block(finally_body.map(dce_block)),
+            },
+            span,
+        }],
+        StmtKind::NamespaceBlock { name, body } => vec![Stmt {
+            kind: StmtKind::NamespaceBlock {
+                name,
+                body: dce_block(body),
+            },
+            span,
+        }],
+        StmtKind::FunctionDecl {
+            name,
+            params,
+            variadic,
+            return_type,
+            body,
+        } => vec![Stmt {
+            kind: StmtKind::FunctionDecl {
+                name,
+                params,
+                variadic,
+                return_type,
+                body: dce_block(body),
+            },
+            span,
+        }],
+        StmtKind::Return(expr) => vec![Stmt {
+            kind: StmtKind::Return(expr.map(prune_expr)),
+            span,
+        }],
+        StmtKind::Throw(expr) => vec![Stmt {
+            kind: StmtKind::Throw(prune_expr(expr)),
+            span,
+        }],
+        StmtKind::ClassDecl {
+            name,
+            extends,
+            implements,
+            is_abstract,
+            is_readonly_class,
+            trait_uses,
+            properties,
+            methods,
+        } => {
+            let parent_name = extends.as_ref().map(|parent| parent.as_str().to_string());
+            let methods = methods
+                .into_iter()
+                .map(|method| dce_method(method, &name, parent_name.as_deref()))
+                .collect();
+            vec![Stmt {
+                kind: StmtKind::ClassDecl {
+                    name,
+                    extends,
+                    implements,
+                    is_abstract,
+                    is_readonly_class,
+                    trait_uses,
+                    properties,
+                    methods,
+                },
+                span,
+            }]
+        }
+        StmtKind::ExprStmt(expr) => {
+            let expr = prune_expr(expr);
+            if expr_has_side_effects(&expr) {
+                vec![Stmt {
+                    kind: StmtKind::ExprStmt(expr),
+                    span,
+                }]
+            } else {
+                Vec::new()
+            }
+        }
+        StmtKind::EnumDecl {
+            name,
+            backing_type,
+            cases,
+        } => vec![Stmt {
+            kind: StmtKind::EnumDecl {
+                name,
+                backing_type,
+                cases,
+            },
+            span,
+        }],
+        StmtKind::PackedClassDecl { name, fields } => vec![Stmt {
+            kind: StmtKind::PackedClassDecl { name, fields },
+            span,
+        }],
+        StmtKind::InterfaceDecl {
+            name,
+            extends,
+            methods,
+        } => vec![Stmt {
+            kind: StmtKind::InterfaceDecl {
+                name,
+                extends,
+                methods: methods
+                    .into_iter()
+                    .map(dce_method_without_context)
+                    .collect(),
+            },
+            span,
+        }],
+        StmtKind::TraitDecl {
+            name,
+            trait_uses,
+            properties,
+            methods,
+        } => vec![Stmt {
+            kind: StmtKind::TraitDecl {
+                name,
+                trait_uses,
+                properties,
+                methods: methods
+                    .into_iter()
+                    .map(dce_method_without_context)
+                    .collect(),
+            },
+            span,
+        }],
+        kind => vec![Stmt { kind, span }],
+    }
+}
+
 fn prune_if_chain(
     condition: Expr,
     then_body: Vec<Stmt>,
@@ -2927,6 +3294,24 @@ fn prune_method(
 fn prune_method_without_context(method: ClassMethod) -> ClassMethod {
     ClassMethod {
         body: with_class_effect_context(None, || prune_block(method.body)),
+        ..method
+    }
+}
+
+fn dce_method(method: ClassMethod, class_name: &str, parent_name: Option<&str>) -> ClassMethod {
+    let context = ClassEffectContext {
+        class_name: class_name.to_string(),
+        parent_name: parent_name.map(str::to_string),
+    };
+    ClassMethod {
+        body: with_class_effect_context(Some(context), || dce_block(method.body)),
+        ..method
+    }
+}
+
+fn dce_method_without_context(method: ClassMethod) -> ClassMethod {
+    ClassMethod {
+        body: with_class_effect_context(None, || dce_block(method.body)),
         ..method
     }
 }
@@ -6311,7 +6696,7 @@ mod tests {
             Span::dummy(),
         )];
 
-        let eliminated = eliminate_dead_code(program);
+        let eliminated = eliminate_dead_code(normalize_control_flow(program));
 
         let StmtKind::FunctionDecl { body, .. } = &eliminated[0].kind else {
             panic!("expected function");
@@ -6398,7 +6783,7 @@ mod tests {
     }
 
     #[test]
-    fn test_eliminate_dead_code_replaces_empty_if_with_effectful_condition_eval() {
+    fn test_normalize_control_flow_replaces_empty_if_with_effectful_condition_eval() {
         let call = Expr::new(
             ExprKind::FunctionCall {
                 name: Name::unqualified("touch"),
@@ -6416,7 +6801,7 @@ mod tests {
             Span::dummy(),
         )];
 
-        let pruned = eliminate_dead_code(program);
+        let pruned = normalize_control_flow(program);
 
         assert_eq!(
             pruned,
@@ -6425,7 +6810,7 @@ mod tests {
     }
 
     #[test]
-    fn test_eliminate_dead_code_drops_empty_ifdef_shell() {
+    fn test_normalize_control_flow_drops_empty_ifdef_shell() {
         let program = vec![Stmt::new(
             StmtKind::IfDef {
                 symbol: "DEBUG".into(),
@@ -6435,13 +6820,13 @@ mod tests {
             Span::dummy(),
         )];
 
-        let pruned = eliminate_dead_code(program);
+        let pruned = normalize_control_flow(program);
 
         assert!(pruned.is_empty());
     }
 
     #[test]
-    fn test_eliminate_dead_code_replaces_empty_switch_with_subject_eval() {
+    fn test_normalize_control_flow_replaces_empty_switch_with_subject_eval() {
         let call = Expr::new(
             ExprKind::FunctionCall {
                 name: Name::unqualified("touch"),
@@ -6458,7 +6843,7 @@ mod tests {
             Span::dummy(),
         )];
 
-        let pruned = eliminate_dead_code(program);
+        let pruned = normalize_control_flow(program);
 
         assert_eq!(
             pruned,
@@ -6467,7 +6852,7 @@ mod tests {
     }
 
     #[test]
-    fn test_eliminate_dead_code_inlines_empty_try_finally_body() {
+    fn test_normalize_control_flow_inlines_empty_try_finally_body() {
         let program = vec![Stmt::new(
             StmtKind::Try {
                 try_body: Vec::new(),
@@ -6481,13 +6866,13 @@ mod tests {
             Span::dummy(),
         )];
 
-        let pruned = eliminate_dead_code(program);
+        let pruned = normalize_control_flow(program);
 
         assert_eq!(pruned, vec![Stmt::echo(Expr::int_lit(9))]);
     }
 
     #[test]
-    fn test_eliminate_dead_code_inverts_single_live_else_branch() {
+    fn test_normalize_control_flow_inverts_single_live_else_branch() {
         let program = vec![Stmt::new(
             StmtKind::If {
                 condition: Expr::var("flag"),
@@ -6498,7 +6883,7 @@ mod tests {
             Span::dummy(),
         )];
 
-        let pruned = eliminate_dead_code(program);
+        let pruned = normalize_control_flow(program);
 
         assert_eq!(
             pruned,
@@ -6518,7 +6903,7 @@ mod tests {
     }
 
     #[test]
-    fn test_eliminate_dead_code_inlines_default_only_switch() {
+    fn test_normalize_control_flow_inlines_default_only_switch() {
         let program = vec![Stmt::new(
             StmtKind::Switch {
                 subject: Expr::var("flag"),
@@ -6528,13 +6913,13 @@ mod tests {
             Span::dummy(),
         )];
 
-        let pruned = eliminate_dead_code(program);
+        let pruned = normalize_control_flow(program);
 
         assert_eq!(pruned, vec![Stmt::echo(Expr::int_lit(9))]);
     }
 
     #[test]
-    fn test_eliminate_dead_code_nests_elseif_chain_after_empty_head() {
+    fn test_normalize_control_flow_nests_elseif_chain_after_empty_head() {
         let program = vec![Stmt::new(
             StmtKind::If {
                 condition: Expr::var("a"),
@@ -6548,7 +6933,7 @@ mod tests {
             Span::dummy(),
         )];
 
-        let pruned = eliminate_dead_code(program);
+        let pruned = normalize_control_flow(program);
 
         assert_eq!(
             pruned,
@@ -6576,7 +6961,7 @@ mod tests {
     }
 
     #[test]
-    fn test_eliminate_dead_code_materializes_constant_switch_match() {
+    fn test_normalize_control_flow_materializes_constant_switch_match() {
         let program = vec![Stmt::new(
             StmtKind::Switch {
                 subject: Expr::int_lit(2),
@@ -6595,13 +6980,13 @@ mod tests {
             Span::dummy(),
         )];
 
-        let pruned = eliminate_dead_code(program);
+        let pruned = normalize_control_flow(program);
 
         assert_eq!(pruned, vec![Stmt::echo(Expr::int_lit(7))]);
     }
 
     #[test]
-    fn test_eliminate_dead_code_materializes_constant_switch_fallthrough() {
+    fn test_normalize_control_flow_materializes_constant_switch_fallthrough() {
         let program = vec![Stmt::new(
             StmtKind::Switch {
                 subject: Expr::int_lit(1),
@@ -6617,13 +7002,13 @@ mod tests {
             Span::dummy(),
         )];
 
-        let pruned = eliminate_dead_code(program);
+        let pruned = normalize_control_flow(program);
 
         assert_eq!(pruned, vec![Stmt::echo(Expr::int_lit(7))]);
     }
 
     #[test]
-    fn test_eliminate_dead_code_materializes_constant_switch_default() {
+    fn test_normalize_control_flow_materializes_constant_switch_default() {
         let program = vec![Stmt::new(
             StmtKind::Switch {
                 subject: Expr::int_lit(3),
@@ -6636,13 +7021,13 @@ mod tests {
             Span::dummy(),
         )];
 
-        let pruned = eliminate_dead_code(program);
+        let pruned = normalize_control_flow(program);
 
         assert_eq!(pruned, vec![Stmt::echo(Expr::int_lit(9))]);
     }
 
     #[test]
-    fn test_eliminate_dead_code_inlines_non_throwing_try_catch() {
+    fn test_normalize_control_flow_inlines_non_throwing_try_catch() {
         let program = vec![Stmt::new(
             StmtKind::Try {
                 try_body: vec![Stmt::echo(Expr::int_lit(7))],
@@ -6656,13 +7041,13 @@ mod tests {
             Span::dummy(),
         )];
 
-        let pruned = eliminate_dead_code(program);
+        let pruned = normalize_control_flow(program);
 
         assert_eq!(pruned, vec![Stmt::echo(Expr::int_lit(7))]);
     }
 
     #[test]
-    fn test_eliminate_dead_code_inlines_non_throwing_try_finally_fallthrough() {
+    fn test_normalize_control_flow_inlines_non_throwing_try_finally_fallthrough() {
         let program = vec![Stmt::new(
             StmtKind::Try {
                 try_body: vec![Stmt::echo(Expr::int_lit(7))],
@@ -6672,13 +7057,13 @@ mod tests {
             Span::dummy(),
         )];
 
-        let pruned = eliminate_dead_code(program);
+        let pruned = normalize_control_flow(program);
 
         assert_eq!(pruned, vec![Stmt::echo(Expr::int_lit(7)), Stmt::echo(Expr::int_lit(9))]);
     }
 
     #[test]
-    fn test_eliminate_dead_code_keeps_non_throwing_try_finally_with_return() {
+    fn test_normalize_control_flow_keeps_non_throwing_try_finally_with_return() {
         let program = vec![Stmt::new(
             StmtKind::Try {
                 try_body: vec![Stmt::new(
@@ -6691,14 +7076,14 @@ mod tests {
             Span::dummy(),
         )];
 
-        let pruned = eliminate_dead_code(program);
+        let pruned = normalize_control_flow(program);
 
         assert_eq!(pruned.len(), 1);
         assert!(matches!(pruned[0].kind, StmtKind::Try { .. }));
     }
 
     #[test]
-    fn test_eliminate_dead_code_hoists_non_throwing_try_prefix() {
+    fn test_normalize_control_flow_hoists_non_throwing_try_prefix() {
         let program = vec![Stmt::new(
             StmtKind::Try {
                 try_body: vec![
@@ -6715,7 +7100,7 @@ mod tests {
             Span::dummy(),
         )];
 
-        let pruned = eliminate_dead_code(program);
+        let pruned = normalize_control_flow(program);
 
         assert_eq!(pruned.len(), 2);
         assert_eq!(pruned[0], Stmt::echo(Expr::int_lit(7)));
@@ -6723,7 +7108,7 @@ mod tests {
     }
 
     #[test]
-    fn test_eliminate_dead_code_flattens_nested_single_path_ifs() {
+    fn test_normalize_control_flow_flattens_nested_single_path_ifs() {
         let program = vec![Stmt::new(
             StmtKind::If {
                 condition: Expr::var("a"),
@@ -6742,7 +7127,7 @@ mod tests {
             Span::dummy(),
         )];
 
-        let pruned = eliminate_dead_code(program);
+        let pruned = normalize_control_flow(program);
 
         assert_eq!(pruned.len(), 1);
         match &pruned[0].kind {

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -352,12 +352,16 @@ fn build_if_chain_body(
     else_body: Option<Vec<Stmt>>,
 ) -> Vec<Stmt> {
     if let Some(((condition, then_body), rest)) = elseif_clauses.split_first() {
+        let nested_else_body = normalize_optional_block(Some(build_if_chain_body(
+            rest.to_vec(),
+            else_body,
+        )));
         vec![Stmt::new(
             StmtKind::If {
                 condition: condition.clone(),
                 then_body: then_body.clone(),
-                elseif_clauses: rest.to_vec(),
-                else_body,
+                elseif_clauses: Vec::new(),
+                else_body: nested_else_body,
             },
             condition.span,
         )]
@@ -3222,11 +3226,14 @@ fn prune_if_chain(
                 }
             }
 
+            let canonical_else_body =
+                normalize_optional_block(Some(build_if_chain_body(kept_elseifs, kept_else)));
+
             vec![build_if_stmt(
                 condition,
                 then_body,
-                kept_elseifs,
-                kept_else,
+                Vec::new(),
+                canonical_else_body,
                 span,
             )]
         }
@@ -3247,11 +3254,13 @@ fn prune_else_if_chain(
                 let span = condition.span;
                 let remaining: Vec<_> = clauses.collect();
                 let (kept_elseifs, kept_else) = prune_remaining_elseif_chain(remaining, else_body);
+                let canonical_else_body =
+                    normalize_optional_block(Some(build_if_chain_body(kept_elseifs, kept_else)));
                 return vec![build_if_stmt(
                     condition,
                     prune_block(body),
-                    kept_elseifs,
-                    kept_else,
+                    Vec::new(),
+                    canonical_else_body,
                     span,
                 )];
             }
@@ -6958,6 +6967,54 @@ mod tests {
                 Span::dummy(),
             )]
         );
+    }
+
+    #[test]
+    fn test_normalize_control_flow_canonicalizes_elseif_chain_into_nested_else_if() {
+        let program = vec![Stmt::new(
+            StmtKind::If {
+                condition: Expr::var("a"),
+                then_body: vec![Stmt::echo(Expr::int_lit(1))],
+                elseif_clauses: vec![(
+                    Expr::var("b"),
+                    vec![Stmt::echo(Expr::int_lit(2))],
+                )],
+                else_body: Some(vec![Stmt::echo(Expr::int_lit(3))]),
+            },
+            Span::dummy(),
+        )];
+
+        let pruned = normalize_control_flow(program);
+
+        assert_eq!(pruned.len(), 1);
+        let StmtKind::If {
+            condition,
+            then_body,
+            elseif_clauses,
+            else_body,
+        } = &pruned[0].kind
+        else {
+            panic!("expected if");
+        };
+        assert_eq!(*condition, Expr::var("a"));
+        assert_eq!(then_body, &vec![Stmt::echo(Expr::int_lit(1))]);
+        assert!(elseif_clauses.is_empty());
+
+        let else_body = else_body.as_ref().expect("expected nested else body");
+        assert_eq!(else_body.len(), 1);
+        let StmtKind::If {
+            condition,
+            then_body,
+            elseif_clauses,
+            else_body,
+        } = &else_body[0].kind
+        else {
+            panic!("expected nested if");
+        };
+        assert_eq!(*condition, Expr::var("b"));
+        assert_eq!(then_body, &vec![Stmt::echo(Expr::int_lit(2))]);
+        assert!(elseif_clauses.is_empty());
+        assert_eq!(else_body, &Some(vec![Stmt::echo(Expr::int_lit(3))]));
     }
 
     #[test]

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -2839,6 +2839,25 @@ fn prune_stmt(stmt: Stmt) -> Vec<Stmt> {
                 })
                 .collect());
             let finally_body = normalize_optional_block(finally_body.map(prune_block));
+
+            if catches.is_empty() && finally_body.is_some() && try_body.len() == 1 {
+                if let StmtKind::Try {
+                    try_body: inner_try_body,
+                    catches: inner_catches,
+                    finally_body: None,
+                } = &try_body[0].kind
+                {
+                    return vec![Stmt {
+                        kind: StmtKind::Try {
+                            try_body: inner_try_body.clone(),
+                            catches: inner_catches.clone(),
+                            finally_body,
+                        },
+                        span,
+                    }];
+                }
+            }
+
             let (mut hoisted_prefix, try_body) = split_hoistable_try_prefix(try_body);
 
             let mut remaining = if try_body.is_empty() {
@@ -7760,6 +7779,77 @@ mod tests {
 
         assert_eq!(pruned.len(), 1);
         assert!(matches!(pruned[0].kind, StmtKind::Try { .. }));
+    }
+
+    #[test]
+    fn test_normalize_control_flow_folds_outer_finally_into_single_inner_try() {
+        let program = vec![Stmt::new(
+            StmtKind::Try {
+                try_body: vec![Stmt::new(
+                    StmtKind::Try {
+                        try_body: vec![Stmt::new(
+                            StmtKind::ExprStmt(Expr::new(
+                                ExprKind::Throw(Box::new(Expr::new(
+                                    ExprKind::NewObject {
+                                        class_name: Name::unqualified("A"),
+                                        args: Vec::new(),
+                                    },
+                                    Span::dummy(),
+                                ))),
+                                Span::dummy(),
+                            )),
+                            Span::dummy(),
+                        )],
+                        catches: vec![crate::parser::ast::CatchClause {
+                            exception_types: vec![Name::unqualified("A")],
+                            variable: Some("e".into()),
+                            body: vec![Stmt::echo(Expr::int_lit(7))],
+                        }],
+                        finally_body: None,
+                    },
+                    Span::dummy(),
+                )],
+                catches: Vec::new(),
+                finally_body: Some(vec![Stmt::echo(Expr::int_lit(9))]),
+            },
+            Span::dummy(),
+        )];
+
+        let pruned = normalize_control_flow(program);
+
+        assert_eq!(pruned.len(), 1);
+        let StmtKind::Try {
+            try_body,
+            catches,
+            finally_body,
+        } = &pruned[0].kind
+        else {
+            panic!("expected normalized try");
+        };
+        assert_eq!(
+            try_body,
+            &vec![Stmt::new(
+                StmtKind::ExprStmt(Expr::new(
+                    ExprKind::Throw(Box::new(Expr::new(
+                        ExprKind::NewObject {
+                            class_name: Name::unqualified("A"),
+                            args: Vec::new(),
+                        },
+                        Span::dummy(),
+                    ))),
+                    Span::dummy(),
+                )),
+                Span::dummy(),
+            )]
+        );
+        assert_eq!(catches.len(), 1);
+        assert_eq!(
+            catches[0].exception_types,
+            vec![Name::unqualified("A")]
+        );
+        assert_eq!(catches[0].variable.as_deref(), Some("e"));
+        assert_eq!(catches[0].body, vec![Stmt::echo(Expr::int_lit(7))]);
+        assert_eq!(finally_body, &Some(vec![Stmt::echo(Expr::int_lit(9))]));
     }
 
     #[test]

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -3393,6 +3393,12 @@ fn prune_if_chain(
             let canonical_else_body =
                 normalize_optional_block(Some(build_if_chain_body(kept_elseifs, kept_else)));
 
+            if canonical_else_body.as_ref() == Some(&then_body) {
+                let mut stmts = expr_to_effect_stmt(condition);
+                stmts.extend(then_body);
+                return stmts;
+            }
+
             vec![build_if_stmt(
                 condition,
                 then_body,
@@ -7924,5 +7930,43 @@ mod tests {
             }
             other => panic!("expected flattened if, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_normalize_control_flow_collapses_identical_if_branches_to_condition_effects_plus_body() {
+        let program = vec![Stmt::new(
+            StmtKind::If {
+                condition: Expr::new(
+                    ExprKind::FunctionCall {
+                        name: Name::unqualified("tick"),
+                        args: Vec::new(),
+                    },
+                    Span::dummy(),
+                ),
+                then_body: vec![Stmt::echo(Expr::int_lit(7))],
+                elseif_clauses: Vec::new(),
+                else_body: Some(vec![Stmt::echo(Expr::int_lit(7))]),
+            },
+            Span::dummy(),
+        )];
+
+        let pruned = normalize_control_flow(program);
+
+        assert_eq!(
+            pruned,
+            vec![
+                Stmt::new(
+                    StmtKind::ExprStmt(Expr::new(
+                        ExprKind::FunctionCall {
+                            name: Name::unqualified("tick"),
+                            args: Vec::new(),
+                        },
+                        Span::dummy(),
+                    )),
+                    Span::dummy(),
+                ),
+                Stmt::echo(Expr::int_lit(7))
+            ]
+        );
     }
 }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -1843,33 +1843,26 @@ fn build_if_stmt(
                 } = &else_body_ref[0].kind
                 {
                     if inner_elseifs.is_empty() && *inner_then_body == then_body {
-                        return Stmt {
-                            kind: StmtKind::If {
-                                condition: combine_if_chain_conditions(
-                                    condition,
-                                    inner_condition.clone(),
-                                ),
-                                then_body,
-                                elseif_clauses: Vec::new(),
-                                else_body: inner_else.clone(),
-                            },
+                        return build_if_stmt(
+                            combine_if_chain_conditions(condition, inner_condition.clone()),
+                            then_body,
+                            Vec::new(),
+                            inner_else.clone(),
                             span,
-                        };
+                        );
                     }
 
                     if inner_elseifs.is_empty() && inner_else.as_ref() == Some(&then_body) {
-                        return Stmt {
-                            kind: StmtKind::If {
-                                condition: combine_if_conditions(
-                                    invert_condition(condition),
-                                    inner_condition.clone(),
-                                ),
-                                then_body: inner_then_body.clone(),
-                                elseif_clauses: Vec::new(),
-                                else_body: Some(then_body),
-                            },
+                        return build_if_stmt(
+                            combine_if_conditions(
+                                invert_condition(condition),
+                                inner_condition.clone(),
+                            ),
+                            inner_then_body.clone(),
+                            Vec::new(),
+                            Some(then_body),
                             span,
-                        };
+                        );
                     }
                 }
             }
@@ -7230,6 +7223,60 @@ mod tests {
                 assert_eq!(then_body, &vec![Stmt::echo(Expr::int_lit(7))]);
                 assert!(elseif_clauses.is_empty());
                 assert_eq!(else_body, &Some(shared_tail));
+            }
+            other => panic!("expected normalized if, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_normalize_control_flow_recursively_merges_longer_if_chain_heads() {
+        let shared_body = vec![Stmt::echo(Expr::int_lit(7))];
+        let program = vec![Stmt::new(
+            StmtKind::If {
+                condition: Expr::var("a"),
+                then_body: shared_body.clone(),
+                elseif_clauses: Vec::new(),
+                else_body: Some(vec![Stmt::new(
+                    StmtKind::If {
+                        condition: Expr::var("b"),
+                        then_body: shared_body.clone(),
+                        elseif_clauses: Vec::new(),
+                        else_body: Some(vec![Stmt::new(
+                            StmtKind::If {
+                                condition: Expr::var("c"),
+                                then_body: shared_body.clone(),
+                                elseif_clauses: Vec::new(),
+                                else_body: Some(vec![Stmt::echo(Expr::int_lit(9))]),
+                            },
+                            Span::dummy(),
+                        )]),
+                    },
+                    Span::dummy(),
+                )]),
+            },
+            Span::dummy(),
+        )];
+
+        let pruned = normalize_control_flow(program);
+
+        assert_eq!(pruned.len(), 1);
+        match &pruned[0].kind {
+            StmtKind::If {
+                condition,
+                then_body,
+                elseif_clauses,
+                else_body,
+            } => {
+                assert_eq!(
+                    *condition,
+                    combine_if_chain_conditions(
+                        Expr::var("a"),
+                        combine_if_chain_conditions(Expr::var("b"), Expr::var("c")),
+                    )
+                );
+                assert_eq!(then_body, &shared_body);
+                assert!(elseif_clauses.is_empty());
+                assert_eq!(else_body, &Some(vec![Stmt::echo(Expr::int_lit(9))]));
             }
             other => panic!("expected normalized if, got {:?}", other),
         }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -342,6 +342,22 @@ fn normalize_optional_block(body: Option<Vec<Stmt>>) -> Option<Vec<Stmt>> {
     body.filter(|body| !body.is_empty())
 }
 
+fn normalize_catch_clauses(
+    catches: Vec<crate::parser::ast::CatchClause>,
+) -> Vec<crate::parser::ast::CatchClause> {
+    let mut normalized: Vec<crate::parser::ast::CatchClause> = Vec::new();
+    for catch in catches {
+        if let Some(last) = normalized.last_mut() {
+            if last.variable == catch.variable && last.body == catch.body {
+                last.exception_types.extend(catch.exception_types);
+                continue;
+            }
+        }
+        normalized.push(catch);
+    }
+    normalized
+}
+
 fn invert_condition(condition: Expr) -> Expr {
     let span = condition.span;
     prune_expr(Expr::new(ExprKind::Not(Box::new(condition)), span))
@@ -2718,14 +2734,14 @@ fn prune_stmt(stmt: Stmt) -> Vec<Stmt> {
             finally_body,
         } => {
             let try_body = prune_block(try_body);
-            let catches: Vec<_> = catches
+            let catches = normalize_catch_clauses(catches
                 .into_iter()
                 .map(|catch| crate::parser::ast::CatchClause {
                     exception_types: catch.exception_types,
                     variable: catch.variable,
                     body: prune_block(catch.body),
                 })
-                .collect();
+                .collect());
             let finally_body = normalize_optional_block(finally_body.map(prune_block));
             let (mut hoisted_prefix, try_body) = split_hoistable_try_prefix(try_body);
 
@@ -7167,6 +7183,55 @@ mod tests {
             }
             other => panic!("expected normalized if, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_normalize_control_flow_merges_adjacent_identical_catches() {
+        let program = vec![Stmt::new(
+            StmtKind::Try {
+                try_body: vec![Stmt::new(
+                    StmtKind::ExprStmt(Expr::new(
+                        ExprKind::Throw(Box::new(Expr::new(
+                            ExprKind::NewObject {
+                                class_name: Name::unqualified("Exception"),
+                                args: Vec::new(),
+                            },
+                            Span::dummy(),
+                        ))),
+                        Span::dummy(),
+                    )),
+                    Span::dummy(),
+                )],
+                catches: vec![
+                    crate::parser::ast::CatchClause {
+                        exception_types: vec![Name::unqualified("A")],
+                        variable: Some("e".into()),
+                        body: vec![Stmt::echo(Expr::int_lit(7))],
+                    },
+                    crate::parser::ast::CatchClause {
+                        exception_types: vec![Name::unqualified("B")],
+                        variable: Some("e".into()),
+                        body: vec![Stmt::echo(Expr::int_lit(7))],
+                    },
+                ],
+                finally_body: None,
+            },
+            Span::dummy(),
+        )];
+
+        let pruned = normalize_control_flow(program);
+
+        assert_eq!(pruned.len(), 1);
+        let StmtKind::Try { catches, .. } = &pruned[0].kind else {
+            panic!("expected normalized try");
+        };
+        assert_eq!(catches.len(), 1);
+        assert_eq!(
+            catches[0].exception_types,
+            vec![Name::unqualified("A"), Name::unqualified("B")]
+        );
+        assert_eq!(catches[0].variable.as_deref(), Some("e"));
+        assert_eq!(catches[0].body, vec![Stmt::echo(Expr::int_lit(7))]);
     }
 
     #[test]

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -350,6 +350,7 @@ fn normalize_exception_types(exception_types: Vec<Name>) -> Vec<Name> {
             normalized.push(exception_type);
         }
     }
+    normalized.sort_by(|left, right| left.as_str().cmp(right.as_str()));
     normalized
 }
 
@@ -7655,6 +7656,54 @@ mod tests {
         );
         assert_eq!(catches[0].variable.as_deref(), Some("e"));
         assert_eq!(catches[0].body, vec![Stmt::echo(Expr::int_lit(7))]);
+    }
+
+    #[test]
+    fn test_normalize_control_flow_sorts_catch_exception_types() {
+        let program = vec![Stmt::new(
+            StmtKind::Try {
+                try_body: vec![Stmt::new(
+                    StmtKind::ExprStmt(Expr::new(
+                        ExprKind::Throw(Box::new(Expr::new(
+                            ExprKind::NewObject {
+                                class_name: Name::unqualified("Exception"),
+                                args: Vec::new(),
+                            },
+                            Span::dummy(),
+                        ))),
+                        Span::dummy(),
+                    )),
+                    Span::dummy(),
+                )],
+                catches: vec![crate::parser::ast::CatchClause {
+                    exception_types: vec![
+                        Name::unqualified("Zed"),
+                        Name::unqualified("Alpha"),
+                        Name::unqualified("Mid"),
+                    ],
+                    variable: Some("e".into()),
+                    body: vec![Stmt::echo(Expr::int_lit(7))],
+                }],
+                finally_body: None,
+            },
+            Span::dummy(),
+        )];
+
+        let pruned = normalize_control_flow(program);
+
+        assert_eq!(pruned.len(), 1);
+        let StmtKind::Try { catches, .. } = &pruned[0].kind else {
+            panic!("expected normalized try");
+        };
+        assert_eq!(catches.len(), 1);
+        assert_eq!(
+            catches[0].exception_types,
+            vec![
+                Name::unqualified("Alpha"),
+                Name::unqualified("Mid"),
+                Name::unqualified("Zed")
+            ]
+        );
     }
 
     #[test]

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -360,7 +360,19 @@ fn normalize_catch_clauses(
 
 fn normalize_switch_cases(cases: Vec<(Vec<Expr>, Vec<Stmt>)>) -> Vec<(Vec<Expr>, Vec<Stmt>)> {
     let mut normalized: Vec<(Vec<Expr>, Vec<Stmt>)> = Vec::new();
-    for (patterns, body) in cases {
+    let mut pending_fallthrough_patterns: Vec<Expr> = Vec::new();
+    for (mut patterns, body) in cases {
+        if body.is_empty() {
+            pending_fallthrough_patterns.extend(patterns);
+            continue;
+        }
+
+        if !pending_fallthrough_patterns.is_empty() {
+            pending_fallthrough_patterns.append(&mut patterns);
+            patterns = pending_fallthrough_patterns;
+            pending_fallthrough_patterns = Vec::new();
+        }
+
         if !body.is_empty() {
             if let Some((last_patterns, last_body)) = normalized.last_mut() {
                 if *last_body == body {
@@ -371,6 +383,11 @@ fn normalize_switch_cases(cases: Vec<(Vec<Expr>, Vec<Stmt>)>) -> Vec<(Vec<Expr>,
         }
         normalized.push((patterns, body));
     }
+
+    if !pending_fallthrough_patterns.is_empty() {
+        normalized.push((pending_fallthrough_patterns, Vec::new()));
+    }
+
     normalized
 }
 
@@ -7454,6 +7471,74 @@ mod tests {
                 assert!(default.is_none());
             }
             other => panic!("expected normalized switch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_normalize_control_flow_merges_fallthrough_switch_labels_into_next_case() {
+        let shared_body = vec![
+            Stmt::echo(Expr::int_lit(7)),
+            Stmt::new(StmtKind::Break, Span::dummy()),
+        ];
+        let program = vec![Stmt::new(
+            StmtKind::Switch {
+                subject: Expr::var("x"),
+                cases: vec![
+                    (vec![Expr::int_lit(1)], Vec::new()),
+                    (vec![Expr::int_lit(2)], Vec::new()),
+                    (vec![Expr::int_lit(3)], shared_body.clone()),
+                ],
+                default: None,
+            },
+            Span::dummy(),
+        )];
+
+        let pruned = normalize_control_flow(program);
+
+        assert_eq!(pruned.len(), 1);
+        match &pruned[0].kind {
+            StmtKind::If {
+                condition,
+                then_body,
+                elseif_clauses,
+                else_body,
+            } => {
+                assert_eq!(
+                    *condition,
+                    combine_if_chain_conditions(
+                        combine_if_chain_conditions(
+                            Expr::new(
+                                ExprKind::BinaryOp {
+                                    left: Box::new(Expr::var("x")),
+                                    op: BinOp::Eq,
+                                    right: Box::new(Expr::int_lit(1)),
+                                },
+                                Span::dummy(),
+                            ),
+                            Expr::new(
+                                ExprKind::BinaryOp {
+                                    left: Box::new(Expr::var("x")),
+                                    op: BinOp::Eq,
+                                    right: Box::new(Expr::int_lit(2)),
+                                },
+                                Span::dummy(),
+                            ),
+                        ),
+                        Expr::new(
+                            ExprKind::BinaryOp {
+                                left: Box::new(Expr::var("x")),
+                                op: BinOp::Eq,
+                                right: Box::new(Expr::int_lit(3)),
+                            },
+                            Span::dummy(),
+                        ),
+                    )
+                );
+                assert_eq!(then_body, &vec![Stmt::echo(Expr::int_lit(7))]);
+                assert!(elseif_clauses.is_empty());
+                assert!(else_body.is_none());
+            }
+            other => panic!("expected normalized if, got {:?}", other),
         }
     }
 

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -432,6 +432,39 @@ fn combine_if_conditions(left: Expr, right: Expr) -> Expr {
     ))
 }
 
+fn build_switch_match_condition(subject: &Expr, patterns: &[Expr]) -> Option<Expr> {
+    if patterns.is_empty() {
+        return None;
+    }
+
+    if patterns.len() > 1 && expr_is_observable(subject) {
+        return None;
+    }
+
+    let mut comparisons = patterns.iter().cloned().map(|pattern| {
+        Expr::new(
+            ExprKind::BinaryOp {
+                left: Box::new(subject.clone()),
+                op: BinOp::Eq,
+                right: Box::new(pattern),
+            },
+            subject.span,
+        )
+    });
+    let mut condition = comparisons.next()?;
+    for comparison in comparisons {
+        condition = Expr::new(
+            ExprKind::BinaryOp {
+                left: Box::new(condition),
+                op: BinOp::Or,
+                right: Box::new(comparison),
+            },
+            subject.span,
+        );
+    }
+    Some(prune_expr(condition))
+}
+
 fn propagate_block(body: Vec<Stmt>, mut env: ConstantEnv) -> (Vec<Stmt>, ConstantEnv) {
     let mut propagated = Vec::new();
     for stmt in body {
@@ -3624,6 +3657,16 @@ fn prune_switch_stmt(
     }
 
     let Some(subject_value) = scalar_value(&subject) else {
+        if cases.len() == 1 {
+            let (patterns, _) = &cases[0];
+            if let Some(condition) = build_switch_match_condition(&subject, patterns) {
+                let then_body = materialize_switch_execution(&cases, &default, Some(0));
+                let else_body =
+                    normalize_optional_block(Some(materialize_switch_execution(&cases, &default, None)));
+                return prune_if_chain(condition, then_body, Vec::new(), else_body);
+            }
+        }
+
         return vec![Stmt {
             kind: StmtKind::Switch {
                 subject,
@@ -6582,8 +6625,8 @@ mod tests {
             panic!("expected function");
         };
         assert_eq!(body.len(), 1);
-        let StmtKind::Switch { .. } = &body[0].kind else {
-            panic!("expected switch");
+        let StmtKind::If { .. } = &body[0].kind else {
+            panic!("expected normalized if");
         };
     }
 
@@ -7081,6 +7124,49 @@ mod tests {
         let pruned = normalize_control_flow(program);
 
         assert_eq!(pruned, vec![Stmt::echo(Expr::int_lit(9))]);
+    }
+
+    #[test]
+    fn test_normalize_control_flow_rewrites_single_case_switch_to_if() {
+        let program = vec![Stmt::new(
+            StmtKind::Switch {
+                subject: Expr::var("x"),
+                cases: vec![(
+                    vec![Expr::int_lit(1)],
+                    vec![Stmt::echo(Expr::int_lit(7)), Stmt::new(StmtKind::Break, Span::dummy())],
+                )],
+                default: Some(vec![Stmt::echo(Expr::int_lit(9))]),
+            },
+            Span::dummy(),
+        )];
+
+        let pruned = normalize_control_flow(program);
+
+        assert_eq!(pruned.len(), 1);
+        match &pruned[0].kind {
+            StmtKind::If {
+                condition,
+                then_body,
+                elseif_clauses,
+                else_body,
+            } => {
+                assert!(elseif_clauses.is_empty());
+                assert_eq!(
+                    *condition,
+                    Expr::new(
+                        ExprKind::BinaryOp {
+                            left: Box::new(Expr::var("x")),
+                            op: BinOp::Eq,
+                            right: Box::new(Expr::int_lit(1)),
+                        },
+                        Span::dummy(),
+                    )
+                );
+                assert_eq!(then_body, &vec![Stmt::echo(Expr::int_lit(7))]);
+                assert_eq!(else_body, &Some(vec![Stmt::echo(Expr::int_lit(9))]));
+            }
+            other => panic!("expected normalized if, got {:?}", other),
+        }
     }
 
     #[test]

--- a/tests/codegen/cli.rs
+++ b/tests/codegen/cli.rs
@@ -12,10 +12,9 @@ echo "ok";
     )
     .unwrap();
 
-    let output = Command::new(elephc_cli_bin())
+    let output = elephc_cli_command(&dir)
         .arg("--check")
         .arg(&php_path)
-        .current_dir(&dir)
         .output()
         .expect("failed to run elephc CLI with --check");
 
@@ -57,10 +56,9 @@ echo "ok";
     )
     .unwrap();
 
-    let output = Command::new(elephc_cli_bin())
+    let output = elephc_cli_command(&dir)
         .arg("--emit-asm")
         .arg(&php_path)
-        .current_dir(&dir)
         .output()
         .expect("failed to run elephc CLI with --emit-asm");
 
@@ -100,11 +98,10 @@ fn test_cli_rejects_emit_asm_and_check_together() {
     let php_path = dir.join("main.php");
     fs::write(&php_path, "<?php echo 1;").unwrap();
 
-    let output = Command::new(elephc_cli_bin())
+    let output = elephc_cli_command(&dir)
         .arg("--emit-asm")
         .arg("--check")
         .arg(&php_path)
-        .current_dir(&dir)
         .output()
         .expect("failed to run elephc CLI with conflicting flags");
 
@@ -127,11 +124,10 @@ fn test_cli_timings_reports_check_phases() {
     let php_path = dir.join("main.php");
     fs::write(&php_path, "<?php echo 1;").unwrap();
 
-    let output = Command::new(elephc_cli_bin())
+    let output = elephc_cli_command(&dir)
         .arg("--check")
         .arg("--timings")
         .arg(&php_path)
-        .current_dir(&dir)
         .output()
         .expect("failed to run elephc CLI with --timings --check");
 
@@ -157,10 +153,9 @@ fn test_cli_timings_reports_assemble_and_link() {
     let php_path = dir.join("main.php");
     fs::write(&php_path, "<?php echo 1;").unwrap();
 
-    let output = Command::new(elephc_cli_bin())
+    let output = elephc_cli_command(&dir)
         .arg("--timings")
         .arg(&php_path)
-        .current_dir(&dir)
         .output()
         .expect("failed to run elephc CLI with --timings");
 
@@ -251,11 +246,10 @@ echo 1;
     )
     .unwrap();
 
-    let output = Command::new(elephc_cli_bin())
+    let output = elephc_cli_command(&dir)
         .arg("--emit-asm")
         .arg("--source-map")
         .arg(&php_path)
-        .current_dir(&dir)
         .output()
         .expect("failed to run elephc CLI with --source-map");
 

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -1550,6 +1550,30 @@ switch (step("s", 1)) {
 }
 
 #[test]
+fn test_dead_code_elimination_merges_identical_adjacent_switch_cases() {
+    let out = compile_and_run(
+        r#"<?php
+function step($label, $ret) {
+    echo $label;
+    return $ret;
+}
+switch (step("s", 2)) {
+    case 1:
+        echo "A";
+        break;
+    case 2:
+        echo "A";
+        break;
+    default:
+        echo "D";
+}
+"#,
+    );
+
+    assert_eq!(out, "sA");
+}
+
+#[test]
 fn test_dead_code_elimination_merges_identical_adjacent_catches() {
     let dir = make_cli_test_dir("elephc_dead_code_elimination_merge_identical_catches");
     let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -1635,6 +1635,48 @@ try {
 }
 
 #[test]
+fn test_dead_code_elimination_deduplicates_merged_catch_types() {
+    let dir = make_cli_test_dir("elephc_dead_code_elimination_dedup_catch_types");
+    let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(
+        r#"<?php
+class A extends Exception {}
+class B extends Exception {}
+class C extends Exception {}
+function boom($flag) {
+    if ($flag === 1) {
+        throw new A("a");
+    }
+    if ($flag === 2) {
+        throw new B("b");
+    }
+    throw new C("c");
+}
+try {
+    boom($argc);
+} catch (A | B $e) {
+    echo pow(2, 3);
+} catch (B | C $e) {
+    echo pow(2, 3);
+}
+"#,
+        &dir,
+        8_388_608,
+        false,
+        false,
+    );
+    let out = assemble_and_run(
+        &user_asm,
+        get_runtime_obj(),
+        &dir,
+        &required_libraries,
+        &default_link_paths(),
+        &[],
+    );
+
+    assert_eq!(out, "8");
+}
+
+#[test]
 fn test_dead_code_elimination_materializes_constant_switch_match() {
     let dir = make_cli_test_dir("elephc_dead_code_elimination_switch_match");
     let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -1704,6 +1704,29 @@ try {
 }
 
 #[test]
+fn test_dead_code_elimination_folds_outer_finally_into_single_inner_try() {
+    let out = compile_and_run(
+        r#"<?php
+class A extends Exception {}
+function boom() {
+    throw new A("a");
+}
+try {
+    try {
+        boom();
+    } catch (A $e) {
+        echo 7;
+    }
+} finally {
+    echo 9;
+}
+"#,
+    );
+
+    assert_eq!(out, "79");
+}
+
+#[test]
 fn test_dead_code_elimination_materializes_constant_switch_match() {
     let dir = make_cli_test_dir("elephc_dead_code_elimination_switch_match");
     let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -1455,6 +1455,39 @@ if (step("a", true)) {
 }
 
 #[test]
+fn test_dead_code_elimination_merges_identical_if_chain_tail_with_short_circuit() {
+    let out = compile_and_run(
+        r#"<?php
+function step($label, $ret) {
+    echo $label;
+    return $ret;
+}
+if (step("a", true)) {
+    echo "X";
+} else {
+    if (step("b", true)) {
+        echo "Y";
+    } else {
+        echo "X";
+    }
+}
+echo "|";
+if (step("c", false)) {
+    echo "X";
+} else {
+    if (step("d", true)) {
+        echo "Y";
+    } else {
+        echo "X";
+    }
+}
+"#,
+    );
+
+    assert_eq!(out, "aX|cdY");
+}
+
+#[test]
 fn test_dead_code_elimination_normalizes_single_case_switch_with_effectful_subject() {
     let out = compile_and_run(
         r#"<?php

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -1453,6 +1453,44 @@ switch (step("s", 1)) {
 }
 
 #[test]
+fn test_dead_code_elimination_merges_identical_adjacent_catches() {
+    let dir = make_cli_test_dir("elephc_dead_code_elimination_merge_identical_catches");
+    let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(
+        r#"<?php
+class A extends Exception {}
+class B extends Exception {}
+function boom($flag) {
+    if ($flag) {
+        throw new A("a");
+    }
+    throw new B("b");
+}
+try {
+    boom($argc > 1);
+} catch (A $e) {
+    echo pow($argc, 3);
+} catch (B $e) {
+    echo pow($argc, 3);
+}
+"#,
+        &dir,
+        8_388_608,
+        false,
+        false,
+    );
+    let out = assemble_and_run(
+        &user_asm,
+        get_runtime_obj(),
+        &dir,
+        &required_libraries,
+        &default_link_paths(),
+        &[],
+    );
+
+    assert_eq!(out, "1");
+}
+
+#[test]
 fn test_dead_code_elimination_materializes_constant_switch_match() {
     let dir = make_cli_test_dir("elephc_dead_code_elimination_switch_match");
     let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -1432,6 +1432,27 @@ if (step("a", false)) {
 }
 
 #[test]
+fn test_dead_code_elimination_normalizes_single_case_switch_with_effectful_subject() {
+    let out = compile_and_run(
+        r#"<?php
+function step($label, $ret) {
+    echo $label;
+    return $ret;
+}
+switch (step("s", 1)) {
+    case step("a", 1):
+        echo "A";
+        break;
+    default:
+        echo "D";
+}
+"#,
+    );
+
+    assert_eq!(out, "saA");
+}
+
+#[test]
 fn test_dead_code_elimination_materializes_constant_switch_match() {
     let dir = make_cli_test_dir("elephc_dead_code_elimination_switch_match");
     let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -1359,6 +1359,25 @@ if ($flag) {
 }
 
 #[test]
+fn test_dead_code_elimination_collapses_identical_if_branches() {
+    let out = compile_and_run(
+        r#"<?php
+function step($label, $ret) {
+    echo $label;
+    return $ret;
+}
+if (step("c", false)) {
+    echo "X";
+} else {
+    echo "X";
+}
+"#,
+    );
+
+    assert_eq!(out, "cX");
+}
+
+#[test]
 fn test_dead_code_elimination_inlines_default_only_switch() {
     let out = compile_and_run(
         r#"<?php

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -1677,6 +1677,33 @@ try {
 }
 
 #[test]
+fn test_dead_code_elimination_accepts_sorted_multi_catch_types() {
+    let out = compile_and_run(
+        r#"<?php
+class Alpha extends Exception {}
+class Mid extends Exception {}
+class Zed extends Exception {}
+function boom($flag) {
+    if ($flag === 1) {
+        throw new Zed("z");
+    }
+    if ($flag === 2) {
+        throw new Alpha("a");
+    }
+    throw new Mid("m");
+}
+try {
+    boom($argc);
+} catch (Zed | Alpha | Mid $e) {
+    echo "ok";
+}
+"#,
+    );
+
+    assert_eq!(out, "ok");
+}
+
+#[test]
 fn test_dead_code_elimination_materializes_constant_switch_match() {
     let dir = make_cli_test_dir("elephc_dead_code_elimination_switch_match");
     let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -1574,6 +1574,29 @@ switch (step("s", 2)) {
 }
 
 #[test]
+fn test_dead_code_elimination_merges_fallthrough_switch_labels_into_next_case() {
+    let out = compile_and_run(
+        r#"<?php
+function step($label, $ret) {
+    echo $label;
+    return $ret;
+}
+switch (step("s", 2)) {
+    case 1:
+    case 2:
+    case 3:
+        echo "A";
+        break;
+    default:
+        echo "D";
+}
+"#,
+    );
+
+    assert_eq!(out, "sA");
+}
+
+#[test]
 fn test_dead_code_elimination_merges_identical_adjacent_catches() {
     let dir = make_cli_test_dir("elephc_dead_code_elimination_merge_identical_catches");
     let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -1411,6 +1411,27 @@ echo "?";
 }
 
 #[test]
+fn test_dead_code_elimination_preserves_regular_elseif_order_after_normalization() {
+    let out = compile_and_run(
+        r#"<?php
+function step($label, $ret) {
+    echo $label;
+    return $ret;
+}
+if (step("a", false)) {
+    echo "A";
+} elseif (step("b", true)) {
+    echo "B";
+} else {
+    echo "C";
+}
+"#,
+    );
+
+    assert_eq!(out, "abB");
+}
+
+#[test]
 fn test_dead_code_elimination_materializes_constant_switch_match() {
     let dir = make_cli_test_dir("elephc_dead_code_elimination_switch_match");
     let (user_asm, _runtime_asm, required_libraries) = compile_source_to_asm_with_options(

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -1488,6 +1488,47 @@ if (step("c", false)) {
 }
 
 #[test]
+fn test_dead_code_elimination_recursively_merges_longer_if_chains() {
+    let out = compile_and_run(
+        r#"<?php
+function step($label, $ret) {
+    echo $label;
+    return $ret;
+}
+if (step("a", false)) {
+    echo "X";
+} else {
+    if (step("b", false)) {
+        echo "X";
+    } else {
+        if (step("c", true)) {
+            echo "X";
+        } else {
+            echo "Y";
+        }
+    }
+}
+echo "|";
+if (step("d", false)) {
+    echo "X";
+} else {
+    if (step("e", false)) {
+        echo "Y";
+    } else {
+        if (step("f", true)) {
+            echo "Y";
+        } else {
+            echo "X";
+        }
+    }
+}
+"#,
+    );
+
+    assert_eq!(out, "abcX|defY");
+}
+
+#[test]
 fn test_dead_code_elimination_normalizes_single_case_switch_with_effectful_subject() {
     let out = compile_and_run(
         r#"<?php

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -1432,6 +1432,29 @@ if (step("a", false)) {
 }
 
 #[test]
+fn test_dead_code_elimination_merges_identical_if_chain_bodies_with_short_circuit() {
+    let out = compile_and_run(
+        r#"<?php
+function step($label, $ret) {
+    echo $label;
+    return $ret;
+}
+if (step("a", true)) {
+    echo "X";
+} else {
+    if (step("b", true)) {
+        echo "X";
+    } else {
+        echo "Y";
+    }
+}
+"#,
+    );
+
+    assert_eq!(out, "aX");
+}
+
+#[test]
 fn test_dead_code_elimination_normalizes_single_case_switch_with_effectful_subject() {
     let out = compile_and_run(
         r#"<?php

--- a/tests/codegen/support/compiler.rs
+++ b/tests/codegen/support/compiler.rs
@@ -34,6 +34,7 @@ pub(crate) fn compile_source_to_asm_with_defines(
     let check_result = elephc::types::check_with_target(&resolved, target()).expect("type check failed");
     let optimized = elephc::optimize::propagate_constants(resolved);
     let optimized = elephc::optimize::prune_constant_control_flow(optimized);
+    let optimized = elephc::optimize::normalize_control_flow(optimized);
     let optimized = elephc::optimize::eliminate_dead_code(optimized);
     let (user_asm, runtime_asm) = elephc::codegen::generate(
         &optimized,

--- a/tests/codegen/support/projects.rs
+++ b/tests/codegen/support/projects.rs
@@ -20,6 +20,13 @@ pub(crate) fn elephc_cli_bin() -> String {
     })
 }
 
+pub(crate) fn elephc_cli_command(dir: &Path) -> Command {
+    let mut cmd = Command::new(elephc_cli_bin());
+    cmd.env("XDG_CACHE_HOME", dir.join("cache-root"));
+    cmd.current_dir(dir);
+    cmd
+}
+
 pub(crate) fn compile_and_run_with_defines(source: &str, defines: &[&str]) -> String {
     let id = TEST_ID.fetch_add(1, Ordering::SeqCst);
     let tid = std::thread::current().id();
@@ -49,11 +56,11 @@ pub(crate) fn compile_cli_file_and_run(source: &str, defines: &[&str]) -> String
     let php_path = dir.join("main.php");
     fs::write(&php_path, source).unwrap();
 
-    let mut compile_cmd = Command::new(elephc_cli_bin());
+    let mut compile_cmd = elephc_cli_command(&dir);
     for define in defines {
         compile_cmd.arg("--define").arg(define);
     }
-    compile_cmd.arg(&php_path).current_dir(&dir);
+    compile_cmd.arg(&php_path);
     let compile_out = compile_cmd.output().expect("failed to run elephc CLI");
     assert!(
         compile_out.status.success(),
@@ -134,6 +141,7 @@ pub(crate) fn compile_and_run_files_with_defines(
         elephc::types::check_with_target(&resolved, target()).expect("type check failed");
     let optimized = elephc::optimize::propagate_constants(resolved);
     let optimized = elephc::optimize::prune_constant_control_flow(optimized);
+    let optimized = elephc::optimize::normalize_control_flow(optimized);
     let optimized = elephc::optimize::eliminate_dead_code(optimized);
     let (user_asm, _runtime_asm) = elephc::codegen::generate(
         &optimized,
@@ -225,6 +233,7 @@ pub(crate) fn compile_and_run_with_stdin(source: &str, stdin_data: &str) -> Stri
     let check_result = elephc::types::check_with_target(&resolved, target()).expect("type check failed");
     let optimized = elephc::optimize::propagate_constants(resolved);
     let optimized = elephc::optimize::prune_constant_control_flow(optimized);
+    let optimized = elephc::optimize::normalize_control_flow(optimized);
     let optimized = elephc::optimize::eliminate_dead_code(optimized);
     let (user_asm, _runtime_asm) = elephc::codegen::generate(
         &optimized,
@@ -321,6 +330,7 @@ pub(crate) fn compile_and_run_in_dir(source: &str) -> (String, std::path::PathBu
     let check_result = elephc::types::check_with_target(&resolved, target()).expect("type check failed");
     let optimized = elephc::optimize::propagate_constants(resolved);
     let optimized = elephc::optimize::prune_constant_control_flow(optimized);
+    let optimized = elephc::optimize::normalize_control_flow(optimized);
     let optimized = elephc::optimize::eliminate_dead_code(optimized);
     let (user_asm, _runtime_asm) = elephc::codegen::generate(
         &optimized,


### PR DESCRIPTION
## Summary

Add a dedicated control-flow normalization pass to the optimizer and use it to canonicalize residual `if`, `switch`, and `try/catch/finally` shapes before dead-code elimination.

This PR separates structural cleanup from dead-code elimination so later optimizer passes operate on fewer equivalent AST shapes and less ad-hoc control-flow structure.

## What changed

- extract `normalize_control_flow()` into its own post-pruning optimizer pass
- run the optimizer pipeline as:
  - constant folding
  - constant propagation
  - control-flow pruning
  - control-flow normalization
  - dead-code elimination
- move structural rewrites out of the old DCE-only path and keep DCE focused on removing leftover unreachable or non-observable statements

### Normalization coverage added or clarified

- canonicalize `elseif` chains into nested `else { if (...) { ... } }`
- merge compatible `if` heads and tails into simpler boolean conditions
- recursively normalize longer `if` chains until they converge
- collapse `if` statements whose normalized `then` and `else` bodies are identical
- merge identical adjacent `switch` cases into multi-pattern cases
- fold pure fallthrough `switch` labels into the next non-empty case
- rewrite safe single-case `switch` shells to `if`
- merge adjacent identical `catch` handlers into canonical multi-catch clauses
- deduplicate and stabilize catch type ordering in merged handlers
- fold an outer `finally` into an inner `try` when the wrapper is structurally redundant

### Documentation and roadmap

- update the optimizer internals docs to describe the five-pass optimizer pipeline
- update pipeline/architecture docs and README timing/pipeline descriptions
- mark control-flow normalization and alias-aware constant propagation roadmap items as completed
- add a follow-up roadmap item for broader control-flow normalization work

## Why

Before this PR, structural rewrites and dead-code cleanup were still mixed together. That made the optimizer harder to reason about and left several equivalent control-flow shapes alive longer than necessary.

Splitting normalization out gives the optimizer a cleaner contract:
- pruning decides what is dead
- normalization canonicalizes what remains
- dead-code elimination removes leftovers from the canonicalized tree

That makes future CFG-aware work, especially `dead-code-elimination v2`, easier to build on top of a more regular AST.

## Testing

Ran:
- targeted optimizer unit tests
- targeted codegen regression tests
- filtered Linux x86_64 and Linux ARM64 runs via `scripts/`
- `cargo test -- --include-ignored`

## Notes

This PR intentionally stays at the AST level. It does not introduce CFG-based optimization yet; that remains follow-up work for later passes.
