### PR TITLE
fix: keep generator send values through ternary echoes

### DIFF
--- a/src/codegen/functions/generator/build.rs
+++ b/src/codegen/functions/generator/build.rs
@@ -130,15 +130,29 @@ pub(super) fn classify_mixed_expr(
 }
 
 /// Classify a boolean expression for v1 generator conditionals.
-/// Supports six comparison operators (`<`, `<=`, `>`, `>=`, `==`, `!=`)
-/// on int-classifiable operands. Returns `None` for non-comparisons or
-/// non-int operands — the builder turns those into `ResumeNode::Bail`.
+/// Supports integer comparisons and strict/loose null checks against
+/// Mixed-typed slots. Returns `None` for unsupported operands — the
+/// builder turns those into `ResumeNode::Bail`.
 pub(super) fn classify_bool_expr(
     expr: &ExprKind,
     slots: &[String],
     types: &[SlotType],
 ) -> Option<BoolExpr> {
     if let ExprKind::BinaryOp { left, op, right } = expr {
+        if matches!(op, BinOp::Eq | BinOp::StrictEq | BinOp::NotEq | BinOp::StrictNotEq) {
+            if let Some(slot_idx) = mixed_slot_null_cmp(left, right, slots, types) {
+                return Some(BoolExpr::MixedSlotNull {
+                    slot_idx,
+                    is_equal: matches!(op, BinOp::Eq | BinOp::StrictEq),
+                });
+            }
+            if let Some(slot_idx) = mixed_slot_null_cmp(right, left, slots, types) {
+                return Some(BoolExpr::MixedSlotNull {
+                    slot_idx,
+                    is_equal: matches!(op, BinOp::Eq | BinOp::StrictEq),
+                });
+            }
+        }
         let cmp = match op {
             BinOp::Lt => CmpOp::Lt,
             BinOp::LtEq => CmpOp::Le,
@@ -150,9 +164,30 @@ pub(super) fn classify_bool_expr(
         };
         let l = classify_int_expr(&left.kind, slots, types)?;
         let r = classify_int_expr(&right.kind, slots, types)?;
-        return Some(BoolExpr { left: l, op: cmp, right: r });
+        return Some(BoolExpr::IntCompare {
+            left: l,
+            op: cmp,
+            right: r,
+        });
     }
     None
+}
+
+/// Returns the Mixed slot index when `value` is a Mixed variable and
+/// `null_candidate` is the PHP null literal.
+fn mixed_slot_null_cmp(
+    value: &Expr,
+    null_candidate: &Expr,
+    slots: &[String],
+    types: &[SlotType],
+) -> Option<usize> {
+    if !matches!(null_candidate.kind, ExprKind::Null) {
+        return None;
+    }
+    let ExprKind::Variable(name) = &value.kind else {
+        return None;
+    };
+    slot_idx_of_type(name, slots, types, SlotType::Mixed)
 }
 
 /// Collects variable-use hints from the generator body before slot
@@ -181,10 +216,10 @@ fn record_stmt_use_hints(body: &[Stmt], hints: &mut SlotUseHints) {
                 elseif_clauses,
                 else_body,
             } => {
-                record_int_expr_use_hints(&condition.kind, hints);
+                record_bool_expr_use_hints(&condition.kind, hints);
                 record_stmt_use_hints(then_body, hints);
                 for (elseif_cond, elseif_body) in elseif_clauses {
-                    record_int_expr_use_hints(&elseif_cond.kind, hints);
+                    record_bool_expr_use_hints(&elseif_cond.kind, hints);
                     record_stmt_use_hints(elseif_body, hints);
                 }
                 if let Some(body) = else_body {
@@ -192,19 +227,19 @@ fn record_stmt_use_hints(body: &[Stmt], hints: &mut SlotUseHints) {
                 }
             }
             StmtKind::While { condition, body } => {
-                record_int_expr_use_hints(&condition.kind, hints);
+                record_bool_expr_use_hints(&condition.kind, hints);
                 record_stmt_use_hints(body, hints);
             }
             StmtKind::DoWhile { body, condition } => {
                 record_stmt_use_hints(body, hints);
-                record_int_expr_use_hints(&condition.kind, hints);
+                record_bool_expr_use_hints(&condition.kind, hints);
             }
             StmtKind::For { init, condition, update, body } => {
                 if let Some(init_stmt) = init.as_deref() {
                     record_stmt_use_hints(std::slice::from_ref(init_stmt), hints);
                 }
                 if let Some(cond) = condition {
-                    record_int_expr_use_hints(&cond.kind, hints);
+                    record_bool_expr_use_hints(&cond.kind, hints);
                 }
                 if let Some(update_stmt) = update.as_deref() {
                     record_stmt_use_hints(std::slice::from_ref(update_stmt), hints);
@@ -314,6 +349,15 @@ fn record_mixed_expr_use_hints(expr: &ExprKind, hints: &mut SlotUseHints) {
                 record_mixed_expr_use_hints(&item.kind, hints);
             }
         }
+        ExprKind::Ternary {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            record_bool_expr_use_hints(&condition.kind, hints);
+            record_mixed_expr_use_hints(&then_expr.kind, hints);
+            record_mixed_expr_use_hints(&else_expr.kind, hints);
+        }
         ExprKind::Yield { key, value } => {
             if let Some(k) = key {
                 record_mixed_expr_use_hints(&k.kind, hints);
@@ -333,6 +377,26 @@ fn record_mixed_expr_use_hints(expr: &ExprKind, hints: &mut SlotUseHints) {
             record_mixed_expr_use_hints(&inner.kind, hints);
         }
         _ => {}
+    }
+}
+
+/// Records variable uses inside boolean expressions. Null checks against
+/// variables require Mixed slots; other supported comparisons stay int-typed.
+fn record_bool_expr_use_hints(expr: &ExprKind, hints: &mut SlotUseHints) {
+    match expr {
+        ExprKind::BinaryOp { left, op, right }
+            if matches!(op, BinOp::Eq | BinOp::StrictEq | BinOp::NotEq | BinOp::StrictNotEq)
+                && matches!(right.kind, ExprKind::Null) =>
+        {
+            record_mixed_expr_use_hints(&left.kind, hints);
+        }
+        ExprKind::BinaryOp { left, op, right }
+            if matches!(op, BinOp::Eq | BinOp::StrictEq | BinOp::NotEq | BinOp::StrictNotEq)
+                && matches!(left.kind, ExprKind::Null) =>
+        {
+            record_mixed_expr_use_hints(&right.kind, hints);
+        }
+        _ => record_int_expr_use_hints(expr, hints),
     }
 }
 
@@ -647,10 +711,7 @@ fn build_node(
             }
             _ => None,
         },
-        StmtKind::Echo(expr) => {
-            let src = classify_mixed_expr(&expr.kind, slots, types, data)?;
-            Some(ResumeNode::Stmt(BodyStmt::EchoMixed(src)))
-        }
+        StmtKind::Echo(expr) => build_echo_node(expr, slots, types, data),
         StmtKind::If {
             condition,
             then_body,
@@ -763,6 +824,37 @@ fn build_node(
         }),
         _ => None,
     }
+}
+
+/// Translates `echo <expr>` into generator IR.
+///
+/// The narrow generator IR can lower ternary echo expressions by turning
+/// them into an `If` whose branches each emit one echo. Non-ternary
+/// expressions use the normal Mixed boxing path.
+fn build_echo_node(
+    expr: &Expr,
+    slots: &[String],
+    types: &[SlotType],
+    data: &mut DataSection,
+) -> Option<ResumeNode> {
+    if let ExprKind::Ternary {
+        condition,
+        then_expr,
+        else_expr,
+    } = &expr.kind
+    {
+        let cond = classify_bool_expr(&condition.kind, slots, types)?;
+        let then_node = build_echo_node(then_expr, slots, types, data)?;
+        let else_node = build_echo_node(else_expr, slots, types, data)?;
+        return Some(ResumeNode::If {
+            cond,
+            then_body: vec![then_node],
+            else_body: vec![else_node],
+        });
+    }
+
+    let src = classify_mixed_expr(&expr.kind, slots, types, data)?;
+    Some(ResumeNode::Stmt(BodyStmt::EchoMixed(src)))
 }
 
 /// Returns true for PHP's global `var_dump` builtin name as it may appear

