### PR TITLE
fix: prevent non-definite control-flow assignments from polluting TypeEnv

### DIFF
--- a/src/types/checker/stmt_check/control_flow.rs
+++ b/src/types/checker/stmt_check/control_flow.rs
@@ -78,7 +78,8 @@ impl Checker {
                         "by-reference foreach over Iterator/IteratorAggregate objects or iterable-typed values is not supported; use an array source or remove &",
                     ));
                 }
-                let errors = self.check_break_continue_target_body(body, env);
+                let mut body_env = env.clone();
+                let errors = self.check_break_continue_target_body(body, &mut body_env);
                 if errors.is_empty() {
                     Ok(())
                 } else {
@@ -119,26 +120,21 @@ impl Checker {
             } => {
                 self.infer_type_with_assignment_effects(condition, env)?;
                 let mut errors = Vec::new();
-                for s in then_body {
-                    if let Err(error) = self.check_stmt(s, env) {
-                        errors.extend(error.flatten());
-                    }
-                }
+
+                let mut then_env = env.clone();
+                errors.extend(self.check_body(then_body, &mut then_env));
+
                 for (cond, body) in elseif_clauses {
                     self.infer_type_with_assignment_effects(cond, env)?;
-                    for s in body {
-                        if let Err(error) = self.check_stmt(s, env) {
-                            errors.extend(error.flatten());
-                        }
-                    }
+                    let mut elseif_env = env.clone();
+                    errors.extend(self.check_body(body, &mut elseif_env));
                 }
+
                 if let Some(body) = else_body {
-                    for s in body {
-                        if let Err(error) = self.check_stmt(s, env) {
-                            errors.extend(error.flatten());
-                        }
-                    }
+                    let mut else_env = env.clone();
+                    errors.extend(self.check_body(body, &mut else_env));
                 }
+
                 if errors.is_empty() {
                     Ok(())
                 } else {
@@ -156,7 +152,8 @@ impl Checker {
             }
             StmtKind::While { condition, body } => {
                 self.infer_type_with_assignment_effects(condition, env)?;
-                let errors = self.check_break_continue_target_body(body, env);
+                let mut body_env = env.clone();
+                let errors = self.check_break_continue_target_body(body, &mut body_env);
                 if errors.is_empty() {
                     Ok(())
                 } else {
@@ -178,7 +175,8 @@ impl Checker {
                 if let Some(s) = update {
                     self.check_stmt(s, env)?;
                 }
-                let errors = self.check_break_continue_target_body(body, env);
+                let mut body_env = env.clone();
+                let errors = self.check_break_continue_target_body(body, &mut body_env);
                 if errors.is_empty() {
                     Ok(())
                 } else {

--- a/tests/error_tests/type_system.rs
+++ b/tests/error_tests/type_system.rs
@@ -103,6 +103,30 @@ fn test_error_undefined_variable() {
     expect_error("<?php echo $x;", "Undefined variable: $x");
 }
 
+
+#[test]
+fn test_error_if_branch_assignment_is_not_definite() {
+    expect_error(
+        "<?php if (0) { $s = \"secret\"; } echo $s;",
+        "Undefined variable: $s",
+    );
+}
+
+#[test]
+fn test_error_while_body_assignment_is_not_definite() {
+    expect_error(
+        "<?php while (0) { $s = \"secret\"; } echo $s;",
+        "Undefined variable: $s",
+    );
+}
+
+#[test]
+fn test_error_for_body_assignment_is_not_definite() {
+    expect_error(
+        "<?php for (; 0; ) { $s = \"secret\"; } echo $s;",
+        "Undefined variable: $s",
+    );
+}
 #[test]
 fn test_error_type_mismatch_reassign() {
     expect_error("<?php $x = 42; $x = \"hello\";", "cannot reassign $x");


### PR DESCRIPTION
### Motivation
- The type checker previously used the same mutable `TypeEnv` when checking `if`, `while`, `for`, and `foreach` bodies, causing assignments inside non-definite paths to be treated as definitely-initialized afterward and enabling uninitialized stack reads in generated code. 
- This could yield information disclosure or crashes (e.g., `<?php if (0) { $s = "secret"; } echo $s;`).

### Description
- Update the control-flow checker so bodies are validated against cloned environments instead of mutating the outer `TypeEnv`, preventing branch/loop-local assignments from leaking; changes live in `src/types/checker/stmt_check/control_flow.rs` and affect `if`/`elseif`/`else`, `while`, `for`, `foreach`, and related body checks.
- Use `env.clone()` and pass the clone to `check_body`/`check_break_continue_target_body` for non-definite bodies to preserve the caller environment.
- Add three regression tests in `tests/error_tests/type_system.rs` asserting variables assigned only inside `if (0)`, `while (0)`, and `for (; 0; )` remain undefined after the control statements.

### Testing
- Ran `cargo build`, which completed successfully.
- Ran the focused test group via `cargo test assignment_is_not_definite`, and the three new regression tests passed.
- Ran `git diff --check` locally to verify no comment/alignment issues (no problems reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d31158088832688eff80f24bbb972)