### PR TITLE
fix/lexer unicode and defensive guards

### DIFF
--- a/docs/php/strings.md
+++ b/docs/php/strings.md
@@ -74,6 +74,30 @@ This is line 2
 EOT;
 ```
 
+The closing label closes the heredoc when it is at the start of a line and followed by any
+non-identifier character, so a heredoc can be used as an expression — for example as a
+function argument or in a concatenation:
+
+```php
+<?php
+echo strtoupper(<<<EOT
+hello
+EOT) . "!";
+```
+
+PHP 7.3+ flexible (indented) heredocs are supported: the closing marker may be indented,
+and that indentation is stripped from every body line.
+
+```php
+<?php
+function describe(): string {
+    return <<<EOT
+        line one
+        line two
+        EOT;   // -> "line one\nline two"
+}
+```
+
 ## Nowdoc strings
 
 Multi-line without escape processing (like single-quoted):

--- a/docs/php/strings.md
+++ b/docs/php/strings.md
@@ -36,10 +36,30 @@ echo 'It\'s here';   // prints: It's here
 
 ## String interpolation
 
+Double-quoted strings and heredocs interpolate variables. Both the simple and complex
+syntaxes are supported:
+
 ```php
 <?php
 $name = "World";
-echo "Hello, $name\n";
+echo "Hello, $name\n";          // simple: $variable
+
+$user = ["name" => "Ada", "age" => 36];
+echo "Name: $user[name]\n";     // simple: one $var[offset] (bareword key, no quotes)
+
+class Point { public int $x = 1; }
+$p = new Point();
+echo "x = $p->x\n";             // simple: one $var->prop
+
+echo "Sum: {$user['age']}\n";   // complex: {$expr} allows full expressions
+```
+
+Variable and identifier names may contain non-ASCII letters, matching PHP:
+
+```php
+<?php
+$café = "espresso";
+echo "Order: $café\n";
 ```
 
 ## Heredoc strings

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -79,10 +79,14 @@ pub(crate) fn parse_args(args: &[String]) -> CliConfig {
             emit_source_map = true;
         } else if arg == "--define" {
             i += 1;
-            defines.insert(required_value(args, i, "Missing symbol after --define"));
+            let symbol = required_value(args, i, "Missing symbol after --define");
+            if let Err(message) = validate_define_symbol(&symbol) {
+                fail(message);
+            }
+            defines.insert(symbol);
         } else if let Some(symbol) = arg.strip_prefix("--define=") {
-            if symbol.is_empty() {
-                fail("Invalid --define: symbol cannot be empty");
+            if let Err(message) = validate_define_symbol(symbol) {
+                fail(message);
             }
             defines.insert(symbol.to_string());
         } else if arg == "--link" || arg == "-l" {
@@ -176,9 +180,38 @@ fn required_value(args: &[String], index: usize, message: &str) -> String {
     }
 }
 
+/// Validates an ifdef symbol supplied via `--define`, rejecting an empty symbol.
+///
+/// Kept pure (no IO/exit) so both the `--define SYMBOL` and `--define=SYMBOL` forms
+/// can share one consistent rule and the rejection can be unit-tested.
+fn validate_define_symbol(symbol: &str) -> Result<(), &'static str> {
+    if symbol.is_empty() {
+        return Err("Invalid --define: symbol cannot be empty");
+    }
+    Ok(())
+}
+
 /// Prints a message to stderr and exits the process with code 1.
 /// Never returns.
 fn fail(message: &str) -> ! {
     eprintln!("{}", message);
     process::exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verifies an empty `--define` symbol is rejected, matching the `--define=` form,
+    /// so the two spellings no longer behave inconsistently.
+    #[test]
+    fn empty_define_symbol_is_rejected() {
+        assert!(validate_define_symbol("").is_err());
+    }
+
+    /// Verifies a normal `--define` symbol is accepted.
+    #[test]
+    fn non_empty_define_symbol_is_accepted() {
+        assert!(validate_define_symbol("FEATURE").is_ok());
+    }
 }

--- a/src/codegen/abi/frame.rs
+++ b/src/codegen/abi/frame.rs
@@ -19,6 +19,10 @@ use super::registers::{
 /// On AArch64: allocates `frame_size` bytes, saves x29/x30 in the footer, and establishes x29 as the frame pointer.
 /// On x86_64: pushes rbp, establishes rsp as the frame base, and reserves `frame_size - 16` bytes for locals.
 pub fn emit_frame_prologue(emitter: &mut Emitter, frame_size: usize) {
+    debug_assert!(
+        frame_size >= 16,
+        "frame_size must reserve the 16-byte frame footer (x29/x30), got {frame_size}"
+    );
     emitter.comment("prologue");
     match emitter.target.arch {
         Arch::AArch64 => {
@@ -53,6 +57,10 @@ pub fn emit_frame_prologue(emitter: &mut Emitter, frame_size: usize) {
 /// On AArch64: restores x29/x30 from the footer and releases `frame_size` bytes.
 /// On x86_64: releases local bytes and pops rbp.
 pub fn emit_frame_restore(emitter: &mut Emitter, frame_size: usize) {
+    debug_assert!(
+        frame_size >= 16,
+        "frame_size must reserve the 16-byte frame footer (x29/x30), got {frame_size}"
+    );
     match emitter.target.arch {
         Arch::AArch64 => {
             let footer_offset = frame_size - 16;

--- a/src/codegen/abi/tests/basics.rs
+++ b/src/codegen/abi/tests/basics.rs
@@ -34,6 +34,16 @@ fn test_emit_frame_helpers_small_frame() {
     );
 }
 
+/// Verifies the frame prologue rejects a frame too small to hold the x29/x30 footer
+/// (`frame_size < 16`) with a clear assertion message in debug builds, instead of
+/// underflowing the `frame_size - 16` footer-offset subtraction into a corrupt offset.
+#[test]
+#[should_panic(expected = "frame_size must reserve the 16-byte frame footer")]
+fn test_emit_frame_prologue_rejects_undersized_frame() {
+    let mut emitter = test_emitter();
+    emit_frame_prologue(&mut emitter, 8);
+}
+
 /// Tests that string return values (pointer in x1, length in x2) are preserved
 /// across function boundaries by storing them to the caller's stack frame at negative
 /// offsets and restoring them after the call. Uses offset 32 for both stores.

--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -38,7 +38,9 @@ pub(crate) use ownership::{
     expr_result_heap_ownership, string_result_is_owned_call_temp,
     string_result_uses_transient_concat_buffer,
 };
-pub use coerce::{coerce_null_to_zero, coerce_to_string, coerce_to_truthiness};
+pub use coerce::{
+    coerce_null_to_zero, coerce_to_string, coerce_to_string_releasing_owned, coerce_to_truthiness,
+};
 use helpers::{retain_borrowed_heap_arg, widen_codegen_type};
 
 /// Dispatches an expression AST node to the appropriate lowering module.

--- a/src/codegen/expr/binops/arithmetic.rs
+++ b/src/codegen/expr/binops/arithmetic.rs
@@ -16,7 +16,7 @@ use super::target::{
     emit_float_binop, emit_promote_int_to_float, emit_set_bool_from_flags,
 };
 use super::super::{
-    coerce_null_to_zero, coerce_to_string, coerce_to_truthiness, emit_expr,
+    coerce_null_to_zero, coerce_to_string_releasing_owned, coerce_to_truthiness, emit_expr,
     expr_result_heap_ownership, string_result_is_owned_call_temp,
     string_result_uses_transient_concat_buffer, BinOp, Expr, PhpType,
 };
@@ -386,7 +386,13 @@ pub(super) fn emit_concat_binop(
     data: &mut DataSection,
 ) -> PhpType {
     let left_ty = emit_expr(left, emitter, ctx, data);
-    coerce_to_string(emitter, ctx, data, &left_ty);
+    coerce_to_string_releasing_owned(
+        emitter,
+        ctx,
+        data,
+        &left_ty,
+        expr_result_heap_ownership(left) == HeapOwnership::Owned,
+    );
     let persisted_left = expr_result_heap_ownership(left) == HeapOwnership::NonHeap
         || string_result_uses_transient_concat_buffer(left);
     let release_left = persisted_left || string_result_is_owned_call_temp(left, ctx);
@@ -396,7 +402,13 @@ pub(super) fn emit_concat_binop(
     let (left_ptr_reg, left_len_reg) = abi::string_result_regs(emitter);
     abi::emit_push_reg_pair(emitter, left_ptr_reg, left_len_reg);
     let right_ty = emit_expr(right, emitter, ctx, data);
-    coerce_to_string(emitter, ctx, data, &right_ty);
+    coerce_to_string_releasing_owned(
+        emitter,
+        ctx,
+        data,
+        &right_ty,
+        expr_result_heap_ownership(right) == HeapOwnership::Owned,
+    );
     let release_right = string_result_is_owned_call_temp(right, ctx);
     let mut cleanup_operands = 0usize;
     match emitter.target.arch {

--- a/src/codegen/expr/coerce.rs
+++ b/src/codegen/expr/coerce.rs
@@ -34,6 +34,34 @@ pub fn coerce_to_string(
     data: &mut DataSection,
     ty: &PhpType,
 ) {
+    coerce_to_string_inner(emitter, ctx, data, ty, false);
+}
+
+/// Like [`coerce_to_string`], but when `release_owned_object` is set and `ty` is an object
+/// stringified via `__toString`, the owned object temporary is released after conversion.
+///
+/// Callers pass `true` only when the source expression produced an owned object temporary
+/// (e.g. `new C()` or a call result); a borrowed object (a variable or property) must pass
+/// `false` so its owner — not this coercion — releases it, avoiding a double free.
+pub fn coerce_to_string_releasing_owned(
+    emitter: &mut Emitter,
+    ctx: &mut Context,
+    data: &mut DataSection,
+    ty: &PhpType,
+    release_owned_object: bool,
+) {
+    coerce_to_string_inner(emitter, ctx, data, ty, release_owned_object);
+}
+
+/// Shared body of the string coercion. `release_owned_object` controls whether an owned
+/// object temporary that is stringified via `__toString` is released after conversion.
+fn coerce_to_string_inner(
+    emitter: &mut Emitter,
+    ctx: &mut Context,
+    data: &mut DataSection,
+    ty: &PhpType,
+    release_owned_object: bool,
+) {
     match ty {
         PhpType::Int => {
             // -- convert integer in x0 to string in x1/x2 --
@@ -107,6 +135,9 @@ pub fn coerce_to_string(
                 .get(class_name)
                 .is_some_and(|class_info| class_info.methods.contains_key("__tostring"))
             {
+                if release_owned_object {
+                    abi::emit_push_reg(emitter, abi::int_result_reg(emitter));  // save the owned object temp below $this so it can be released after __toString borrows it
+                }
                 abi::emit_push_reg(emitter, abi::int_result_reg(emitter));      // push $this pointer for __toString dispatch using the active target ABI
                 super::objects::emit_method_call_with_pushed_args(
                     class_name,
@@ -115,6 +146,9 @@ pub fn coerce_to_string(
                     emitter,
                     ctx,
                 );
+                if release_owned_object {
+                    emit_release_saved_object_temp(emitter, ty);
+                }
             } else {
                 emit_missing_tostring_fatal(emitter, data, class_name);
             }
@@ -127,6 +161,21 @@ pub fn coerce_to_string(
         | PhpType::Packed(_)
         | PhpType::Pointer(_) => {}
     }
+}
+
+/// Releases an owned object temporary that was just stringified via `__toString`.
+///
+/// On entry the produced string is in the string result registers, and the object pointer
+/// was saved on the temporary stack below the (already-popped) `$this` slot. The string
+/// result is preserved across the object decref, then restored, and the saved object slot
+/// is discarded — leaving the string result in place and the object temporary freed.
+fn emit_release_saved_object_temp(emitter: &mut Emitter, ty: &PhpType) {
+    let (ptr_reg, len_reg) = abi::string_result_regs(emitter);
+    abi::emit_push_reg_pair(emitter, ptr_reg, len_reg);                         // preserve the __toString result string across the object decref call
+    abi::emit_load_temporary_stack_slot(emitter, abi::int_result_reg(emitter), 16); // reload the saved owned object pointer from below the 16-byte string slot
+    abi::emit_decref_if_refcounted(emitter, ty);                                // release the owned object temporary now that __toString produced its string
+    abi::emit_pop_reg_pair(emitter, ptr_reg, len_reg);                          // restore the preserved __toString result string
+    abi::emit_release_temporary_stack(emitter, 16);                             // discard the saved owned object slot
 }
 
 /// Emit a fatal error and terminate when an object without `__toString()` is coerced to string.

--- a/src/codegen/expr/compare/casts.rs
+++ b/src/codegen/expr/compare/casts.rs
@@ -9,13 +9,15 @@
 //! - Null, type-tag, and string comparisons must follow PHP semantics before emitting boolean results.
 
 use crate::codegen::abi;
-use crate::codegen::context::Context;
+use crate::codegen::context::{Context, HeapOwnership};
 use crate::codegen::data_section::DataSection;
 use crate::codegen::emit::Emitter;
 use crate::parser::ast::Expr;
 use crate::types::PhpType;
 
-use super::super::{coerce_to_string, coerce_to_truthiness, emit_expr};
+use super::super::{
+    coerce_to_string_releasing_owned, coerce_to_truthiness, emit_expr, expr_result_heap_ownership,
+};
 
 /// Emits a PHP cast expression (`(int)`, `(float)`, `(string)`, `(bool)`, `(array)`).
 ///
@@ -133,7 +135,13 @@ pub(in crate::codegen::expr) fn emit_cast(
             PhpType::Float
         }
         CastType::String => {
-            coerce_to_string(emitter, ctx, data, &src_ty);
+            coerce_to_string_releasing_owned(
+                emitter,
+                ctx,
+                data,
+                &src_ty,
+                expr_result_heap_ownership(expr) == HeapOwnership::Owned,
+            );
             PhpType::Str
         }
         CastType::Bool => {

--- a/src/codegen/stmt/io.rs
+++ b/src/codegen/stmt/io.rs
@@ -12,7 +12,11 @@ use super::super::abi;
 use super::super::context::Context;
 use super::super::data_section::DataSection;
 use super::super::emit::Emitter;
-use super::super::expr::{coerce_to_string, emit_expr, string_result_is_owned_call_temp};
+use super::super::context::HeapOwnership;
+use super::super::expr::{
+    coerce_to_string_releasing_owned, emit_expr, expr_result_heap_ownership,
+    string_result_is_owned_call_temp,
+};
 use super::super::platform::Arch;
 use super::PhpType;
 use crate::parser::ast::Expr;
@@ -80,7 +84,8 @@ pub(crate) fn emit_expr_to_stdout(
             );
         }
         PhpType::Object(_) => {
-            coerce_to_string(emitter, ctx, data, &ty);
+            let release_object = expr_result_heap_ownership(expr) == HeapOwnership::Owned;
+            coerce_to_string_releasing_owned(emitter, ctx, data, &ty, release_object);
             emit_string_to_stdout_and_release_if_needed(emitter, true);
         }
         _ => {

--- a/src/conditional/stmts.rs
+++ b/src/conditional/stmts.rs
@@ -47,12 +47,59 @@ pub(super) fn apply_stmts(stmts: Vec<Stmt>, defines: &HashSet<String>) -> Vec<St
     result
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::ast::Stmt;
+    use crate::span::Span;
+
+    /// Builds a `for` header whose init slot holds an `ifdef` — a position the parser
+    /// cannot currently produce — and verifies `rewrite_stmt_kind` (reached via the for
+    /// header) resolves the ifdef against `defines` instead of hitting `unreachable!()`.
+    #[test]
+    fn for_header_ifdef_resolves_active_branch_without_panic() {
+        let span = Span::new(1, 1);
+        let ifdef = Stmt::new(
+            StmtKind::IfDef {
+                symbol: "FEATURE".to_string(),
+                then_body: vec![Stmt::new(StmtKind::Break(0), span)],
+                else_body: Some(vec![Stmt::new(StmtKind::Continue(0), span)]),
+            },
+            span,
+        );
+        let for_stmt = Stmt::new(
+            StmtKind::For {
+                init: Some(Box::new(ifdef)),
+                condition: None,
+                update: None,
+                body: Vec::new(),
+            },
+            span,
+        );
+
+        let mut defines = HashSet::new();
+        defines.insert("FEATURE".to_string());
+        let result = apply_stmts(vec![for_stmt], &defines);
+
+        let StmtKind::For { init: Some(init), .. } = &result[0].kind else {
+            panic!("expected a For statement with an init slot");
+        };
+        let StmtKind::Synthetic(stmts) = &init.kind else {
+            panic!("expected the ifdef init to be flattened into a Synthetic block");
+        };
+        assert!(
+            matches!(stmts.as_slice(), [Stmt { kind: StmtKind::Break(0), .. }]),
+            "expected the active (then) branch to be selected"
+        );
+    }
+}
+
 /// Rewrites a single `StmtKind` by applying `ifdef` conditions and recursively processing child bodies.
 ///
 /// For each variant, expressions are rewritten via `rewrite_expr` and nested statement lists are
 /// rewritten via `apply_stmts`. Branchless variants (declarations, breaks, etc.) are returned unchanged.
-/// `IfDef` variants should not reach this function — they are handled in `apply_stmts` before this
-/// is called; the `unreachable!` on line 385 enforces this invariant.
+/// `IfDef` variants are normally flattened in `apply_stmts` before this is called; if one still
+/// reaches here it is resolved against `defines` defensively rather than panicking.
 fn rewrite_stmt_kind(kind: StmtKind, defines: &HashSet<String>) -> StmtKind {
     match kind {
         StmtKind::Synthetic(stmts) => StmtKind::Synthetic(apply_stmts(stmts, defines)),
@@ -393,7 +440,22 @@ fn rewrite_stmt_kind(kind: StmtKind, defines: &HashSet<String>) -> StmtKind {
         StmtKind::ExternGlobalDecl { name, c_type } => {
             StmtKind::ExternGlobalDecl { name, c_type }
         }
-        StmtKind::IfDef { .. } => unreachable!("ifdefs are flattened in apply_stmts"),
+        StmtKind::IfDef {
+            symbol,
+            then_body,
+            else_body,
+        } => {
+            // Defense-in-depth: `apply_stmts` normally flattens ifdefs before this runs,
+            // so this arm is unreachable today. If a future caller routes an ifdef here
+            // (e.g. a `for` header), resolve it against `defines` like `apply_stmts` does
+            // rather than panicking, so the invariant fails soft instead of crashing.
+            let selected = if defines.contains(&symbol) {
+                then_body
+            } else {
+                else_body.unwrap_or_default()
+            };
+            StmtKind::Synthetic(apply_stmts(selected, defines))
+        }
         StmtKind::NamespaceDecl { name } => StmtKind::NamespaceDecl { name },
         StmtKind::NamespaceBlock { name, body } => StmtKind::NamespaceBlock {
             name,

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -46,7 +46,13 @@ impl CompileError {
     }
 
     /// Combines a vector of errors into a single error, treating the first as primary and the rest as related.
+    ///
+    /// # Panics
+    /// Panics if `errors` is empty. Callers must guarantee at least one error; the
+    /// explicit assert turns a misuse into a clear message instead of an opaque
+    /// `Vec::remove(0)` index-out-of-bounds panic.
     pub fn from_many(mut errors: Vec<CompileError>) -> Self {
+        assert!(!errors.is_empty(), "from_many requires at least one error");
         let mut first = errors.remove(0);
         first.related = errors;
         first
@@ -98,4 +104,31 @@ pub fn report(error: &CompileError) {
 /// Prints the warning message to stderr with file:line:col formatting when available.
 pub fn report_warning(warning: &CompileWarning) {
     report::print_warning(warning);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::span::Span;
+
+    /// Verifies `from_many` panics with an explicit precondition message when given an
+    /// empty error vector, instead of the opaque `Vec::remove(0)` index-out-of-bounds panic.
+    #[test]
+    #[should_panic(expected = "from_many requires at least one error")]
+    fn from_many_empty_vec_panics_with_clear_message() {
+        let _ = CompileError::from_many(Vec::new());
+    }
+
+    /// Verifies `from_many` keeps the first error as primary and attaches the rest as related.
+    #[test]
+    fn from_many_promotes_first_and_keeps_rest_related() {
+        let errors = vec![
+            CompileError::new(Span::new(1, 1), "first"),
+            CompileError::new(Span::new(2, 2), "second"),
+        ];
+        let combined = CompileError::from_many(errors);
+        assert_eq!(combined.message, "first");
+        assert_eq!(combined.related.len(), 1);
+        assert_eq!(combined.related[0].message, "second");
+    }
 }

--- a/src/lexer/cursor.rs
+++ b/src/lexer/cursor.rs
@@ -31,6 +31,21 @@ impl<'a> Cursor<'a> {
         }
     }
 
+    /// Test-only constructor over raw bytes.
+    ///
+    /// The public `new` takes `&str` (always valid UTF-8), so it cannot exercise the
+    /// malformed-byte handling in `peek`/`advance`. This builds a cursor directly over
+    /// arbitrary bytes for those tests.
+    #[cfg(test)]
+    fn from_bytes(bytes: &'a [u8]) -> Self {
+        Self {
+            bytes,
+            pos: 0,
+            line: 1,
+            col: 1,
+        }
+    }
+
     /// Returns the current source position as a one-based `Span` (line, column).
     ///
     /// Used to attach source locations to tokens for diagnostics.
@@ -48,11 +63,13 @@ impl<'a> Cursor<'a> {
         if b.is_ascii() {
             Some(b as char)
         } else {
-            // Fallback for non-ASCII (rare in PHP source)
+            // Decode the next full UTF-8 codepoint. On a malformed byte yield the U+FFFD
+            // replacement char rather than None, so callers always observe a character
+            // while bytes remain and a scan loop can never spin on a non-advancing None.
             std::str::from_utf8(&self.bytes[self.pos..])
-                .ok()?
-                .chars()
-                .next()
+                .ok()
+                .and_then(|s| s.chars().next())
+                .or(Some('\u{FFFD}'))
         }
     }
 
@@ -69,10 +86,22 @@ impl<'a> Cursor<'a> {
             self.pos += 1;
             b as char
         } else {
-            let s = std::str::from_utf8(&self.bytes[self.pos..]).ok()?;
-            let ch = s.chars().next()?;
-            self.pos += ch.len_utf8();
-            ch
+            match std::str::from_utf8(&self.bytes[self.pos..])
+                .ok()
+                .and_then(|s| s.chars().next())
+            {
+                Some(ch) => {
+                    self.pos += ch.len_utf8();
+                    ch
+                }
+                None => {
+                    // Malformed byte: consume exactly one byte and report U+FFFD so the
+                    // cursor always makes forward progress instead of returning a
+                    // non-advancing None that a scan loop could spin on.
+                    self.pos += 1;
+                    '\u{FFFD}'
+                }
+            }
         };
         if ch == '\n' {
             self.line += 1;
@@ -93,5 +122,40 @@ impl<'a> Cursor<'a> {
     /// The slice is guaranteed to be valid UTF-8 (panics if byte range is malformed).
     pub fn remaining(&self) -> &'a str {
         std::str::from_utf8(&self.bytes[self.pos..]).unwrap_or("")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verifies `advance` makes forward progress on a malformed UTF-8 byte (yields the
+    /// U+FFFD replacement char and consumes exactly one byte) so a scan loop can never
+    /// spin on a non-advancing `None` — the latent hang class is removed at the source.
+    #[test]
+    fn advance_makes_progress_on_malformed_utf8() {
+        let mut cursor = Cursor::from_bytes(&[0xff, b'a']);
+        assert_eq!(cursor.advance(), Some('\u{FFFD}'));
+        assert_eq!(cursor.advance(), Some('a'));
+        assert_eq!(cursor.advance(), None);
+        assert!(cursor.is_eof());
+    }
+
+    /// Verifies `peek` never returns `None` on a malformed byte while bytes remain, so a
+    /// `while let Some(_) = peek()` loop also terminates via progress instead of hanging.
+    #[test]
+    fn peek_yields_replacement_on_malformed_utf8() {
+        let cursor = Cursor::from_bytes(&[0xff]);
+        assert_eq!(cursor.peek(), Some('\u{FFFD}'));
+        assert!(!cursor.is_eof());
+    }
+
+    /// Verifies a valid multi-byte UTF-8 codepoint is still decoded whole and advances by
+    /// its byte length, so the malformed-byte handling does not corrupt valid input.
+    #[test]
+    fn advance_decodes_valid_multibyte_codepoint() {
+        let mut cursor = Cursor::from_bytes("é".as_bytes());
+        assert_eq!(cursor.advance(), Some('é'));
+        assert!(cursor.is_eof());
     }
 }

--- a/src/lexer/literals.rs
+++ b/src/lexer/literals.rs
@@ -12,6 +12,6 @@ mod identifiers;
 mod numbers;
 mod strings;
 
-pub(super) use identifiers::{scan_keyword, scan_variable};
+pub(super) use identifiers::{is_ident_start, scan_keyword, scan_variable};
 pub(super) use numbers::{scan_dot_float, scan_number};
 pub(super) use strings::{scan_double_string_interpolated, scan_heredoc, scan_single_string};

--- a/src/lexer/literals/identifiers.rs
+++ b/src/lexer/literals/identifiers.rs
@@ -12,6 +12,19 @@ use super::super::cursor::Cursor;
 use super::super::token::Token;
 use crate::errors::CompileError;
 
+/// Returns true if `c` may start a PHP identifier: an ASCII letter, `_`, or any
+/// non-ASCII character. PHP allows identifier bytes 0x80-0xFF, so names like `$café`
+/// and `function 价格()` are valid; a non-ASCII codepoint encodes to such bytes.
+pub(in crate::lexer) fn is_ident_start(c: char) -> bool {
+    c.is_ascii_alphabetic() || c == '_' || !c.is_ascii()
+}
+
+/// Returns true if `c` may continue a PHP identifier: an ASCII alphanumeric, `_`, or any
+/// non-ASCII character. Matches PHP's `[a-zA-Z0-9_\x80-\xff]*` continuation class.
+pub(in crate::lexer) fn is_ident_continue(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_' || !c.is_ascii()
+}
+
 /// Scans a PHP variable (`$name`), consuming the leading `$` and collecting the
 /// identifier name. Returns `Token::This` for `$this`, or `Token::Variable(name)`
 /// otherwise. Leaves the cursor positioned after the last valid identifier character.
@@ -20,7 +33,7 @@ pub(in crate::lexer) fn scan_variable(cursor: &mut Cursor) -> Result<Token, Comp
     let mut name = String::new();
 
     while let Some(ch) = cursor.peek() {
-        if ch.is_ascii_alphanumeric() || ch == '_' {
+        if is_ident_continue(ch) {
             name.push(ch);
             cursor.advance();
         } else {
@@ -49,7 +62,7 @@ pub(in crate::lexer) fn scan_keyword(cursor: &mut Cursor) -> Result<Token, Compi
     let mut word = String::new();
 
     while let Some(ch) = cursor.peek() {
-        if ch.is_ascii_alphanumeric() || ch == '_' {
+        if is_ident_continue(ch) {
             word.push(ch);
             cursor.advance();
         } else {

--- a/src/lexer/literals/strings.rs
+++ b/src/lexer/literals/strings.rs
@@ -16,12 +16,17 @@ use crate::span::Span;
 use std::iter::Peekable;
 use std::str::Chars;
 
-/// Abstracts single-character lookahead and consumption for escape sequence parsers.
+/// Abstracts character lookahead and consumption for escape sequence and interpolation
+/// parsers, so the double-quoted (cursor-backed) and heredoc (chars-backed) paths share
+/// one implementation.
 trait EscapeInput {
     /// Returns the next character without consuming it.
     fn peek_escape(&mut self) -> Option<char>;
     /// Consumes and returns the next character.
     fn advance_escape(&mut self) -> Option<char>;
+    /// Returns the character `n` positions ahead (0 = next) without consuming, for the
+    /// multi-character lookahead interpolation needs (`{$`, `->prop`).
+    fn peek_nth(&mut self, n: usize) -> Option<char>;
 }
 
 impl EscapeInput for Cursor<'_> {
@@ -32,6 +37,10 @@ impl EscapeInput for Cursor<'_> {
     /// Consumes and returns the next character from the cursor.
     fn advance_escape(&mut self) -> Option<char> {
         self.advance()
+    }
+    /// Returns the character `n` positions ahead in the remaining source.
+    fn peek_nth(&mut self, n: usize) -> Option<char> {
+        self.remaining().chars().nth(n)
     }
 }
 
@@ -50,40 +59,101 @@ impl EscapeInput for CharsEscapeInput<'_, '_> {
     fn advance_escape(&mut self) -> Option<char> {
         self.chars.next()
     }
+
+    /// Returns the character `n` positions ahead by cloning the peekable iterator, which
+    /// is cheap (a `Chars` slice cursor) and leaves the original position untouched.
+    fn peek_nth(&mut self, n: usize) -> Option<char> {
+        (*self.chars).clone().nth(n)
+    }
 }
 
 /// Scan a double-quoted string with interpolation support.
 /// Returns one or more tokens: for `"Hello $name!"` it returns
-/// `StringLiteral("Hello ") . Variable("name") . StringLiteral("!")`
-/// (with Dot tokens for concatenation).
+/// `("Hello " . Variable("name") . "!")` (parenthesized, with Dot tokens for concatenation).
 pub(in crate::lexer) fn scan_double_string_interpolated(
     cursor: &mut Cursor,
 ) -> Result<Vec<(Token, Span)>, CompileError> {
     let span = cursor.span();
     cursor.advance(); // opening "
+    interpolate(cursor, span, Some('"'), MissingEscape::Error)
+}
 
-    let mut tokens = Vec::new();
+/// Appends one interpolated expression part (already a token list) to the running stream,
+/// flushing any pending literal text and inserting `.` concatenation.
+///
+/// When this is the first part, the pending literal (possibly empty) is emitted first so
+/// the resulting `.` chain is always string-typed, matching PHP's rule that a
+/// double-quoted/heredoc string is always a string.
+fn push_interp_part(
+    tokens: &mut Vec<(Token, Span)>,
+    current: &mut String,
+    part: Vec<Token>,
+    span: Span,
+) {
+    if tokens.is_empty() {
+        tokens.push((Token::StringLiteral(std::mem::take(current)), span));
+    } else if !current.is_empty() {
+        tokens.push((Token::Dot, span));
+        tokens.push((Token::StringLiteral(std::mem::take(current)), span));
+    }
+    tokens.push((Token::Dot, span));
+    for token in part {
+        tokens.push((token, span));
+    }
+}
+
+/// Shared interpolation routine for double-quoted strings and heredoc bodies.
+///
+/// `terminator` is the closing delimiter (`Some('"')` for double-quoted strings, `None`
+/// for heredoc content that ends at input end). Handles escapes, simple `$name`,
+/// `$name[offset]` and `$name->prop` syntax, and complex `{$expr}` interpolation. Returns
+/// a single `StringLiteral` when no interpolation occurred, otherwise a parenthesized
+/// concatenation token stream.
+fn interpolate(
+    input: &mut impl EscapeInput,
+    span: Span,
+    terminator: Option<char>,
+    missing_escape: MissingEscape,
+) -> Result<Vec<(Token, Span)>, CompileError> {
+    let mut tokens: Vec<(Token, Span)> = Vec::new();
     let mut current = String::new();
     let mut has_interpolation = false;
 
     loop {
-        match cursor.peek() {
-            Some('"') => {
-                cursor.advance();
+        match input.peek_escape() {
+            None => {
+                if terminator.is_some() {
+                    return Err(CompileError::new(span, "Unterminated string literal"));
+                }
+                break;
+            }
+            Some(c) if Some(c) == terminator => {
+                input.advance_escape();
                 break;
             }
             Some('\\') => {
-                cursor.advance();
-                let escaped = scan_double_quoted_escape(cursor, span, MissingEscape::Error)?;
+                input.advance_escape();
+                let escaped = scan_double_quoted_escape(input, span, missing_escape)?;
                 current.push_str(&escaped);
             }
+            // Complex interpolation: `{$expr}` (the `{` is only special when followed by `$`).
+            Some('{') if input.peek_nth(1) == Some('$') => {
+                input.advance_escape(); // consume '{'
+                let inner = capture_braced_expr(input, span)?;
+                let fragment = tokenize_fragment(&inner, span)?;
+                has_interpolation = true;
+                let mut part = vec![Token::LParen];
+                part.extend(fragment.into_iter().map(|(token, _)| token));
+                part.push(Token::RParen);
+                push_interp_part(&mut tokens, &mut current, part, span);
+            }
             Some('$') => {
-                cursor.advance(); // consume '$'
+                input.advance_escape(); // consume '$'
                 let mut name = String::new();
-                while let Some(ch) = cursor.peek() {
+                while let Some(ch) = input.peek_escape() {
                     if is_ident_continue(ch) {
                         name.push(ch);
-                        cursor.advance();
+                        input.advance_escape();
                     } else {
                         break;
                     }
@@ -92,23 +162,15 @@ pub(in crate::lexer) fn scan_double_string_interpolated(
                     current.push('$');
                 } else {
                     has_interpolation = true;
-                    if !current.is_empty() || tokens.is_empty() {
-                        if !tokens.is_empty() {
-                            tokens.push((Token::Dot, span));
-                        }
-                        tokens.push((Token::StringLiteral(std::mem::take(&mut current)), span));
-                    }
-                    if !tokens.is_empty() && !matches!(tokens.last(), Some((Token::Dot, _))) {
-                        tokens.push((Token::Dot, span));
-                    }
-                    tokens.push((Token::Variable(name), span));
+                    let mut part = vec![Token::Variable(name)];
+                    append_simple_access(input, &mut part, span)?;
+                    push_interp_part(&mut tokens, &mut current, part, span);
                 }
             }
             Some(c) => {
                 push_literal_char(c, &mut current);
-                cursor.advance();
+                input.advance_escape();
             }
-            None => return Err(CompileError::new(span, "Unterminated string literal")),
         }
     }
 
@@ -125,6 +187,172 @@ pub(in crate::lexer) fn scan_double_string_interpolated(
     result.extend(tokens);
     result.push((Token::RParen, span));
     Ok(result)
+}
+
+/// Appends the simple-syntax access that may follow a `$name` in an interpolated string:
+/// a single `[offset]` or a single `->prop`. PHP's "simple syntax" allows exactly one
+/// level; anything more must use the complex `{$expr}` form. Leaves `input` positioned
+/// after the consumed access (or unchanged if none applies).
+fn append_simple_access(
+    input: &mut impl EscapeInput,
+    part: &mut Vec<Token>,
+    span: Span,
+) -> Result<(), CompileError> {
+    if input.peek_escape() == Some('[') {
+        input.advance_escape(); // consume '['
+        append_simple_offset_key(input, part);
+        if input.peek_escape() == Some(']') {
+            input.advance_escape();
+        } else {
+            return Err(CompileError::new(
+                span,
+                "Unterminated array offset in string interpolation",
+            ));
+        }
+    } else if input.peek_escape() == Some('-')
+        && input.peek_nth(1) == Some('>')
+        && input.peek_nth(2).is_some_and(is_ident_continue)
+    {
+        input.advance_escape(); // consume '-'
+        input.advance_escape(); // consume '>'
+        let mut prop = String::new();
+        while let Some(ch) = input.peek_escape() {
+            if is_ident_continue(ch) {
+                prop.push(ch);
+                input.advance_escape();
+            } else {
+                break;
+            }
+        }
+        part.push(Token::Arrow);
+        part.push(Token::Identifier(prop));
+    }
+    Ok(())
+}
+
+/// Reads the offset key for a simple `$name[offset]` interpolation and appends the
+/// `[ key ]` tokens to `part`. PHP simple syntax keys are a `$var`, an optionally-negative
+/// integer, or a bareword treated as a string key (never quoted).
+fn append_simple_offset_key(input: &mut impl EscapeInput, part: &mut Vec<Token>) {
+    part.push(Token::LBracket);
+    match input.peek_escape() {
+        Some('$') => {
+            input.advance_escape();
+            let mut name = String::new();
+            while let Some(ch) = input.peek_escape() {
+                if is_ident_continue(ch) {
+                    name.push(ch);
+                    input.advance_escape();
+                } else {
+                    break;
+                }
+            }
+            part.push(Token::Variable(name));
+        }
+        Some(c) if c == '-' || c.is_ascii_digit() => {
+            let mut digits = String::new();
+            if c == '-' {
+                digits.push('-');
+                input.advance_escape();
+            }
+            while let Some(ch) = input.peek_escape() {
+                if ch.is_ascii_digit() {
+                    digits.push(ch);
+                    input.advance_escape();
+                } else {
+                    break;
+                }
+            }
+            part.push(Token::IntLiteral(digits.parse().unwrap_or(0)));
+        }
+        _ => {
+            let mut key = String::new();
+            while let Some(ch) = input.peek_escape() {
+                if is_ident_continue(ch) {
+                    key.push(ch);
+                    input.advance_escape();
+                } else {
+                    break;
+                }
+            }
+            part.push(Token::StringLiteral(key));
+        }
+    }
+    part.push(Token::RBracket);
+}
+
+/// Captures the source text of a complex `{$expr}` interpolation up to its matching `}`.
+///
+/// The opening `{` has already been consumed; the leading `$` is still pending and is
+/// included in the returned text. Nested braces are balanced, and string literals inside
+/// the expression are copied verbatim so their braces/quotes do not affect the depth.
+fn capture_braced_expr(
+    input: &mut impl EscapeInput,
+    span: Span,
+) -> Result<String, CompileError> {
+    let mut inner = String::new();
+    let mut depth = 1usize;
+    loop {
+        match input.advance_escape() {
+            None => {
+                return Err(CompileError::new(
+                    span,
+                    "Unterminated complex interpolation '{$...}'",
+                ))
+            }
+            Some('{') => {
+                depth += 1;
+                inner.push('{');
+            }
+            Some('}') => {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+                inner.push('}');
+            }
+            Some(quote @ ('"' | '\'')) => {
+                inner.push(quote);
+                loop {
+                    match input.advance_escape() {
+                        None => {
+                            return Err(CompileError::new(
+                                span,
+                                "Unterminated string in complex interpolation '{$...}'",
+                            ))
+                        }
+                        Some('\\') => {
+                            inner.push('\\');
+                            if let Some(escaped) = input.advance_escape() {
+                                inner.push(escaped);
+                            }
+                        }
+                        Some(c) if c == quote => {
+                            inner.push(c);
+                            break;
+                        }
+                        Some(c) => inner.push(c),
+                    }
+                }
+            }
+            Some(c) => inner.push(c),
+        }
+    }
+    Ok(inner)
+}
+
+/// Tokenizes the captured `{$expr}` source as a standalone expression by lexing it behind
+/// a synthetic `<?php` tag, then dropping the open tag and EOF and re-spanning the tokens
+/// to the enclosing string's span. Reuses the full lexer so nested strings, calls, and
+/// array/property access inside the braces are handled like any other expression.
+fn tokenize_fragment(inner: &str, span: Span) -> Result<Vec<(Token, Span)>, CompileError> {
+    let source = format!("<?php {}", inner);
+    let tokens = crate::lexer::tokenize(&source)?;
+    Ok(tokens
+        .into_iter()
+        .filter(|(token, _)| !matches!(token, Token::OpenTag | Token::Eof))
+        .map(|(token, _)| (token, span))
+        .collect())
 }
 
 /// Scans a single-quoted PHP string, handling `\'` and `\\` escape sequences.
@@ -254,7 +482,9 @@ pub(in crate::lexer) fn scan_heredoc(
                     return Ok(vec![(Token::StringLiteral(content), span)]);
                 }
 
-                return interpolate_heredoc_content(&content, span);
+                let mut chars = content.chars().peekable();
+                let mut input = CharsEscapeInput { chars: &mut chars };
+                return interpolate(&mut input, span, None, MissingEscape::Literal);
             }
         }
 
