### PR TITLE
hotfix: lower generator concat echoes after yield from

### DIFF
--- a/src/codegen/functions/generator/build.rs
+++ b/src/codegen/functions/generator/build.rs
@@ -300,6 +300,10 @@ fn record_mixed_expr_use_hints(expr: &ExprKind, hints: &mut SlotUseHints) {
         ExprKind::Variable(name) => {
             hints.mixed.insert(name.clone());
         }
+        ExprKind::BinaryOp { left, op: BinOp::Concat, right } => {
+            record_mixed_expr_use_hints(&left.kind, hints);
+            record_mixed_expr_use_hints(&right.kind, hints);
+        }
         ExprKind::BinaryOp { left, op, right } if is_generator_int_binop(op) => {
             record_int_expr_use_hints(&left.kind, hints);
             record_int_expr_use_hints(&right.kind, hints);
@@ -647,10 +651,7 @@ fn build_node(
             }
             _ => None,
         },
-        StmtKind::Echo(expr) => {
-            let src = classify_mixed_expr(&expr.kind, slots, types, data)?;
-            Some(ResumeNode::Stmt(BodyStmt::EchoMixed(src)))
-        }
+        StmtKind::Echo(expr) => build_echo_node(expr, slots, types, data),
         StmtKind::If {
             condition,
             then_body,
@@ -763,6 +764,35 @@ fn build_node(
         }),
         _ => None,
     }
+}
+
+/// Translates `echo <expr>` into generator IR.
+///
+/// The narrow generator IR can lower concat echo expressions by emitting each
+/// operand in source order. Non-concat expressions use the normal Mixed boxing
+/// path.
+fn build_echo_node(
+    expr: &Expr,
+    slots: &[String],
+    types: &[SlotType],
+    data: &mut DataSection,
+) -> Option<ResumeNode> {
+    if let ExprKind::BinaryOp {
+        left,
+        op: BinOp::Concat,
+        right,
+    } = &expr.kind
+    {
+        return Some(ResumeNode::Block {
+            stmts: vec![
+                build_echo_node(left, slots, types, data)?,
+                build_echo_node(right, slots, types, data)?,
+            ],
+        });
+    }
+
+    let src = classify_mixed_expr(&expr.kind, slots, types, data)?;
+    Some(ResumeNode::Stmt(BodyStmt::EchoMixed(src)))
 }
 
 /// Returns true for PHP's global `var_dump` builtin name as it may appear

--- a/tests/codegen/generators/yield_from.rs
+++ b/tests/codegen/generators/yield_from.rs
@@ -113,6 +113,31 @@ foreach (outer() as $v) {
     assert_eq!(out, "17");
 }
 
+/// Regression for issue #192: a delegated generator's return value remains
+/// available when the outer generator uses it in a concat echo after
+/// `yield from` completes.
+#[test]
+fn test_generator_yield_from_return_value_survives_concat_echo_after_delegation() {
+    let out = compile_and_run(
+        r#"<?php
+function inner() {
+    yield 1;
+    return 9;
+}
+
+function outer() {
+    $r = yield from inner();
+    echo ":" . $r;
+}
+
+foreach (outer() as $v) {
+    echo $v;
+}
+"#,
+    );
+    assert_eq!(out, "1:9");
+}
+
 /// Regression test for delegated generator sends: a typed generator may
 /// `return` its terminal value, and `send()` on the outer generator must
 /// deliver the payload into the currently active inner generator.


### PR DESCRIPTION
## Summary

- lower generator echo concat expressions as source-order echo operations
- keep variables used in generator concat echoes on the Mixed path
- add a regression for yield-from return values used in concat echoes

## Validation

- `cargo test test_generator_yield_from_return_value_survives_concat_echo_after_delegation -- --nocapture`
- `cargo test codegen::generators::yield_from`
- `cargo test codegen::generators`
- manual PHP/elephc comparison for the issue reproduction: both print `1:9`
- `git diff --check`

Closes #192