--- a/src/codegen/functions/generator/emit/values.rs
+++ b/src/codegen/functions/generator/emit/values.rs
@@ -384,15 +384,23 @@ pub(super) fn emit_replace_mixed_slot(
 /// preserving them across evaluation, then emits the appropriate compare and branch
 /// using inverted condition codes. The branch is a no-op when the condition is true.
 pub(super) fn emit_branch_if_false(emitter: &mut Emitter, cond: &BoolExpr, false_label: &str) {
+    if let BoolExpr::MixedSlotNull { slot_idx, is_equal } = cond {
+        emit_branch_if_mixed_slot_null_condition_false(emitter, *slot_idx, *is_equal, false_label);
+        return;
+    }
+
+    let BoolExpr::IntCompare { left, op, right } = cond else {
+        unreachable!("all non-mixed-null generator bool expressions are int comparisons");
+    };
     if emitter.target.arch == Arch::X86_64 {
-        emit_load_int_source_x86_64(emitter, "r10", &cond.left);
+        emit_load_int_source_x86_64(emitter, "r10", left);
         emitter.instruction("sub rsp, 16");                                     // reserve aligned temporary storage for the left comparison value
         emitter.instruction("mov QWORD PTR [rsp], r10");                        // preserve the left comparison value while evaluating the right side
-        emit_load_int_source_x86_64(emitter, "r11", &cond.right);
+        emit_load_int_source_x86_64(emitter, "r11", right);
         emitter.instruction("mov r10, QWORD PTR [rsp]");                        // restore the left comparison value after right-side evaluation
         emitter.instruction("add rsp, 16");                                     // release the temporary comparison storage
         emitter.instruction("cmp r10, r11");                                    // compare the two computed integers
-        let inverse_cc = match cond.op {
+        let inverse_cc = match op {
             CmpOp::Lt => "jge",
             CmpOp::Le => "jg",
             CmpOp::Gt => "jle",
@@ -404,14 +412,14 @@ pub(super) fn emit_branch_if_false(emitter: &mut Emitter, cond: &BoolExpr, false
         return;
     }
 
-    emit_load_int_source(emitter, "x1", &cond.left);
+    emit_load_int_source(emitter, "x1", left);
     emitter.instruction("sub sp, sp, #16");                                     // reserve aligned temporary storage for the left comparison value
     emitter.instruction("str x1, [sp, #0]");                                    // preserve the left comparison value while evaluating the right side
-    emit_load_int_source(emitter, "x2", &cond.right);
+    emit_load_int_source(emitter, "x2", right);
     emitter.instruction("ldr x1, [sp, #0]");                                    // restore the left comparison value after right-side evaluation
     emitter.instruction("add sp, sp, #16");                                     // release the temporary comparison storage
     emitter.instruction("cmp x1, x2");                                          // compare the two computed integers
-    let inverse_cc = match cond.op {
+    let inverse_cc = match op {
         CmpOp::Lt => "ge",
         CmpOp::Le => "gt",
         CmpOp::Gt => "le",
@@ -420,4 +428,45 @@ pub(super) fn emit_branch_if_false(emitter: &mut Emitter, cond: &BoolExpr, false
         CmpOp::Ne => "eq",
     };
     emitter.instruction(&format!("b.{} {}", inverse_cc, false_label));          // branch if the condition is false
+}
+
+/// Emits a false branch for `$mixed_slot === null` or `$mixed_slot !== null`.
+///
+/// A generator Mixed slot may be a null pointer when no value was sent, or a
+/// boxed Mixed null cell. Both forms compare as PHP null.
+fn emit_branch_if_mixed_slot_null_condition_false(
+    emitter: &mut Emitter,
+    slot_idx: usize,
+    is_equal: bool,
+    false_label: &str,
+) {
+    let boxed_null = format!("{}_mixed_null", false_label);
+    let done = format!("{}_mixed_null_done", false_label);
+    if emitter.target.arch == Arch::X86_64 {
+        emitter.instruction(&format!("mov rax, QWORD PTR [r12 + {}]", slot_offset(slot_idx))); // load the boxed Mixed slot pointer for null comparison
+        emitter.instruction("test rax, rax");                                   // null pointer slots are PHP null
+        emitter.instruction(&format!("jz {}", boxed_null));                     // skip unboxing when the slot has no box
+        emitter.instruction("call __rt_mixed_unbox");                           // rax = Mixed tag for the boxed slot
+        emitter.instruction("cmp rax, 8");                                      // tag 8 is PHP null
+        emitter.instruction(&format!("{} {}", if is_equal { "jne" } else { "je" }, false_label)); // branch when the null predicate is false
+        emitter.instruction(&format!("jmp {}", done));                          // skip the raw-null branch
+        emitter.label(&boxed_null);
+        if !is_equal {
+            emitter.instruction(&format!("jmp {}", false_label));               // raw null makes !== null false
+        }
+        emitter.label(&done);
+        return;
+    }
+
+    emitter.instruction(&format!("ldr x0, [x19, #{}]", slot_offset(slot_idx))); // load the boxed Mixed slot pointer for null comparison
+    emitter.instruction(&format!("cbz x0, {}", boxed_null));                    // null pointer slots are PHP null
+    emitter.instruction("bl __rt_mixed_unbox");                                 // x0 = Mixed tag for the boxed slot
+    emitter.instruction("cmp x0, #8");                                          // tag 8 is PHP null
+    emitter.instruction(&format!("b.{} {}", if is_equal { "ne" } else { "eq" }, false_label)); // branch when the null predicate is false
+    emitter.instruction(&format!("b {}", done));                                // skip the raw-null branch
+    emitter.label(&boxed_null);
+    if !is_equal {
+        emitter.instruction(&format!("b {}", false_label));                     // raw null makes !== null false
+    }
+    emitter.label(&done);
 }

--- a/src/codegen/functions/generator/model.rs
+++ b/src/codegen/functions/generator/model.rs
@@ -223,14 +223,21 @@ pub(super) enum IntBinOp {
     Div,
 }
 
-/// A boolean comparison expression used in generator control-flow nodes
-/// (While, DoWhile, For). Compares two IntSources using a CmpOp and feeds
-/// the resulting bool into the loop condition for branching.
+/// A boolean expression used in generator control-flow and ternary nodes.
+/// Covers integer comparisons and null checks against Mixed slots.
 #[derive(Clone)]
-pub(super) struct BoolExpr {
-    pub left: IntSource,
-    pub op: CmpOp,
-    pub right: IntSource,
+pub(super) enum BoolExpr {
+    /// Compares two int-classifiable values with a comparison operator.
+    IntCompare {
+        left: IntSource,
+        op: CmpOp,
+        right: IntSource,
+    },
+    /// Compares a Mixed-typed slot with PHP null.
+    MixedSlotNull {
+        slot_idx: usize,
+        is_equal: bool,
+    },
 }
 
 #[derive(Clone, Copy)]

--- a/tests/codegen/generators/send_throw.rs
+++ b/tests/codegen/generators/send_throw.rs
@@ -165,6 +165,26 @@ var_dump($g->send("p"));
     assert_eq!(out, "int(1)\np\nint(2)\n");
 }
 
+/// Regression for issue #308: a value sent into a plain yield assignment
+/// remains visible to following generator statements even when the next
+/// statement is a ternary echo and the generator then terminates.
+#[test]
+fn test_generator_send_value_reaches_ternary_echo_before_termination() {
+    let out = compile_and_run(
+        r#"<?php
+function g() {
+    $x = yield 1;
+    echo $x === null ? "n" : $x;
+}
+
+$g = g();
+echo $g->current();
+$g->send(5);
+"#,
+    );
+    assert_eq!(out, "15");
+}
+
 /// Verifies `send()` value participates in Mixed arithmetic when used in expressions
 /// on the right side of `yield`. Tests `$a * 2` and `$a + $b` with sent int payloads,
 /// and that `send()` on an already-terminated generator returns `null`.


### PR DESCRIPTION
## Summary

- keep generator yield-assignment values live through ternary echo statements
- add Mixed-slot null checks to the narrow generator IR
- add a regression test for Generator::send() followed by a ternary echo before termination

## Validation

- `cargo test test_generator_send_value_reaches_ternary_echo_before_termination -- --nocapture`
- `cargo test codegen::generators::send_throw`
- `cargo test codegen::generators`
- manual PHP/elephc comparison for the issue reproduction: both print `15`
- `git diff --check`

Closes #308