@@ -263,80 +493,6 @@ pub(in crate::lexer) fn scan_heredoc(
             None => return Err(CompileError::new(span, "Unterminated heredoc/nowdoc")),
         }
     }
-}
-
-/// Interpolate variables and process escape sequences in heredoc content.
-/// Handles both in a single pass so that `\$` produces a literal `$` without triggering
-/// variable interpolation. Scans for `$identifier` patterns and expands them into
-/// concatenation tokens: `Hello $name!` -> `("Hello " . $name . "!")`
-fn interpolate_heredoc_content(
-    content: &str,
-    span: Span,
-) -> Result<Vec<(Token, Span)>, CompileError> {
-    let mut tokens = Vec::new();
-    let mut current = String::new();
-    let mut has_interpolation = false;
-    let mut chars = content.chars().peekable();
-
-    loop {
-        match chars.peek() {
-            None => break,
-            Some(&'\\') => {
-                chars.next();
-                let mut input = CharsEscapeInput { chars: &mut chars };
-                let escaped = scan_double_quoted_escape(&mut input, span, MissingEscape::Literal)?;
-                current.push_str(&escaped);
-            }
-            Some(&'$') => {
-                chars.next();
-                let mut name = String::new();
-                while let Some(&ch) = chars.peek() {
-                    if is_ident_continue(ch) {
-                        name.push(ch);
-                        chars.next();
-                    } else {
-                        break;
-                    }
-                }
-                if name.is_empty() {
-                    current.push('$');
-                } else {
-                    has_interpolation = true;
-                    if !current.is_empty() || tokens.is_empty() {
-                        if !tokens.is_empty() {
-                            tokens.push((Token::Dot, span));
-                        }
-                        tokens.push((
-                            Token::StringLiteral(std::mem::take(&mut current)),
-                            span,
-                        ));
-                    }
-                    if !tokens.is_empty() && !matches!(tokens.last(), Some((Token::Dot, _))) {
-                        tokens.push((Token::Dot, span));
-                    }
-                    tokens.push((Token::Variable(name), span));
-                }
-            }
-            Some(&ch) => {
-                push_literal_char(ch, &mut current);
-                chars.next();
-            }
-        }
-    }
-
-    if !has_interpolation {
-        return Ok(vec![(Token::StringLiteral(current), span)]);
-    }
-
-    if !current.is_empty() {
-        tokens.push((Token::Dot, span));
-        tokens.push((Token::StringLiteral(current), span));
-    }
-
-    let mut result = vec![(Token::LParen, span)];
-    result.extend(tokens);
-    result.push((Token::RParen, span));
-    Ok(result)
 }
 
 /// Controls how a bare backslash at end of input is treated inside double-quoted strings.

--- a/src/lexer/literals/strings.rs
+++ b/src/lexer/literals/strings.rs
@@ -440,59 +440,111 @@ pub(in crate::lexer) fn scan_heredoc(
     }
 
     let mut content = String::new();
+    let mut at_line_start = true;
     loop {
         if cursor.is_eof() {
             return Err(CompileError::new(span, "Unterminated heredoc/nowdoc"));
         }
 
-        let remaining = cursor.remaining();
-
-        let mut ws_count = 0;
-        for b in remaining.bytes() {
-            if b == b' ' || b == b'\t' {
-                ws_count += 1;
-            } else {
-                break;
-            }
-        }
-
-        let after_ws = &remaining[ws_count..];
-        if after_ws.starts_with(&label) {
-            let after_label = &after_ws[label.len()..];
-            if after_label.is_empty()
-                || after_label.starts_with(';')
-                || after_label.starts_with('\n')
-                || after_label.starts_with('\r')
-            {
-                for _ in 0..ws_count {
-                    cursor.advance();
-                }
-                for _ in 0..label.len() {
-                    cursor.advance();
-                }
-
-                if content.ends_with('\n') {
-                    content.pop();
-                    if content.ends_with('\r') {
-                        content.pop();
+        // The closing label is only recognized at the start of a line (optionally indented),
+        // so a label appearing mid-line is treated as body content.
+        if at_line_start {
+            let remaining = cursor.remaining();
+            let ws_count = remaining
+                .bytes()
+                .take_while(|&b| b == b' ' || b == b'\t')
+                .count();
+            let after_ws = &remaining[ws_count..];
+            if after_ws.starts_with(&label) {
+                let after_label = &after_ws[label.len()..];
+                // PHP closes the heredoc when the label is followed by end-of-input or any
+                // character that cannot continue an identifier (`;`, `)`, `,`, `.`, space,
+                // `[`, newline, ...) — but not by another identifier char (e.g. `EOTX`).
+                let closes = after_label
+                    .chars()
+                    .next()
+                    .map_or(true, |c| !is_ident_continue(c));
+                if closes {
+                    for _ in 0..ws_count + label.len() {
+                        cursor.advance();
                     }
-                }
 
-                if is_nowdoc {
-                    return Ok(vec![(Token::StringLiteral(content), span)]);
-                }
+                    if content.ends_with('\n') {
+                        content.pop();
+                        if content.ends_with('\r') {
+                            content.pop();
+                        }
+                    }
 
-                let mut chars = content.chars().peekable();
-                let mut input = CharsEscapeInput { chars: &mut chars };
-                return interpolate(&mut input, span, None, MissingEscape::Literal);
+                    // PHP 7.3+ flexible heredoc/nowdoc: strip the closing marker's
+                    // indentation from every body line before interpolation.
+                    let content = strip_heredoc_indentation(&content, ws_count, span)?;
+
+                    if is_nowdoc {
+                        return Ok(vec![(Token::StringLiteral(content), span)]);
+                    }
+
+                    let mut chars = content.chars().peekable();
+                    let mut input = CharsEscapeInput { chars: &mut chars };
+                    return interpolate(&mut input, span, None, MissingEscape::Literal);
+                }
             }
         }
 
         match cursor.advance() {
-            Some(ch) => push_literal_char(ch, &mut content),
+            Some(ch) => {
+                at_line_start = ch == '\n';
+                push_literal_char(ch, &mut content);
+            }
             None => return Err(CompileError::new(span, "Unterminated heredoc/nowdoc")),
         }
     }
+}
+
+/// Strips the closing marker's indentation (`indent` leading space/tab characters) from
+/// every line of a PHP 7.3+ flexible heredoc/nowdoc body.
+///
+/// A non-blank line indented by fewer than `indent` whitespace characters is a PHP
+/// "Invalid body indentation level" error. Blank lines keep whatever they had (after
+/// removing up to `indent` leading whitespace). `\r` line endings are preserved.
+fn strip_heredoc_indentation(
+    content: &str,
+    indent: usize,
+    span: Span,
+) -> Result<String, CompileError> {
+    if indent == 0 {
+        return Ok(content.to_string());
+    }
+    let mut result = String::new();
+    for (i, line) in content.split('\n').enumerate() {
+        if i > 0 {
+            result.push('\n');
+        }
+        let (body, carriage_return) = match line.strip_suffix('\r') {
+            Some(stripped) => (stripped, "\r"),
+            None => (line, ""),
+        };
+        let mut removed = 0;
+        let mut rest = body;
+        while removed < indent {
+            match rest.chars().next() {
+                Some(c) if c == ' ' || c == '\t' => {
+                    rest = &rest[1..];
+                    removed += 1;
+                }
+                _ => break,
+            }
+        }
+        if removed < indent && !rest.is_empty() {
+            return Err(CompileError::new(
+                span,
+                "Invalid heredoc body indentation level",
+            ));
+        }
+        result.push_str(rest);
+        result.push_str(carriage_return);
+    }
+    Ok(result)
 }
 
 /// Controls how a bare backslash at end of input is treated inside double-quoted strings.

--- a/src/lexer/literals/strings.rs
+++ b/src/lexer/literals/strings.rs
@@ -10,6 +10,7 @@
 
 use super::super::cursor::Cursor;
 use super::super::token::Token;
+use super::identifiers::is_ident_continue;
 use crate::errors::CompileError;
 use crate::span::Span;
 use std::iter::Peekable;
@@ -80,7 +81,7 @@ pub(in crate::lexer) fn scan_double_string_interpolated(
                 cursor.advance(); // consume '$'
                 let mut name = String::new();
                 while let Some(ch) = cursor.peek() {
-                    if ch.is_ascii_alphanumeric() || ch == '_' {
+                    if is_ident_continue(ch) {
                         name.push(ch);
                         cursor.advance();
                     } else {
@@ -290,7 +291,7 @@ fn interpolate_heredoc_content(
                 chars.next();
                 let mut name = String::new();
                 while let Some(&ch) = chars.peek() {
-                    if ch.is_ascii_alphanumeric() || ch == '_' {
+                    if is_ident_continue(ch) {
                         name.push(ch);
                         chars.next();
                     } else {

--- a/src/lexer/scan.rs
+++ b/src/lexer/scan.rs
@@ -297,6 +297,9 @@ fn scan_token(cursor: &mut Cursor) -> Result<Token, CompileError> {
         '$' => literals::scan_variable(cursor),
         '0'..='9' => literals::scan_number(cursor),
         'a'..='z' | 'A'..='Z' | '_' => literals::scan_keyword(cursor),
+        // PHP allows non-ASCII identifier characters (bytes 0x80-0xFF), so a word that
+        // starts with one is scanned as an identifier rather than rejected.
+        c if literals::is_ident_start(c) => literals::scan_keyword(cursor),
         _ => Err(CompileError::new(
             cursor.span(),
             &format!("Unexpected character: '{}'", ch),

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -304,13 +304,39 @@ fn run_tool(name: &str, cmd: &mut Command) {
 }
 
 /// Returns the macOS SDK path by running `xcrun --show-sdk-path`.
-/// Returns an empty string if the command fails.
+///
+/// Exits with an actionable diagnostic when no SDK path can be resolved (xcrun missing,
+/// or returning empty output because the Xcode Command Line Tools are not installed /
+/// `xcode-select` points at a bad directory) instead of passing an empty `-syslibroot`
+/// argument to `ld`, which fails with a cryptic `ld: -syslibroot missing <path>`.
 fn macos_sdk_path() -> String {
-    Command::new("xcrun")
+    let resolved = Command::new("xcrun")
         .args(["--show-sdk-path"])
         .output()
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-        .unwrap_or_default()
+        .unwrap_or_default();
+    match validate_macos_sdk_path(&resolved) {
+        Ok(path) => path,
+        Err(message) => {
+            eprintln!("{}", message);
+            process::exit(1);
+        }
+    }
+}
+
+/// Validates a resolved macOS SDK path, returning the trimmed path or an actionable
+/// error message when `xcrun` produced no path. Kept pure (no IO/exit) so the
+/// empty-path diagnostic can be unit-tested.
+fn validate_macos_sdk_path(resolved: &str) -> Result<String, String> {
+    let trimmed = resolved.trim();
+    if trimmed.is_empty() {
+        return Err(
+            "Could not locate the macOS SDK. Install the Xcode Command Line Tools \
+             (run: xcode-select --install) and make sure `xcrun --show-sdk-path` prints a valid path."
+                .to_string(),
+        );
+    }
+    Ok(trimmed.to_string())
 }
 
 /// Returns common Homebrew library directories used for optional native deps on macOS.
@@ -337,5 +363,26 @@ fn macos_sdk_version() -> String {
             }
         }
         Err(_) => "15.0".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verifies an empty or whitespace-only SDK path (xcrun missing or misconfigured)
+    /// yields an actionable Xcode Command Line Tools hint instead of being silently
+    /// passed to `ld` as an empty `-syslibroot` argument.
+    #[test]
+    fn empty_sdk_path_produces_actionable_error() {
+        let err = validate_macos_sdk_path("   ").expect_err("empty path must error");
+        assert!(err.contains("xcode-select --install"), "got: {err}");
+    }
+
+    /// Verifies a real SDK path is returned trimmed and otherwise unchanged.
+    #[test]
+    fn valid_sdk_path_is_returned_trimmed() {
+        let ok = validate_macos_sdk_path("  /Library/Dev/MacOSX.sdk\n").expect("valid path");
+        assert_eq!(ok, "/Library/Dev/MacOSX.sdk");
     }
 }

--- a/src/names.rs
+++ b/src/names.rs
@@ -191,9 +191,11 @@ pub fn php_symbol_key(name: &str) -> String {
 
 /// Returns an assembly-safe mangled form of a fully-qualified name.
 ///
-/// Replaces non-alphanumeric characters: `_` → `_u_`, `\` → `_N_`. Alphanumeric
-/// characters and digits are preserved. Panics on unsupported characters.
-/// Used to produce valid assembly labels from PHP FQNs.
+/// ASCII letters and digits are preserved; `_` → `_u_` and `\` → `_N_`. Any other
+/// character (including the non-ASCII bytes PHP permits in identifiers) is escaped as
+/// one `_xNN_` group per UTF-8 byte. The `_x` prefix cannot collide with the `_u_`/`_N_`
+/// escapes, so the mapping stays injective. Total by construction — never panics — so
+/// an unusual symbol name can never crash the compiler.
 pub fn mangle_fqn(name: &str) -> String {
     let mut mangled = String::new();
     for ch in name.chars() {
@@ -201,10 +203,49 @@ pub fn mangle_fqn(name: &str) -> String {
             'A'..='Z' | 'a'..='z' | '0'..='9' => mangled.push(ch),
             '_' => mangled.push_str("_u_"),
             '\\' => mangled.push_str("_N_"),
-            _ => panic!("unsupported symbol character in mangled name: {}", ch),
+            other => {
+                let mut buf = [0u8; 4];
+                for byte in other.encode_utf8(&mut buf).bytes() {
+                    mangled.push_str(&format!("_x{:02x}_", byte));
+                }
+            }
         }
     }
     mangled
+}
+
+#[cfg(test)]
+mod mangle_tests {
+    use super::*;
+
+    /// Verifies the existing `_u_`/`_N_` escapes for underscore and namespace separator
+    /// are preserved unchanged by the mangling.
+    #[test]
+    fn mangle_fqn_preserves_existing_escapes() {
+        assert_eq!(mangle_fqn("foo"), "foo");
+        assert_eq!(mangle_fqn("foo_bar"), "foo_u_bar");
+        assert_eq!(mangle_fqn("A\\B"), "A_N_B");
+    }
+
+    /// Verifies a non-ASCII identifier (legal in PHP) mangles into a valid assembly label
+    /// instead of panicking, so unsupported characters can never crash the compiler.
+    #[test]
+    fn mangle_fqn_escapes_non_ascii_without_panicking() {
+        let mangled = mangle_fqn("价格");
+        assert!(
+            mangled.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'),
+            "mangled name must be an assembler-safe label, got {mangled}"
+        );
+    }
+
+    /// Verifies distinct names mangle to distinct labels, so escaping does not collapse
+    /// different symbols onto the same assembly label.
+    #[test]
+    fn mangle_fqn_distinguishes_distinct_names() {
+        assert_ne!(mangle_fqn("价"), mangle_fqn("格"));
+        assert_ne!(mangle_fqn("价"), mangle_fqn("a"));
+        assert_ne!(mangle_fqn("a_b"), mangle_fqn("a\\b"));
+    }
 }
 
 /// Returns the global function symbol label for a given PHP function name.

--- a/src/source_map.rs
+++ b/src/source_map.rs
@@ -66,12 +66,44 @@ pub fn write_source_map(
 }
 
 /// Escapes a string for use inside a JSON value: backslashes, quotes, and control
-/// characters are prefixed with backslashes so the result is valid JSON text.
+/// characters are escaped so the result is valid JSON text (RFC 8259 §7). All control
+/// characters below 0x20 are escaped — `\b`/`\f`/`\n`/`\r`/`\t` use their short forms,
+/// any other control char uses a `\u00XX` sequence.
 fn escape_json(value: &str) -> String {
-    value
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
-        .replace('\t', "\\t")
+    let mut out = String::new();
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\u{08}' => out.push_str("\\b"),
+            '\u{0c}' => out.push_str("\\f"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verifies control characters below 0x20 are escaped per RFC 8259: backspace/form-feed
+    /// use their short forms and other control chars (vertical tab, ESC) use `\u00XX`, so a
+    /// path containing such bytes still produces valid JSON instead of raw control bytes.
+    #[test]
+    fn escapes_control_characters() {
+        let escaped = escape_json("a\u{08}b\u{0c}c\u{0b}d\u{1b}e");
+        assert_eq!(escaped, "a\\bb\\fc\\u000bd\\u001be");
+    }
+
+    /// Verifies the previously handled cases (backslash, quote, newline, tab) still escape.
+    #[test]
+    fn escapes_quotes_backslashes_and_whitespace() {
+        let escaped = escape_json("a\\b\"c\nd\te");
+        assert_eq!(escaped, "a\\\\b\\\"c\\nd\\te");
+    }
 }

--- a/src/types/checker/builtins/callables.rs
+++ b/src/types/checker/builtins/callables.rs
@@ -1059,6 +1059,18 @@ pub(super) fn check_builtin(
                     let ret_ty = checker.check_function_call(&cb_name, &spread_args, span, env)?;
                     return Ok(Some(ret_ty));
                 }
+                // A string-literal callback that matched no extern, builtin, user function,
+                // or fn_decl is an undefined function. Reject plain function-name callbacks
+                // here instead of falling through to the generic `Str` acceptance below
+                // (which returns Mixed and defers the unknown name to a dangling symbol /
+                // mangle escape at codegen). Strings containing "::" are static-method
+                // forms and keep their existing fall-through path.
+                if !cb_name.contains("::") {
+                    return Err(CompileError::new(
+                        args[0].span,
+                        &format!("Undefined function: {}", cb_name),
+                    ));
+                }
             }
             let arg_array_ty = checker.infer_type(&args[1], env)?;
             if call_user_func_array_arg_container_is_runtime_opaque(&arg_array_ty) {

--- a/tests/codegen/callables/language_features.rs
+++ b/tests/codegen/callables/language_features.rs
@@ -450,3 +450,35 @@ fn test_heredoc_escaped_dollar() {
     assert_eq!(out, "Price is $100");
 }
 
+/// Verifies a heredoc passed as a function argument closes when its label is immediately
+/// followed by `)` (PHP closes on any non-identifier char after the label).
+#[test]
+fn test_heredoc_closer_as_call_argument() {
+    let out = compile_and_run("<?php\nfunction f($s) { return $s; }\necho f(<<<EOT\nhello\nEOT);\n");
+    assert_eq!(out, "hello");
+}
+
+/// Verifies a heredoc whose label is followed by ` . "..."` closes and concatenates,
+/// covering closer terminators other than `;`/newline.
+#[test]
+fn test_heredoc_closer_followed_by_concat() {
+    let out = compile_and_run("<?php\necho <<<EOT\nhi\nEOT . \"!\";\n");
+    assert_eq!(out, "hi!");
+}
+
+/// Verifies PHP 7.3+ flexible-heredoc indentation: the closing marker's leading whitespace
+/// is stripped from every body line.
+#[test]
+fn test_heredoc_flexible_indentation() {
+    let out = compile_and_run("<?php\necho <<<EOT\n    line1\n    line2\n    EOT;\n");
+    assert_eq!(out, "line1\nline2");
+}
+
+/// Verifies the closing label is only recognized at the start of a line: a label appearing
+/// mid-line (`a EOT b`) is body content, not a closer.
+#[test]
+fn test_heredoc_label_substring_midline_not_closer() {
+    let out = compile_and_run("<?php\n$s = <<<EOT\na EOT b\nEOT;\necho $s;\n");
+    assert_eq!(out, "a EOT b");
+}
+

--- a/tests/codegen/echo_vars.rs
+++ b/tests/codegen/echo_vars.rs
@@ -40,6 +40,30 @@ fn test_echo_escape_sequences() {
     assert_eq!(out, "a\tb\nc");
 }
 
+/// Verifies a variable whose name contains non-ASCII letters (PHP allows identifier
+/// bytes 0x80-0xFF) round-trips through the full pipeline and echoes its value.
+#[test]
+fn test_echo_unicode_variable() {
+    let out = compile_and_run("<?php $café = 7; echo $café;");
+    assert_eq!(out, "7");
+}
+
+/// Verifies a user function with a non-ASCII name is declared, mangled to a valid symbol,
+/// and called end-to-end.
+#[test]
+fn test_call_unicode_function_name() {
+    let out = compile_and_run("<?php function 价格() { return 5; } echo 价格();");
+    assert_eq!(out, "5");
+}
+
+/// Verifies a variable with non-ASCII letters interpolates inside a double-quoted string
+/// instead of being truncated at the first non-ASCII byte.
+#[test]
+fn test_echo_unicode_variable_interpolated() {
+    let out = compile_and_run("<?php $café = \"x\"; echo \"v=$café\";");
+    assert_eq!(out, "v=x");
+}
+
 // --- Phase 2: Variables and integers ---
 
 /// Compiles `<?php echo 42;` and asserts stdout is `"42"`.

--- a/tests/codegen/runtime_gc/regressions.rs
+++ b/tests/codegen/runtime_gc/regressions.rs
@@ -96,6 +96,69 @@ echo "done";
     assert_eq!(allocs, frees, "expected clean heap, got: {}", out.stderr);
 }
 
+/// Regression: a temporary object implicitly stringified via `__toString` in `echo` must
+/// be released, not leaked. 100 iterations would accumulate 100 leaked objects otherwise.
+#[test]
+fn test_tostring_temp_object_released_on_echo() {
+    let out = compile_and_run_with_gc_stats(
+        r#"<?php
+class Greeter { public function __toString(): string { return "hi"; } }
+for ($i = 0; $i < 100; $i++) { echo new Greeter(); }
+echo "\n";
+"#,
+    );
+    let (allocs, frees) = parse_gc_stats(&out.stderr);
+    assert_eq!(allocs, frees, "expected clean heap, got: {}", out.stderr);
+}
+
+/// Regression: a temporary object stringified via `__toString` in a concatenation must be
+/// released.
+#[test]
+fn test_tostring_temp_object_released_on_concat() {
+    let out = compile_and_run_with_gc_stats(
+        r#"<?php
+class Greeter { public function __toString(): string { return "hi"; } }
+for ($i = 0; $i < 100; $i++) { $s = "x" . new Greeter(); }
+echo "done";
+"#,
+    );
+    assert_eq!(out.stdout, "done");
+    let (allocs, frees) = parse_gc_stats(&out.stderr);
+    assert_eq!(allocs, frees, "expected clean heap, got: {}", out.stderr);
+}
+
+/// Regression: a temporary object cast to string via `(string)` must be released.
+#[test]
+fn test_tostring_temp_object_released_on_string_cast() {
+    let out = compile_and_run_with_gc_stats(
+        r#"<?php
+class Greeter { public function __toString(): string { return "hi"; } }
+for ($i = 0; $i < 100; $i++) { $s = (string) new Greeter(); }
+echo "done";
+"#,
+    );
+    assert_eq!(out.stdout, "done");
+    let (allocs, frees) = parse_gc_stats(&out.stderr);
+    assert_eq!(allocs, frees, "expected clean heap, got: {}", out.stderr);
+}
+
+/// Guard: a variable-held object stringified via `__toString` is owned by the variable
+/// slot and must NOT be released by the coercion (otherwise it would be double-freed).
+#[test]
+fn test_tostring_variable_object_not_double_freed() {
+    let out = compile_and_run_with_gc_stats(
+        r#"<?php
+class Greeter { public function __toString(): string { return "hi"; } }
+$g = new Greeter();
+for ($i = 0; $i < 100; $i++) { echo $g; }
+echo "\n";
+"#,
+    );
+    assert!(out.success, "program crashed (double free?): {}", out.stderr);
+    let (allocs, frees) = parse_gc_stats(&out.stderr);
+    assert_eq!(allocs, frees, "expected clean heap, got: {}", out.stderr);
+}
+
 /// Regression test: creating assoc arrays via a factory function, pushing them
 /// into a numerically-indexed array, then iterating and accessing keys. Verifies
 /// that `make()` return values survive being stored and retrieved from a outer

--- a/tests/codegen/strings/interpolation_and_hashes.rs
+++ b/tests/codegen/strings/interpolation_and_hashes.rs
@@ -50,6 +50,58 @@ fn test_string_no_interpolation() {
     assert_eq!(out, "$x");
 }
 
+/// Verifies complex `{$var}` interpolation: the braces delimit the variable and are not
+/// emitted literally.
+#[test]
+fn test_string_interpolation_complex_simple_var() {
+    let out = compile_and_run(r#"<?php $b = "B"; echo "a{$b}c";"#);
+    assert_eq!(out, "aBc");
+}
+
+/// Verifies complex `{$arr[idx]}` interpolation evaluates the array access inside braces.
+#[test]
+fn test_string_interpolation_complex_array_access() {
+    let out = compile_and_run(r#"<?php $a = [1, 2, 3]; echo "x{$a[1]}y";"#);
+    assert_eq!(out, "x2y");
+}
+
+/// Verifies complex `{$obj->prop}` interpolation evaluates the property access inside braces.
+#[test]
+fn test_string_interpolation_complex_property() {
+    let out = compile_and_run(r#"<?php class C { public $x = 5; } $o = new C(); echo "{$o->x}";"#);
+    assert_eq!(out, "5");
+}
+
+/// Verifies simple `$arr[key]` interpolation with a bareword key (treated as a string key).
+#[test]
+fn test_string_interpolation_simple_array_bareword() {
+    let out = compile_and_run(r#"<?php $a = ["k" => "V"]; echo "X $a[k] Y";"#);
+    assert_eq!(out, "X V Y");
+}
+
+/// Verifies simple `$arr[int]` interpolation with an integer key.
+#[test]
+fn test_string_interpolation_simple_array_int() {
+    let out = compile_and_run(r#"<?php $a = [10, 20]; echo "$a[1]";"#);
+    assert_eq!(out, "20");
+}
+
+/// Verifies simple `$obj->prop` interpolation reads a single property.
+#[test]
+fn test_string_interpolation_simple_property() {
+    let out =
+        compile_and_run(r#"<?php class C { public $x = 5; } $o = new C(); echo "v=$o->x";"#);
+    assert_eq!(out, "v=5");
+}
+
+/// Verifies a `{` not followed by `$` stays a literal brace (PHP only treats `{$` as the
+/// start of complex interpolation).
+#[test]
+fn test_string_literal_brace_not_interpolation() {
+    let out = compile_and_run(r#"<?php echo "a{b}c";"#);
+    assert_eq!(out, "a{b}c");
+}
+
 /// Verifies `md5()` produces the correct hash for an empty string input.
 #[test]
 fn test_md5_empty() {

--- a/tests/error_tests/misc/functions.rs
+++ b/tests/error_tests/misc/functions.rs
@@ -137,6 +137,17 @@ fn test_error_named_arguments_reject_unknown_parameter() {
     );
 }
 
+/// Verifies an unknown string-literal callback passed to `call_user_func_array` with a
+/// runtime-opaque (non-array-literal) second argument is rejected as an undefined function,
+/// instead of being accepted and deferring to a mangle panic / dangling symbol at codegen.
+#[test]
+fn test_error_call_user_func_array_unknown_string_callback() {
+    expect_error(
+        "<?php $args = [1, 2]; call_user_func_array(\"does_not_exist\", $args);",
+        "Undefined function: does_not_exist",
+    );
+}
+
 /// Verifies that positional arguments cannot follow named arguments in a call.
 #[test]
 fn test_error_named_arguments_reject_positional_after_named() {

--- a/tests/error_tests/syntax.rs
+++ b/tests/error_tests/syntax.rs
@@ -23,6 +23,19 @@ fn test_error_unterminated_string() {
     expect_error("<?php \"no end", "Unterminated string");
 }
 
+/// Verifies a complex `{$...}` interpolation without a closing brace is reported, rather
+/// than running past the end of the string.
+#[test]
+fn test_error_unterminated_complex_interpolation() {
+    expect_error("<?php $x = 1; echo \"a{$x\";", "complex interpolation");
+}
+
+/// Verifies a simple `$arr[offset` interpolation without a closing bracket is reported.
+#[test]
+fn test_error_unterminated_interpolation_offset() {
+    expect_error("<?php $a = [1]; echo \"$a[0\";", "Unterminated array offset");
+}
+
 /// Verifies the error diagnostic for invalid unicode string escape.
 #[test]
 fn test_error_invalid_unicode_string_escape() {

--- a/tests/error_tests/syntax.rs
+++ b/tests/error_tests/syntax.rs
@@ -36,6 +36,16 @@ fn test_error_unterminated_interpolation_offset() {
     expect_error("<?php $a = [1]; echo \"$a[0\";", "Unterminated array offset");
 }
 
+/// Verifies a flexible heredoc whose body line is indented less than the closing marker
+/// is reported as an invalid body indentation level (PHP 7.3+).
+#[test]
+fn test_error_heredoc_invalid_indentation() {
+    expect_error(
+        "<?php echo <<<EOT\n    indented\n  under\n    EOT;\n",
+        "Invalid heredoc body indentation level",
+    );
+}
+
 /// Verifies the error diagnostic for invalid unicode string escape.
 #[test]
 fn test_error_invalid_unicode_string_escape() {

--- a/tests/lexer_tests/literals.rs
+++ b/tests/lexer_tests/literals.rs
@@ -43,6 +43,65 @@ fn test_echo_string() {
     );
 }
 
+/// Verifies complex `{$var}` interpolation lexes the braced expression as a parenthesized
+/// operand rather than emitting the braces as literal text.
+#[test]
+fn test_interpolation_complex_braces() {
+    let t = tokens("<?php \"a{$b}c\";");
+    assert_eq!(
+        &t[1..t.len() - 2],
+        &[
+            Token::LParen,
+            Token::StringLiteral("a".into()),
+            Token::Dot,
+            Token::LParen,
+            Token::Variable("b".into()),
+            Token::RParen,
+            Token::Dot,
+            Token::StringLiteral("c".into()),
+            Token::RParen,
+        ]
+    );
+}
+
+/// Verifies simple `$arr[key]` interpolation lexes a bareword offset as a string-keyed
+/// array access on the variable.
+#[test]
+fn test_interpolation_simple_offset_bareword() {
+    let t = tokens("<?php \"$a[k]\";");
+    assert_eq!(
+        &t[1..t.len() - 2],
+        &[
+            Token::LParen,
+            Token::StringLiteral(String::new()),
+            Token::Dot,
+            Token::Variable("a".into()),
+            Token::LBracket,
+            Token::StringLiteral("k".into()),
+            Token::RBracket,
+            Token::RParen,
+        ]
+    );
+}
+
+/// Verifies simple `$obj->prop` interpolation lexes a single property access on the variable.
+#[test]
+fn test_interpolation_simple_property() {
+    let t = tokens("<?php \"$o->x\";");
+    assert_eq!(
+        &t[1..t.len() - 2],
+        &[
+            Token::LParen,
+            Token::StringLiteral(String::new()),
+            Token::Dot,
+            Token::Variable("o".into()),
+            Token::Arrow,
+            Token::Identifier("x".into()),
+            Token::RParen,
+        ]
+    );
+}
+
 /// Verifies double-quoted string `"hello\nworld\t!"` produces `StringLiteral`
 /// with actual newline (`\n`) and tab (`\t`) characters — confirming escape sequence
 /// interpretation, not raw literal text.

--- a/tests/lexer_tests/syntax.rs
+++ b/tests/lexer_tests/syntax.rs
@@ -16,6 +16,23 @@ fn test_variable() {
     assert_eq!(t[1], Token::Variable("foo".into()));
 }
 
+/// Verifies a variable name with non-ASCII letters (PHP allows bytes 0x80-0xFF in
+/// identifiers) lexes as one `Variable` token instead of truncating at the first
+/// non-ASCII byte.
+#[test]
+fn test_unicode_variable() {
+    let t = tokens("<?php $café");
+    assert_eq!(t[1], Token::Variable("café".into()));
+}
+
+/// Verifies an identifier made of non-ASCII letters lexes as a single `Identifier`
+/// token instead of erroring as an unexpected character.
+#[test]
+fn test_unicode_identifier() {
+    let t = tokens("<?php 价格");
+    assert_eq!(t[1], Token::Identifier("价格".into()));
+}
+
 // --- Operators ---
 
 /// Verifies `{` and `}` tokenize as `LBrace` / `RBrace`.


### PR DESCRIPTION
- **fix(errors): make from_many fail with a clear message on empty input**
- **fix(codegen): assert frame_size reserves the 16-byte footer**
- **fix(conditional): resolve stray ifdef instead of unreachable! panic**
- **fix(linker): clear diagnostic when macOS SDK path cannot be resolved**
- **fix(cli): reject empty symbol for both --define forms**
- **fix(source-map): escape all JSON control characters**
- **fix(lexer): guarantee cursor progress on malformed UTF-8**
- **fix: make mangle_fqn total and reject unknown string callbacks**
- **fix(lexer): accept non-ASCII PHP identifiers and variables**
- **fix(lexer): support complex and simple string interpolation forms**
- **fix(lexer): PHP-compatible heredoc closer and flexible indentation**
- **fix(codegen): release temporary object stringified via __toString**
