### PR TITLE
fix/php compatibility audit

### DIFF
--- a/docs/php/types.md
+++ b/docs/php/types.md
@@ -181,7 +181,8 @@ Narrowing applies to function and method parameters. A parameter whose call site
 ### Known incompatibilities with PHP
 
 - `$argv[0]` returns the compiled binary path, not the `.php` file path.
-- Integer `+`, `-`, and `*` overflow promotes to `double` for both constant-folded and non-folded runtime scalar arithmetic.
+- Integer `+`, `-`, and `*` overflow promotes to `float` only for **constant-folded** arithmetic (compile-time-constant operands), matching PHP. At **runtime**, `int op int` has the static type `int`, so an overflowing operation does **not** promote to `float`: the result is clamped toward the 64-bit integer boundary and `is_float()` stays `false`, whereas PHP returns a `float`. Promoting at runtime would require boxing every arithmetic result, which elephc's unboxed scalar representation avoids. For the same reason, `intval()`/`(int)` of an integer-valued string near the 64-bit boundary (e.g. `intval("9223372036854775807")`) is lossy.
+- Converting an array to a string (via `.` concatenation, `echo`, or string interpolation) yields the literal `"Array"`, matching PHP's value, but elephc does not emit PHP's `E_WARNING` "Array to string conversion".
 - Scalar loose comparison (`==`, `!=`) follows PHP-style bool truthiness, null-vs-empty-string, numeric-string, and non-numeric string byte-comparison rules for constant-folded literals and non-folded runtime scalar operands.
 - `??=` is checked against typed assignment storage for variables, object properties, static properties, and non-append array elements. For concrete local variable types, the fallback must keep the same type or be a literal `null`.
 - Plain array numeric casts (`(int)$array`, `(float)$array`) follow elephc's existing array cast semantics (return the element count rather than PHP's `0`/`1`). Direct `iterable` numeric casts use PHP's empty/non-empty `0`/`1` semantics.

--- a/src/codegen/expr/binops/comparison.rs
+++ b/src/codegen/expr/binops/comparison.rs
@@ -580,12 +580,17 @@ pub(super) fn emit_spaceship_binop(
         Arch::AArch64 => {
             emitter.instruction("cset x0, gt");                                 // set x0 to 1 when left > right, else 0
             emitter.instruction("csinv x0, x0, xzr, ge");                       // keep 1 when left >= right, invert to -1 when left < right
+            if left_ty == PhpType::Float || right_ty == PhpType::Float {
+                emitter.instruction("mov w1, #1");                              // candidate spaceship result for an unordered (NaN) comparison
+                emitter.instruction("csel x0, x1, x0, vs");                     // PHP: NaN <=> x is 1 — pick 1 when fcmp was unordered
+            }
         }
         Arch::X86_64 => {
             let greater_label = ctx.next_label("spaceship_gt");
             let less_label = ctx.next_label("spaceship_lt");
             let done_label = ctx.next_label("spaceship_done");
             if left_ty == PhpType::Float || right_ty == PhpType::Float {
+                emitter.instruction(&format!("jp {}", greater_label));          // PHP: NaN <=> x is 1 — route unordered (parity) to the greater (1) branch
                 emitter.instruction(&format!("ja {}", greater_label));          // floats: jump to greater branch when unordered-above
                 emitter.instruction(&format!("jb {}", less_label));             // floats: jump to less branch when unordered-below
             } else {

--- a/src/codegen/expr/binops/target.rs
+++ b/src/codegen/expr/binops/target.rs
@@ -35,10 +35,17 @@ pub(super) fn emit_set_bool_from_flags(emitter: &mut Emitter, cond: &str) {
 }
 
 /// Sets integer result (x0/rax) from float comparison flags.
+///
+/// Applies PHP's NaN (unordered) rule: every ordering/equality comparison against NaN is false
+/// except `!=`, which is true. After the conditional set, the unordered case (ARM64 `V`, x86_64
+/// parity flag) is forced to 0 for `==`/`<`/`>`/`<=`/`>=` and to 1 for `!=`.
 pub(super) fn emit_set_float_bool_from_flags(emitter: &mut Emitter, cond: &str) {
     match emitter.target.arch {
         Arch::AArch64 => {
             emitter.instruction(&format!("cset x0, {}", cond));                 // set integer result to 1 if the float comparison condition matched
+            if cond != "ne" {
+                emitter.instruction("csel x0, xzr, x0, vs");                    // PHP: an unordered (NaN) ==, <, >, <=, >= is false — force 0 when fcmp was unordered
+            }
         }
         Arch::X86_64 => {
             let setcc = match cond {
@@ -51,6 +58,13 @@ pub(super) fn emit_set_float_bool_from_flags(emitter: &mut Emitter, cond: &str) 
                 _ => unreachable!("unsupported float comparison condition {cond}"),
             };
             emitter.instruction(&format!("{} al", setcc));                      // set the low result byte when the float comparison condition matched
+            if cond == "ne" {
+                emitter.instruction("setp cl");                                 // cl = 1 when ucomisd was unordered (a NaN operand)
+                emitter.instruction("or al, cl");                               // PHP: NaN != x is true — OR the unordered case into the not-equal result
+            } else {
+                emitter.instruction("setnp cl");                                // cl = 1 only when the comparison was ordered (no NaN operand)
+                emitter.instruction("and al, cl");                              // PHP: an unordered (NaN) comparison is false — mask out the unordered case
+            }
             emitter.instruction("movzx rax, al");                               // zero-extend the boolean byte into the integer result register
         }
     }

--- a/src/codegen/expr/coerce.rs
+++ b/src/codegen/expr/coerce.rs
@@ -115,8 +115,8 @@ fn coerce_to_string_inner(
             // -- mixed strings dispatch on the boxed payload at runtime --
             abi::emit_call_label(emitter, "__rt_mixed_cast_string");            // cast the boxed mixed payload to string in the ABI string result registers
         }
-        PhpType::Iterable => {
-            // -- iterable values stringify to the literal "Array", matching PHP --
+        PhpType::Iterable | PhpType::Array(_) | PhpType::AssocArray { .. } => {
+            // -- iterable and array values stringify to the literal "Array", matching PHP --
             let (label, len) = data.add_string(b"Array");
             let (ptr_reg, len_reg) = abi::string_result_regs(emitter);
             abi::emit_symbol_address(emitter, ptr_reg, &label);                 // materialize the literal "Array" address in the active string-pointer result register
@@ -154,8 +154,6 @@ fn coerce_to_string_inner(
             }
         }
         PhpType::Str
-        | PhpType::Array(_)
-        | PhpType::AssocArray { .. }
         | PhpType::Callable
         | PhpType::Buffer(_)
         | PhpType::Packed(_)

--- a/src/codegen/runtime/strings/str_to_int.rs
+++ b/src/codegen/runtime/strings/str_to_int.rs
@@ -1,12 +1,16 @@
 //! Purpose:
 //! Emits the `__rt_str_to_int` runtime helper for PHP string-to-int casts.
-//! Bridges bounded PHP strings through numeric-string parsing so whitespace, signs, and exponents match PHP.
+//! Parses the bounded PHP string as both an integer (libc `strtoll`) and a double (libc `strtod`)
+//! and returns the integer-form value unless the string is actually float-form.
 //!
 //! Called from:
 //! - `crate::codegen::runtime::emitters::emit_runtime()` via `crate::codegen::runtime::strings`.
 //!
 //! Key details:
-//! - Reuses `__rt_str_to_number`, then truncates the parsed double toward zero like PHP casts.
+//! - `strtoll` gives the exact 64-bit value and PHP's saturating overflow (LLONG_MAX/MIN == PHP_INT_MAX/MIN),
+//!   so large integer strings are not rounded through `f64`.
+//! - When `strtod` consumes more bytes than `strtoll`, the string has a `.`/`e` float part (e.g. `"1e3"`),
+//!   so the truncated double is returned, matching PHP's leading-numeric-string rules.
 
 use crate::codegen::{abi, emit::Emitter, platform::Arch};
 
@@ -14,8 +18,9 @@ use crate::codegen::{abi, emit::Emitter, platform::Arch};
 ///
 /// Input follows the active string-result convention:
 /// AArch64 uses `x1`/`x2`; x86_64 uses `rax`/`rdx`.
-/// The helper preserves nested-call return state, reuses `__rt_str_to_number`
-/// for PHP numeric-prefix parsing, and returns the truncated integer result.
+/// The helper copies the string into the C-string scratch buffer via `__rt_cstr`, then parses it
+/// with `strtoll` (exact + saturating) and `strtod`, returning the integer-form value unless the
+/// string is float-form, in which case the truncated double is returned.
 pub fn emit_str_to_int(emitter: &mut Emitter) {
     if emitter.target.arch == Arch::X86_64 {
         emit_str_to_int_linux_x86_64(emitter);
@@ -26,30 +31,86 @@ pub fn emit_str_to_int(emitter: &mut Emitter) {
     emitter.comment("--- runtime: str_to_int ---");
     emitter.label_global("__rt_str_to_int");
 
-    emitter.instruction("sub sp, sp, #16");                                     // allocate a frame for preserving the return address across parsing
-    emitter.instruction("stp x29, x30, [sp]");                                  // save frame pointer and return address before the nested helper call
-    emitter.instruction("mov x29, sp");                                         // establish a stable helper frame pointer
-    abi::emit_call_label(emitter, "__rt_str_to_number");                        // parse the PHP string as a numeric prefix and leave the double result live
-    abi::emit_float_result_to_int_result(emitter);                              // truncate the parsed numeric value toward zero for PHP int casts
-    emitter.instruction("ldp x29, x30, [sp]");                                  // restore the caller frame pointer and return address
-    emitter.instruction("add sp, sp, #16");                                     // release the helper frame
+    // -- set up the helper frame (slots: end_i=[sp,#0], end_d=[sp,#8], ll_val=[sp,#16], cstr=[sp,#24]) --
+    emitter.instruction("sub sp, sp, #48");                                     // allocate slots for both end pointers, the integer value, and the C-string pointer
+    emitter.instruction("stp x29, x30, [sp, #32]");                             // save frame pointer and return address across the libc calls
+    emitter.instruction("add x29, sp, #32");                                    // establish a stable helper frame pointer
+
+    // -- copy the PHP string into the C-string scratch buffer --
+    emitter.instruction("bl __rt_cstr");                                        // copy the bounded PHP string into the C-string scratch buffer
+    emitter.instruction("str x0, [sp, #24]");                                   // save the C-string pointer for the second parse
+
+    // -- integer parse: strtoll(cstr, &end_i, 10) gives the exact, saturating 64-bit value --
+    emitter.instruction("add x1, sp, #0");                                      // pass &end_i so strtoll reports where the integer prefix ended
+    emitter.instruction("mov x2, #10");                                         // parse in base 10 like PHP string-to-int
+    emitter.bl_c("strtoll");
+    emitter.instruction("str x0, [sp, #16]");                                   // save the integer-form value (LLONG_MAX/MIN on overflow == PHP_INT_MAX/MIN)
+
+    // -- float parse: strtod(cstr, &end_d) detects a '.'/'e' float continuation --
+    emitter.instruction("ldr x0, [sp, #24]");                                   // reload the C-string pointer for strtod
+    emitter.instruction("add x1, sp, #8");                                      // pass &end_d so strtod reports where the numeric value ended
+    emitter.bl_c("strtod");
+
+    // -- choose the integer value unless strtod consumed more bytes (a float part) --
+    emitter.instruction("ldr x9, [sp, #8]");                                    // load the end pointer returned by strtod
+    emitter.instruction("ldr x10, [sp, #0]");                                   // load the end pointer returned by strtoll
+    emitter.instruction("cmp x9, x10");                                         // did strtod consume more bytes than strtoll?
+    emitter.instruction("b.hi __rt_str_to_int_float");                          // yes: the string is float-form, return the truncated double
+    emitter.instruction("ldr x0, [sp, #16]");                                   // no: return the exact integer-form value
+    emitter.instruction("b __rt_str_to_int_done");                              // skip the float-truncation path
+
+    emitter.label("__rt_str_to_int_float");
+    abi::emit_float_result_to_int_result(emitter);                              // truncate the parsed double in d0 toward zero for PHP float-string casts
+
+    emitter.label("__rt_str_to_int_done");
+    emitter.instruction("ldp x29, x30, [sp, #32]");                             // restore the caller frame pointer and return address
+    emitter.instruction("add sp, sp, #48");                                     // release the helper frame
     emitter.instruction("ret");                                                 // return the integer cast result
 }
 
 /// Emits the Linux x86_64 `__rt_str_to_int` runtime helper.
 ///
 /// The input string arrives in the elephc string-result registers (`rax`/`rdx`).
-/// The nested numeric parser returns the parsed double in `xmm0`; this helper
-/// truncates it into `rax`, matching PHP's string-to-int cast behavior.
+/// Parses with `strtoll` (exact + saturating) and `strtod`, returning the integer-form value in
+/// `rax` unless `strtod` consumed a `.`/`e` float part, in which case the truncated double is used.
 fn emit_str_to_int_linux_x86_64(emitter: &mut Emitter) {
     emitter.blank();
     emitter.comment("--- runtime: str_to_int ---");
     emitter.label_global("__rt_str_to_int");
 
-    emitter.instruction("push rbp");                                            // preserve the caller frame pointer before calling the numeric parser
-    emitter.instruction("mov rbp, rsp");                                        // establish a stable helper frame pointer and aligned call stack
-    abi::emit_call_label(emitter, "__rt_str_to_number");                        // parse the PHP string as a numeric prefix and leave the double result live
-    abi::emit_float_result_to_int_result(emitter);                              // truncate the parsed numeric value toward zero for PHP int casts
+    // -- set up the helper frame (locals: cstr=[rbp-8], ll_val=[rbp-16], end_i=[rbp-24], end_d=[rbp-32]) --
+    emitter.instruction("push rbp");                                            // preserve the caller frame pointer before calling libc parsers
+    emitter.instruction("mov rbp, rsp");                                        // establish a stable helper frame pointer
+    emitter.instruction("sub rsp, 48");                                         // allocate aligned slots for the C-string pointer, integer value, and end pointers
+
+    // -- copy the PHP string into the C-string scratch buffer --
+    emitter.instruction("call __rt_cstr");                                      // copy the bounded PHP string into the C-string scratch buffer
+    emitter.instruction("mov QWORD PTR [rbp - 8], rax");                        // save the C-string pointer for the second parse
+
+    // -- integer parse: strtoll(cstr, &end_i, 10) gives the exact, saturating 64-bit value --
+    emitter.instruction("mov rdi, rax");                                        // strtoll arg1: the C-string pointer
+    emitter.instruction("lea rsi, [rbp - 24]");                                 // strtoll arg2: &end_i
+    emitter.instruction("mov edx, 10");                                         // strtoll arg3: parse in base 10 like PHP string-to-int
+    emitter.instruction("call strtoll");                                        // rax = integer-form value (LLONG_MAX/MIN on overflow == PHP_INT_MAX/MIN)
+    emitter.instruction("mov QWORD PTR [rbp - 16], rax");                       // save the integer-form value
+
+    // -- float parse: strtod(cstr, &end_d) detects a '.'/'e' float continuation --
+    emitter.instruction("mov rdi, QWORD PTR [rbp - 8]");                        // reload the C-string pointer for strtod
+    emitter.instruction("lea rsi, [rbp - 32]");                                 // strtod arg2: &end_d
+    emitter.instruction("call strtod");                                         // xmm0 = parsed double value
+
+    // -- choose the integer value unless strtod consumed more bytes (a float part) --
+    emitter.instruction("mov r8, QWORD PTR [rbp - 32]");                        // load the end pointer returned by strtod
+    emitter.instruction("cmp r8, QWORD PTR [rbp - 24]");                        // did strtod consume more bytes than strtoll?
+    emitter.instruction("ja __rt_str_to_int_float_linux_x86_64");               // yes: the string is float-form, return the truncated double
+    emitter.instruction("mov rax, QWORD PTR [rbp - 16]");                       // no: return the exact integer-form value
+    emitter.instruction("jmp __rt_str_to_int_done_linux_x86_64");               // skip the float-truncation path
+
+    emitter.label("__rt_str_to_int_float_linux_x86_64");
+    abi::emit_float_result_to_int_result(emitter);                              // truncate the parsed double in xmm0 toward zero for PHP float-string casts
+
+    emitter.label("__rt_str_to_int_done_linux_x86_64");
+    emitter.instruction("add rsp, 48");                                         // release the helper frame
     emitter.instruction("pop rbp");                                             // restore the caller frame pointer
     emitter.instruction("ret");                                                 // return the integer cast result
 }

--- a/src/codegen/stmt/io.rs
+++ b/src/codegen/stmt/io.rs
@@ -88,6 +88,22 @@ pub(crate) fn emit_expr_to_stdout(
             coerce_to_string_releasing_owned(emitter, ctx, data, &ty, release_object);
             emit_string_to_stdout_and_release_if_needed(emitter, true);
         }
+        PhpType::Array(_) | PhpType::AssocArray { .. } | PhpType::Iterable => {
+            // Arrays stringify to the literal "Array" (matching PHP). The array pointer is
+            // preserved across the write so an owned temporary can be released afterward; a
+            // borrowed array (e.g. a plain variable) is left for its owner to release.
+            let release_array = expr_result_heap_ownership(expr) == HeapOwnership::Owned;
+            if release_array {
+                abi::emit_push_reg(emitter, abi::int_result_reg(emitter));
+            }
+            coerce_to_string_releasing_owned(emitter, ctx, data, &ty, false);
+            abi::emit_write_stdout(emitter, &PhpType::Str);
+            if release_array {
+                abi::emit_load_temporary_stack_slot(emitter, abi::int_result_reg(emitter), 0);
+                abi::emit_decref_if_refcounted(emitter, &ty);
+                abi::emit_release_temporary_stack(emitter, 16);
+            }
+        }
         _ => {
             abi::emit_write_stdout(emitter, &ty);
         }

--- a/src/lexer/literals/numbers.rs
+++ b/src/lexer/literals/numbers.rs
@@ -109,6 +109,8 @@ fn parse_decimal_int_or_float(cursor: &Cursor, digits: &str) -> Result<Token, Co
 /// alphanumeric characters remain. Returns `Token::IntLiteral` or `Token::FloatLiteral`.
 /// Handles PHP 7.4+ underscore numeric separators and legacy octal forms.
 pub(in crate::lexer) fn scan_number(cursor: &mut Cursor) -> Result<Token, CompileError> {
+    // Captured before consuming any prefix so empty-literal errors point at the literal start.
+    let start_span = cursor.span();
     if cursor.peek() == Some('0') {
         let remaining = cursor.remaining();
         if remaining.len() > 1 {
@@ -120,7 +122,7 @@ pub(in crate::lexer) fn scan_number(cursor: &mut Cursor) -> Result<Token, Compil
                 let hex_str = scan_radix_digits(cursor, |c| c.is_ascii_hexdigit());
                 if hex_str.is_empty() {
                     return Err(CompileError::new(
-                        cursor.span(),
+                        start_span,
                         "Expected hex digits after '0x'",
                     ));
                 }
@@ -134,7 +136,7 @@ pub(in crate::lexer) fn scan_number(cursor: &mut Cursor) -> Result<Token, Compil
                 let octal_str = scan_radix_digits(cursor, |c| c.is_ascii_digit() && c < '8');
                 if octal_str.is_empty() {
                     return Err(CompileError::new(
-                        cursor.span(),
+                        start_span,
                         "Expected octal digits after '0o'",
                     ));
                 }
@@ -148,7 +150,7 @@ pub(in crate::lexer) fn scan_number(cursor: &mut Cursor) -> Result<Token, Compil
                 let bin_str = scan_radix_digits(cursor, |c| c == '0' || c == '1');
                 if bin_str.is_empty() {
                     return Err(CompileError::new(
-                        cursor.span(),
+                        start_span,
                         "Expected binary digits after '0b'",
                     ));
                 }

--- a/src/lexer/scan.rs
+++ b/src/lexer/scan.rs
@@ -23,6 +23,9 @@ use crate::span::Span;
 /// # Errors
 /// Returns `CompileError` if the file does not open with `<?php`.
 pub fn scan_tokens(source: &str) -> Result<Vec<(Token, Span)>, CompileError> {
+    // A leading UTF-8 byte-order mark (U+FEFF) is ignored, matching editors that save PHP
+    // files as BOM-prefixed UTF-8; stripping it keeps the `<?php` open tag at the start.
+    let source = source.strip_prefix('\u{feff}').unwrap_or(source);
     let mut cursor = Cursor::new(source);
     let mut tokens = Vec::new();
 

--- a/src/optimize/fold/scalar.rs
+++ b/src/optimize/fold/scalar.rs
@@ -195,7 +195,10 @@ pub(in crate::optimize) fn compare_numeric(
 pub(in crate::optimize) fn spaceship_numeric(left: &Expr, right: &Expr) -> Option<i64> {
     let left = numeric_literal(left)?;
     let right = numeric_literal(right)?;
-    Some(if left < right {
+    Some(if left.is_nan() || right.is_nan() {
+        // NAN is uncomparable: PHP's `<=>` yields 1 whenever either operand is NAN.
+        1
+    } else if left < right {
         -1
     } else if left > right {
         1

--- a/src/parser/expr/calls.rs
+++ b/src/parser/expr/calls.rs
@@ -57,6 +57,13 @@ pub(super) fn parse_scoped_static_call(
             *pos += 1;
             "MATCH".to_string()
         }
+        // PHP 8 allows semi-reserved keywords as static method / class-constant names
+        // (e.g. `Foo::self()`, `Foo::print`); `class` and `$var` are handled above.
+        Some(t) if crate::parser::keyword_name::bareword_name_from_token(t).is_some() => {
+            let name = crate::parser::keyword_name::bareword_name_from_token(t).unwrap();
+            *pos += 1;
+            name
+        }
         _ => {
             return Err(CompileError::new(
                 span,

--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -35,99 +35,10 @@ pub(crate) fn parse_assignment_value_expr(
     pratt::parse_expr_bp(tokens, pos, 7)
 }
 
-/// Provides the Argument name from token helper used by the expr module.
+/// Returns the name to use for a named-argument label, accepting identifiers and PHP
+/// semi-reserved keywords (e.g. `f(array: 1)`); delegates to the shared bareword mapper.
 fn argument_name_from_token(token: &Token) -> Option<String> {
-    match token {
-        Token::Identifier(name) => Some(name.clone()),
-        Token::Echo => Some("echo".to_string()),
-        Token::If => Some("if".to_string()),
-        Token::IfDef => Some("ifdef".to_string()),
-        Token::Else => Some("else".to_string()),
-        Token::ElseIf => Some("elseif".to_string()),
-        Token::While => Some("while".to_string()),
-        Token::For => Some("for".to_string()),
-        Token::Break => Some("break".to_string()),
-        Token::Continue => Some("continue".to_string()),
-        Token::Function => Some("function".to_string()),
-        Token::Return => Some("return".to_string()),
-        Token::True => Some("true".to_string()),
-        Token::False => Some("false".to_string()),
-        Token::Null => Some("null".to_string()),
-        Token::Do => Some("do".to_string()),
-        Token::Foreach => Some("foreach".to_string()),
-        Token::As => Some("as".to_string()),
-        Token::Try => Some("try".to_string()),
-        Token::Catch => Some("catch".to_string()),
-        Token::Finally => Some("finally".to_string()),
-        Token::Throw => Some("throw".to_string()),
-        Token::Extends => Some("extends".to_string()),
-        Token::Implements => Some("implements".to_string()),
-        Token::Interface => Some("interface".to_string()),
-        Token::Abstract => Some("abstract".to_string()),
-        Token::Final => Some("final".to_string()),
-        Token::Print => Some("print".to_string()),
-        Token::Switch => Some("switch".to_string()),
-        Token::Case => Some("case".to_string()),
-        Token::Default => Some("default".to_string()),
-        Token::Match => Some("match".to_string()),
-        Token::Include => Some("include".to_string()),
-        Token::IncludeOnce => Some("include_once".to_string()),
-        Token::Require => Some("require".to_string()),
-        Token::RequireOnce => Some("require_once".to_string()),
-        Token::Fn => Some("fn".to_string()),
-        Token::Use => Some("use".to_string()),
-        Token::Namespace => Some("namespace".to_string()),
-        Token::Const => Some("const".to_string()),
-        Token::Global => Some("global".to_string()),
-        Token::Static => Some("static".to_string()),
-        Token::Self_ => Some("self".to_string()),
-        Token::Trait => Some("trait".to_string()),
-        Token::Parent => Some("parent".to_string()),
-        Token::InsteadOf => Some("insteadof".to_string()),
-        Token::Class => Some("class".to_string()),
-        Token::Enum => Some("enum".to_string()),
-        Token::New => Some("new".to_string()),
-        Token::Public => Some("public".to_string()),
-        Token::Protected => Some("protected".to_string()),
-        Token::Private => Some("private".to_string()),
-        Token::ReadOnly => Some("readonly".to_string()),
-        Token::Extern => Some("extern".to_string()),
-        Token::Packed => Some("packed".to_string()),
-        Token::Yield => Some("yield".to_string()),
-        Token::And => Some("and".to_string()),
-        Token::Or => Some("or".to_string()),
-        Token::Xor => Some("xor".to_string()),
-        Token::InstanceOf => Some("instanceof".to_string()),
-        Token::Inf => Some("INF".to_string()),
-        Token::Nan => Some("NAN".to_string()),
-        Token::PhpIntMax => Some("PHP_INT_MAX".to_string()),
-        Token::PhpIntMin => Some("PHP_INT_MIN".to_string()),
-        Token::PhpFloatMax => Some("PHP_FLOAT_MAX".to_string()),
-        Token::MPi => Some("M_PI".to_string()),
-        Token::ME => Some("M_E".to_string()),
-        Token::MSqrt2 => Some("M_SQRT2".to_string()),
-        Token::MPi2 => Some("M_PI_2".to_string()),
-        Token::MPi4 => Some("M_PI_4".to_string()),
-        Token::MLog2e => Some("M_LOG2E".to_string()),
-        Token::MLog10e => Some("M_LOG10E".to_string()),
-        Token::PhpFloatMin => Some("PHP_FLOAT_MIN".to_string()),
-        Token::PhpFloatEpsilon => Some("PHP_FLOAT_EPSILON".to_string()),
-        Token::Stdin => Some("STDIN".to_string()),
-        Token::Stdout => Some("STDOUT".to_string()),
-        Token::Stderr => Some("STDERR".to_string()),
-        Token::PhpEol => Some("PHP_EOL".to_string()),
-        Token::PhpOs => Some("PHP_OS".to_string()),
-        Token::DirectorySeparator => Some("DIRECTORY_SEPARATOR".to_string()),
-        Token::DunderDir => Some("__DIR__".to_string()),
-        Token::DunderFile => Some("__FILE__".to_string()),
-        Token::DunderLine => Some("__LINE__".to_string()),
-        Token::DunderFunction => Some("__FUNCTION__".to_string()),
-        Token::DunderClass => Some("__CLASS__".to_string()),
-        Token::DunderMethod => Some("__METHOD__".to_string()),
-        Token::DunderNamespace => Some("__NAMESPACE__".to_string()),
-        Token::DunderTrait => Some("__TRAIT__".to_string()),
-        _ => None,
-    }
+    crate::parser::keyword_name::bareword_name_from_token(token)
 }
 
 /// Parse a comma-separated argument list. The opening `(` must already be consumed.
@@ -147,6 +58,10 @@ pub(crate) fn parse_args(
                 ));
             }
             *pos += 1;
+            // Allow a trailing comma before the closing paren (PHP 7.3+).
+            if *pos < tokens.len() && tokens[*pos].0 == Token::RParen {
+                break;
+            }
         }
         if *pos < tokens.len() && tokens[*pos].0 == Token::Ellipsis {
             let spread_span = tokens[*pos].1;

--- a/src/parser/expr/pratt.rs
+++ b/src/parser/expr/pratt.rs
@@ -411,8 +411,8 @@ enum ObjectMember {
 /// Handles three forms:
 /// - Static identifier: `->foo`
 /// - Dynamic expression in braces: `->{$expr}`
-/// - PHP 7+ reserved keywords allowed as member names: `throw`, `yield`, `match`,
-///   `print`, `echo`, `return`
+/// - PHP 8 semi-reserved keywords as member names: any keyword (e.g. `->self`, `->parent`,
+///   `->static`, `->class`, `->list`, `->print`) is accepted via the shared bareword mapper.
 ///
 /// Returns `ObjectMember::Named` for identifiers and keywords, or
 /// `ObjectMember::Dynamic` for brace-enclosed expressions.
@@ -426,56 +426,31 @@ fn parse_object_member(
     arrow_span: Span,
     nullsafe: bool,
 ) -> Result<ObjectMember, CompileError> {
-    match tokens.get(*pos).map(|(token, _)| token) {
-        Some(Token::Identifier(name)) => {
-            let name = name.clone();
-            *pos += 1;
-            Ok(ObjectMember::Named(name))
+    if let Some((Token::LBrace, _)) = tokens.get(*pos) {
+        *pos += 1;
+        let property = parse_expr(tokens, pos)?;
+        if *pos >= tokens.len() || tokens[*pos].0 != Token::RBrace {
+            return Err(CompileError::new(arrow_span, "Expected '}'"));
         }
-        Some(Token::LBrace) => {
-            *pos += 1;
-            let property = parse_expr(tokens, pos)?;
-            if *pos >= tokens.len() || tokens[*pos].0 != Token::RBrace {
-                return Err(CompileError::new(arrow_span, "Expected '}'"));
-            }
-            *pos += 1;
-            Ok(ObjectMember::Dynamic(property))
-        }
-        // PHP 7+ allows reserved keywords as method/property names after `->`.
-        // Keep the whitelist to the keywords already accepted by static property parsing.
-        Some(Token::Throw) => {
-            *pos += 1;
-            Ok(ObjectMember::Named("throw".to_string()))
-        }
-        Some(Token::Yield) => {
-            *pos += 1;
-            Ok(ObjectMember::Named("yield".to_string()))
-        }
-        Some(Token::Match) => {
-            *pos += 1;
-            Ok(ObjectMember::Named("match".to_string()))
-        }
-        Some(Token::Print) => {
-            *pos += 1;
-            Ok(ObjectMember::Named("print".to_string()))
-        }
-        Some(Token::Echo) => {
-            *pos += 1;
-            Ok(ObjectMember::Named("echo".to_string()))
-        }
-        Some(Token::Return) => {
-            *pos += 1;
-            Ok(ObjectMember::Named("return".to_string()))
-        }
-        _ => Err(CompileError::new(
-            arrow_span,
-            if nullsafe {
-                "Expected property or method name after '?->'"
-            } else {
-                "Expected property or method name after '->'"
-            },
-        )),
+        *pos += 1;
+        return Ok(ObjectMember::Dynamic(property));
     }
+    // PHP 8 allows identifiers and any semi-reserved keyword as a member name after `->`/`?->`.
+    if let Some(name) = tokens
+        .get(*pos)
+        .and_then(|(token, _)| crate::parser::keyword_name::bareword_name_from_token(token))
+    {
+        *pos += 1;
+        return Ok(ObjectMember::Named(name));
+    }
+    Err(CompileError::new(
+        arrow_span,
+        if nullsafe {
+            "Expected property or method name after '?->'"
+        } else {
+            "Expected property or method name after '->'"
+        },
+    ))
 }
 
 /// Represents the specific assignment operator encountered during parsing.

--- a/src/parser/expr/prefix_complex.rs
+++ b/src/parser/expr/prefix_complex.rs
@@ -502,6 +502,10 @@ fn parse_closure_params(
                 ));
             }
             *pos += 1;
+            // Allow a trailing comma before the closing paren (PHP 8.0+).
+            if *pos < tokens.len() && tokens[*pos].0 == Token::RParen {
+                break;
+            }
         }
         // PHP 8.0 closure-parameter attributes (`fn(#[X] $a) => …`).
         crate::parser::consume_attribute_lists(tokens, pos)?;
@@ -675,6 +679,13 @@ pub(super) fn parse_named_expr(
             Some(Token::Match) => {
                 *pos += 1;
                 "MATCH".to_string()
+            }
+            // PHP 8 allows semi-reserved keywords as static method / class-constant names
+            // (e.g. `Foo::self()`, `Foo::print`); `class` and `$var` are handled above.
+            Some(t) if crate::parser::keyword_name::bareword_name_from_token(t).is_some() => {
+                let member = crate::parser::keyword_name::bareword_name_from_token(t).unwrap();
+                *pos += 1;
+                member
             }
             _ => return Err(CompileError::new(span, "Expected member name after '::'")),
         };

--- a/src/parser/keyword_name.rs
+++ b/src/parser/keyword_name.rs
@@ -1,0 +1,116 @@
+//! Purpose:
+//! Maps a token that may legally appear as a bareword name to its source-text spelling.
+//! Centralizes the PHP "semi-reserved" rule: identifiers and (nearly) all keywords are
+//! valid as named-argument labels, `->`/`?->`/`::` member names, and method/constant names.
+//!
+//! Called from:
+//! - `crate::parser::expr` (named arguments, `->`/`?->` members, `::` scoped access)
+//! - `crate::parser::stmt::oop` (method and class-constant declaration names)
+//!
+//! Key details:
+//! - Returns the exact source lexeme so the resulting name matches what PHP would record.
+//! - Callers that need PHP's narrow exceptions (e.g. `class` is reserved as a constant name,
+//!   and `Foo::class` is the special class-name fetch) must special-case those tokens first.
+
+use crate::lexer::Token;
+
+/// Returns the source-text spelling of a token that can be used as a bareword name, or `None`
+/// for tokens (operators, punctuation, literals) that cannot.
+///
+/// Accepts plain identifiers plus every reserved keyword and magic-constant token, matching
+/// PHP 8's semi-reserved-word rule where keywords are permitted as member, method, constant,
+/// and named-argument names. Callers requiring PHP's exceptions (`class` as a constant name,
+/// the `Foo::class` fetch) must handle those tokens before consulting this helper.
+pub(crate) fn bareword_name_from_token(token: &Token) -> Option<String> {
+    match token {
+        Token::Identifier(name) => Some(name.clone()),
+        Token::Echo => Some("echo".to_string()),
+        Token::If => Some("if".to_string()),
+        Token::IfDef => Some("ifdef".to_string()),
+        Token::Else => Some("else".to_string()),
+        Token::ElseIf => Some("elseif".to_string()),
+        Token::While => Some("while".to_string()),
+        Token::For => Some("for".to_string()),
+        Token::Break => Some("break".to_string()),
+        Token::Continue => Some("continue".to_string()),
+        Token::Function => Some("function".to_string()),
+        Token::Return => Some("return".to_string()),
+        Token::True => Some("true".to_string()),
+        Token::False => Some("false".to_string()),
+        Token::Null => Some("null".to_string()),
+        Token::Do => Some("do".to_string()),
+        Token::Foreach => Some("foreach".to_string()),
+        Token::As => Some("as".to_string()),
+        Token::Try => Some("try".to_string()),
+        Token::Catch => Some("catch".to_string()),
+        Token::Finally => Some("finally".to_string()),
+        Token::Throw => Some("throw".to_string()),
+        Token::Extends => Some("extends".to_string()),
+        Token::Implements => Some("implements".to_string()),
+        Token::Interface => Some("interface".to_string()),
+        Token::Abstract => Some("abstract".to_string()),
+        Token::Final => Some("final".to_string()),
+        Token::Print => Some("print".to_string()),
+        Token::Switch => Some("switch".to_string()),
+        Token::Case => Some("case".to_string()),
+        Token::Default => Some("default".to_string()),
+        Token::Match => Some("match".to_string()),
+        Token::Include => Some("include".to_string()),
+        Token::IncludeOnce => Some("include_once".to_string()),
+        Token::Require => Some("require".to_string()),
+        Token::RequireOnce => Some("require_once".to_string()),
+        Token::Fn => Some("fn".to_string()),
+        Token::Use => Some("use".to_string()),
+        Token::Namespace => Some("namespace".to_string()),
+        Token::Const => Some("const".to_string()),
+        Token::Global => Some("global".to_string()),
+        Token::Static => Some("static".to_string()),
+        Token::Self_ => Some("self".to_string()),
+        Token::Trait => Some("trait".to_string()),
+        Token::Parent => Some("parent".to_string()),
+        Token::InsteadOf => Some("insteadof".to_string()),
+        Token::Class => Some("class".to_string()),
+        Token::Enum => Some("enum".to_string()),
+        Token::New => Some("new".to_string()),
+        Token::Public => Some("public".to_string()),
+        Token::Protected => Some("protected".to_string()),
+        Token::Private => Some("private".to_string()),
+        Token::ReadOnly => Some("readonly".to_string()),
+        Token::Extern => Some("extern".to_string()),
+        Token::Packed => Some("packed".to_string()),
+        Token::Yield => Some("yield".to_string()),
+        Token::And => Some("and".to_string()),
+        Token::Or => Some("or".to_string()),
+        Token::Xor => Some("xor".to_string()),
+        Token::InstanceOf => Some("instanceof".to_string()),
+        Token::Inf => Some("INF".to_string()),
+        Token::Nan => Some("NAN".to_string()),
+        Token::PhpIntMax => Some("PHP_INT_MAX".to_string()),
+        Token::PhpIntMin => Some("PHP_INT_MIN".to_string()),
+        Token::PhpFloatMax => Some("PHP_FLOAT_MAX".to_string()),
+        Token::MPi => Some("M_PI".to_string()),
+        Token::ME => Some("M_E".to_string()),
+        Token::MSqrt2 => Some("M_SQRT2".to_string()),
+        Token::MPi2 => Some("M_PI_2".to_string()),
+        Token::MPi4 => Some("M_PI_4".to_string()),
+        Token::MLog2e => Some("M_LOG2E".to_string()),
+        Token::MLog10e => Some("M_LOG10E".to_string()),
+        Token::PhpFloatMin => Some("PHP_FLOAT_MIN".to_string()),
+        Token::PhpFloatEpsilon => Some("PHP_FLOAT_EPSILON".to_string()),
+        Token::Stdin => Some("STDIN".to_string()),
+        Token::Stdout => Some("STDOUT".to_string()),
+        Token::Stderr => Some("STDERR".to_string()),
+        Token::PhpEol => Some("PHP_EOL".to_string()),
+        Token::PhpOs => Some("PHP_OS".to_string()),
+        Token::DirectorySeparator => Some("DIRECTORY_SEPARATOR".to_string()),
+        Token::DunderDir => Some("__DIR__".to_string()),
+        Token::DunderFile => Some("__FILE__".to_string()),
+        Token::DunderLine => Some("__LINE__".to_string()),
+        Token::DunderFunction => Some("__FUNCTION__".to_string()),
+        Token::DunderClass => Some("__CLASS__".to_string()),
+        Token::DunderMethod => Some("__METHOD__".to_string()),
+        Token::DunderNamespace => Some("__NAMESPACE__".to_string()),
+        Token::DunderTrait => Some("__TRAIT__".to_string()),
+        _ => None,
+    }
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -14,6 +14,8 @@ mod attributes;
 /// Control flow statements: `if`, `while`, `for`, `foreach`, `switch`, `try`, `goto`, and `label` parsing.
 mod control;
 pub mod expr;
+/// Maps tokens that may legally appear as bareword names (identifiers and semi-reserved keywords).
+mod keyword_name;
 mod stmt;
 
 pub(crate) use attributes::{consume_attribute_lists, parse_attribute_lists};

--- a/src/parser/stmt/oop/body.rs
+++ b/src/parser/stmt/oop/body.rs
@@ -186,9 +186,17 @@ pub(in crate::parser::stmt) fn parse_class_like_body(
                 ));
             }
             *pos += 1; // consume `const`
+            // PHP 8 allows semi-reserved keywords as class-constant names, except `class`,
+            // which is reserved for the `Foo::class` name fetch.
             let const_name = match tokens.get(*pos).map(|(t, _)| t) {
-                Some(Token::Identifier(n)) => {
-                    let n = n.clone();
+                Some(Token::Class) => {
+                    return Err(CompileError::new(
+                        member_span,
+                        "Cannot use 'class' as a class constant name",
+                    ))
+                }
+                Some(t) if crate::parser::keyword_name::bareword_name_from_token(t).is_some() => {
+                    let n = crate::parser::keyword_name::bareword_name_from_token(t).unwrap();
                     *pos += 1;
                     n
                 }
@@ -477,13 +485,17 @@ fn parse_class_like_method(
     is_final: bool,
 ) -> Result<(ClassMethod, Vec<ClassProperty>), CompileError> {
     *pos += 1; // consume 'function'
-    let method_name = match tokens.get(*pos).map(|(t, _)| t) {
-        Some(Token::Identifier(n)) => {
-            let n = n.clone();
+    // PHP 8 allows identifiers and any semi-reserved keyword as a method name (e.g. `self`,
+    // `parent`, `static`, `list`, `print`).
+    let method_name = match tokens
+        .get(*pos)
+        .and_then(|(t, _)| crate::parser::keyword_name::bareword_name_from_token(t))
+    {
+        Some(n) => {
             *pos += 1;
             n
         }
-        _ => return Err(CompileError::new(span, "Expected method name")),
+        None => return Err(CompileError::new(span, "Expected method name")),
     };
 
     expect_token(
@@ -570,9 +582,17 @@ fn parse_interface_body(
         }
         if tokens[*pos].0 == Token::Const {
             *pos += 1; // consume `const`
+            // PHP 8 allows semi-reserved keywords as class-constant names, except `class`,
+            // which is reserved for the `Foo::class` name fetch.
             let const_name = match tokens.get(*pos).map(|(t, _)| t) {
-                Some(Token::Identifier(n)) => {
-                    let n = n.clone();
+                Some(Token::Class) => {
+                    return Err(CompileError::new(
+                        member_span,
+                        "Cannot use 'class' as a class constant name",
+                    ))
+                }
+                Some(t) if crate::parser::keyword_name::bareword_name_from_token(t).is_some() => {
+                    let n = crate::parser::keyword_name::bareword_name_from_token(t).unwrap();
                     *pos += 1;
                     n
                 }

--- a/src/parser/stmt/oop/method_params.rs
+++ b/src/parser/stmt/oop/method_params.rs
@@ -50,6 +50,10 @@ pub(super) fn parse_method_params(
                 &Token::Comma,
                 "Expected ',' between parameters",
             )?;
+            // Allow a trailing comma before the closing paren (PHP 8.0+).
+            if *pos < tokens.len() && tokens[*pos].0 == Token::RParen {
+                break;
+            }
         }
         // PHP 8.0 parameter attributes — also covers attributes preceding a
         // promoted-property modifier such as `#[Inject] public Foo $f`.

--- a/src/parser/stmt/params.rs
+++ b/src/parser/stmt/params.rs
@@ -249,6 +249,10 @@ pub(super) fn parse_params(
                 &Token::Comma,
                 "Expected ',' between parameters",
             )?;
+            // Allow a trailing comma before the closing paren (PHP 8.0+).
+            if *pos < tokens.len() && tokens[*pos].0 == Token::RParen {
+                break;
+            }
         }
         // PHP 8.0 parameter attributes (`function f(#[Sensitive] $s)`).
         crate::parser::consume_attribute_lists(tokens, pos)?;

--- a/tests/codegen/misc.rs
+++ b/tests/codegen/misc.rs
@@ -9,6 +9,14 @@
 
 use crate::support::*;
 
+/// Compiles a program whose source begins with a UTF-8 BOM (U+FEFF) before `<?php` and
+/// verifies it builds and runs end-to-end, matching editors that emit BOM-prefixed UTF-8.
+#[test]
+fn test_utf8_bom_prefixed_source_compiles_and_runs() {
+    let out = compile_and_run("\u{feff}<?php echo \"hi\";");
+    assert_eq!(out, "hi");
+}
+
 // --- IIFE (Immediately Invoked Function Expression) ---
 
 /// Compiles an IIFE that returns a string literal and verifies the value is echoed correctly.

--- a/tests/codegen/objects/classes.rs
+++ b/tests/codegen/objects/classes.rs
@@ -9,6 +9,32 @@
 
 use super::*;
 
+/// Verifies that PHP 8 semi-reserved keywords are usable as member names end-to-end: an
+/// instance method (`self`), a static method (`new`), an instance method via `->parent()`,
+/// a property accessed as `->list`, and a class constant `FN` accessed via `::`. Mirrors PHP,
+/// which outputs "3|7|9|11|5".
+#[test]
+fn test_keyword_named_members() {
+    let out = compile_and_run(
+        r#"<?php
+class Widget {
+    public $list = 7;
+    const FN = 5;
+    public function self() { return 3; }
+    public function parent() { return 9; }
+    public static function new() { return 11; }
+}
+$w = new Widget();
+echo $w->self(), "|";
+echo $w->list, "|";
+echo $w->parent(), "|";
+echo Widget::new(), "|";
+echo Widget::FN;
+"#,
+    );
+    assert_eq!(out, "3|7|9|11|5");
+}
+
 /// Verifies that an empty class (no properties or methods) can be instantiated and
 /// emits the expected "ok" output, confirming object allocation works for minimal classes.
 #[test]

--- a/tests/codegen/operators.rs
+++ b/tests/codegen/operators.rs
@@ -167,6 +167,38 @@ fn test_concat_with_newline() {
     assert_eq!(out, "hello\n");
 }
 
+/// Verifies that concatenating an array onto a string stringifies the array to the literal
+/// "Array" (matching PHP's array-to-string conversion) for both an array literal and an
+/// array-typed function result, instead of crashing by treating the array pointer as a string.
+#[test]
+fn test_concat_array_stringifies_to_array_literal() {
+    let out = compile_and_run(
+        r#"<?php
+function makeArr() { return [1, 2, 3]; }
+echo "a" . [4, 5];
+echo "|";
+echo "prefix" . makeArr();
+"#,
+    );
+    assert_eq!(out, "aArray|prefixArray");
+}
+
+/// Verifies that echoing an array stringifies to the literal "Array" (matching PHP), routing
+/// through the same string-coercion path as concatenation.
+#[test]
+fn test_echo_array_stringifies_to_array_literal() {
+    let out = compile_and_run("<?php $a = [1, 2, 3]; echo $a;");
+    assert_eq!(out, "Array");
+}
+
+/// Verifies that interpolating an array into a double-quoted string stringifies it to the
+/// literal "Array" (matching PHP) for both simple `$a` and complex `{$a}` interpolation.
+#[test]
+fn test_interpolated_array_stringifies_to_array_literal() {
+    let out = compile_and_run("<?php $a = [1, 2, 3]; echo \"v=$a|w={$a}\";");
+    assert_eq!(out, "v=Array|w=Array");
+}
+
 // --- Phase 3: Mixed-type concatenation ---
 
 /// Verifies concatenation of string literal and integer literal: "Value: " . 42 = "Value: 42".
@@ -320,6 +352,33 @@ fn test_constant_loose_eq_number_and_non_numeric_string_is_false() {
 fn test_constant_loose_eq_number_and_numeric_string_is_true() {
     let out = compile_and_run("<?php var_dump(10 == \"1e1\");");
     assert_eq!(out, "bool(true)\n");
+}
+
+/// Verifies runtime float comparisons against NaN match PHP: NaN is uncomparable, so `<`, `<=`,
+/// `>`, `>=`, `==` are all false and `!=` is true, while `<=>` yields 1 in every direction
+/// (including NaN<=>NaN). Operands come from `float`-returning calls so the optimizer cannot
+/// constant-fold them, exercising the runtime comparison codegen rather than the folder.
+#[test]
+fn test_runtime_nan_comparisons() {
+    let out = compile_and_run(
+        r#"<?php
+function nan_val(): float { return NAN; }
+function one_val(): float { return 1.0; }
+$nan = nan_val();
+$one = one_val();
+var_dump($nan < $one);
+var_dump($nan <= $one);
+var_dump($nan > $one);
+var_dump($nan >= $one);
+var_dump($nan == $one);
+var_dump($nan != $one);
+echo ($nan <=> $one), ($one <=> $nan), ($nan <=> $nan);
+"#,
+    );
+    assert_eq!(
+        out,
+        "bool(false)\nbool(false)\nbool(false)\nbool(false)\nbool(false)\nbool(true)\n111"
+    );
 }
 
 /// Verifies runtime loose equality of two non-numeric strings compares by byte sequence.

--- a/tests/codegen/optimizer/constant_folding/expressions.rs
+++ b/tests/codegen/optimizer/constant_folding/expressions.rs
@@ -153,6 +153,22 @@ echo (2 <=> 3) + 2;
     assert_eq!(out, "11");
 }
 
+/// Verifies the spaceship operator folds NAN comparisons to PHP's result: NAN is uncomparable,
+/// so `<=>` yields 1 whenever either operand is NAN (`NAN <=> 1.0`, `1.0 <=> NAN`, `NAN <=> NAN`
+/// all give 1 in PHP). Ordinary ordering still folds correctly.
+#[test]
+fn test_constant_folding_spaceship_with_nan() {
+    let out = compile_and_run(
+        r#"<?php
+echo (NAN <=> 1.0), ",";
+echo (1.0 <=> NAN), ",";
+echo (NAN <=> NAN), ",";
+echo (1.0 <=> 2.0);
+"#,
+    );
+    assert_eq!(out, "1,1,1,-1");
+}
+
 /// Verifies that a literal int-cast from a string is folded, eliminating the
 /// `__rt_str_to_int` call from user assembly.
 #[test]

--- a/tests/codegen/runtime_gc/regressions.rs
+++ b/tests/codegen/runtime_gc/regressions.rs
@@ -851,3 +851,21 @@ run();
         out.stderr
     );
 }
+
+/// Regression test for the array-to-string echo fix: echoing an owned temporary array
+/// stringifies to "Array" and releases the temporary, keeping GC allocs and frees balanced
+/// (no leak from the discarded array, no premature/double free).
+#[test]
+fn test_echo_owned_temp_array_balances_gc_stats() {
+    let baseline = compile_and_run_with_gc_stats("<?php");
+    let out = compile_and_run_with_gc_stats("<?php echo [1, 2, 3];");
+    assert!(out.success, "program failed: {}", out.stderr);
+    assert_eq!(out.stdout, "Array");
+    let (baseline_allocs, baseline_frees) = parse_gc_stats(&baseline.stderr);
+    let (allocs, frees) = parse_gc_stats(&out.stderr);
+    assert!(
+        allocs - baseline_allocs >= 1,
+        "expected the temporary array to allocate at least once"
+    );
+    assert_eq!(allocs - baseline_allocs, frees - baseline_frees);
+}

--- a/tests/codegen/scalar_strings.rs
+++ b/tests/codegen/scalar_strings.rs
@@ -135,6 +135,53 @@ fn test_intval_int_passthrough() {
     assert_eq!(out, "42");
 }
 
+/// Verifies that `intval()` of a large integer string above 2^53 is exact, not routed through
+/// `f64` (which would lose precision — e.g. `1234567890123456789` would become `...456768`).
+/// These strings are not constant-folded (intval-of-string is evaluated at runtime), so this
+/// exercises the `__rt_str_to_int` helper.
+#[test]
+fn test_intval_large_exact_integer_strings() {
+    let out = compile_and_run(
+        "<?php echo intval(\"9223372036854775805\"), \"|\", intval(\"1234567890123456789\"), \"|\", intval(\"9223372036854775000\"), \"|\", intval(\"-9223372036854775808\");",
+    );
+    assert_eq!(
+        out,
+        "9223372036854775805|1234567890123456789|9223372036854775000|-9223372036854775808"
+    );
+}
+
+/// Verifies that `intval()` of out-of-range integer strings clamps to PHP_INT_MAX/PHP_INT_MIN
+/// (matching PHP's `strtol`-style saturation), exercising the runtime `__rt_str_to_int` helper.
+#[test]
+fn test_intval_overflow_strings_clamp() {
+    let out = compile_and_run(
+        "<?php echo intval(\"99999999999999999999\"), \"|\", intval(\"-99999999999999999999\");",
+    );
+    assert_eq!(out, "9223372036854775807|-9223372036854775808");
+}
+
+/// Verifies that the `(int)` cast of a runtime (non-constant) large integer string is exact,
+/// sharing the `__rt_str_to_int` helper with `intval()` (the constant `(int)"..."` form folds
+/// separately at compile time, so this passes the string through a function to force runtime).
+#[test]
+fn test_int_cast_large_exact_integer_string_runtime() {
+    let out = compile_and_run(
+        "<?php function s($x): string { return $x; } echo (int) s(\"1234567890123456789\");",
+    );
+    assert_eq!(out, "1234567890123456789");
+}
+
+/// Verifies that `intval()` of float-form and partial numeric strings still matches PHP:
+/// `"1e3"` parses as the float 1000, `"3.14"` truncates to 3, `"12abc"` stops at the first
+/// non-digit, leading whitespace/sign are handled, and non-numeric strings yield 0.
+#[test]
+fn test_intval_float_form_and_partial_strings() {
+    let out = compile_and_run(
+        "<?php echo intval(\"1e3\"), \"|\", intval(\"3.14\"), \"|\", intval(\"12abc\"), \"|\", intval(\"  -5\"), \"|\", intval(\"abc\");",
+    );
+    assert_eq!(out, "1000|3|12|-5|0");
+}
+
 /// Compiles `<?php echo "before"; exit(0); echo "after";` and asserts stdout is `before`.
 /// Verifies `exit` stops execution and prevents output of subsequent statements.
 #[test]

--- a/tests/codegen/types/named_arguments/direct_and_builtins.rs
+++ b/tests/codegen/types/named_arguments/direct_and_builtins.rs
@@ -214,6 +214,41 @@ echo ":" . str_repeat(times: times_arg(), string: string_arg());
     assert_eq!(out, "ts:hahaha");
 }
 
+/// Verifies that a trailing comma after the last call argument (PHP 7.3+) and after the last
+/// parameter (PHP 8.0+) is accepted across every call/declaration surface — top-level function,
+/// method, static method, `new`, and closure — by summing values; outputs "11" (3+2+2+2+2).
+#[test]
+fn test_trailing_comma_across_call_surfaces() {
+    let out = compile_and_run(
+        r#"<?php
+function add($a, $b,) {
+    return $a + $b;
+}
+class Calc {
+    public function sum($a, $b,) {
+        return $a + $b;
+    }
+    public static function smul($a, $b,) {
+        return $a * $b;
+    }
+}
+class Pair {
+    public $total;
+    public function __construct($a, $b,) {
+        $this->total = $a + $b;
+    }
+}
+$c = new Calc();
+$p = new Pair(1, 1,);
+$mul = function ($a, $b,) {
+    return $a * $b;
+};
+echo add(1, 2,) + $c->sum(1, 1,) + Calc::smul(1, 2,) + $p->total + $mul(1, 2,);
+"#,
+    );
+    assert_eq!(out, "11");
+}
+
 /// Verifies that a spread argument is evaluated exactly once when followed by named arguments;
 /// `str_repeat(...args(), times: times_arg())` outputs "xt:hahaha" (x printed once from args, t from times_arg).
 #[test]

--- a/tests/error_tests/misc/classes.rs
+++ b/tests/error_tests/misc/classes.rs
@@ -853,3 +853,23 @@ fn test_error_concrete_property_redeclared_as_abstract() {
         "Cannot make concrete property abstract: Child::$value",
     );
 }
+
+/// Verifies that `class` is rejected as a class-constant name, even though other semi-reserved
+/// keywords are allowed (PHP reserves `class` for the `Foo::class` name fetch).
+#[test]
+fn test_error_const_named_class_is_rejected() {
+    expect_error(
+        "<?php class A { const class = 1; }",
+        "Cannot use 'class' as a class constant name",
+    );
+}
+
+/// Verifies that a non-name token (an operator) after `->` is still rejected even though
+/// semi-reserved keywords are now accepted as member names.
+#[test]
+fn test_error_operator_after_arrow_is_rejected() {
+    expect_error(
+        "<?php $o = 1; echo $o->+;",
+        "Expected property or method name after '->'",
+    );
+}

--- a/tests/error_tests/syntax.rs
+++ b/tests/error_tests/syntax.rs
@@ -318,6 +318,25 @@ fn test_error_echo_trailing_comma_requires_argument() {
     expect_error("<?php echo \"A\",;", "Unexpected token");
 }
 
+/// Verifies that a lone comma inside an otherwise-empty call argument list is rejected
+/// (a trailing comma after a real argument is allowed, but `foo(,)` is not, matching PHP).
+#[test]
+fn test_error_leading_comma_in_call_args() {
+    expect_error("<?php foo(,);", "Unexpected token");
+}
+
+/// Verifies that a doubled trailing comma in a call argument list is rejected (`foo(1,,)`).
+#[test]
+fn test_error_double_trailing_comma_in_call_args() {
+    expect_error("<?php foo(1,,);", "Unexpected token");
+}
+
+/// Verifies that a lone comma inside an otherwise-empty parameter list is rejected (`f(,)`).
+#[test]
+fn test_error_leading_comma_in_param_list() {
+    expect_error("<?php function f(,) {}", "Expected parameter variable");
+}
+
 /// Verifies the error diagnostic for break level must be positive.
 #[test]
 fn test_error_break_level_must_be_positive() {

--- a/tests/lexer_tests/literals.rs
+++ b/tests/lexer_tests/literals.rs
@@ -232,6 +232,21 @@ fn test_integer_not_mistaken_for_float() {
     assert_eq!(t[1], Token::IntLiteral(42));
 }
 
+/// Verifies that an empty radix literal (`0x`/`0o`/`0b` with no digits) reports its error at the
+/// start of the literal (the `0`, column 7 in `<?php 0x;`), not one column past the consumed prefix.
+#[test]
+fn test_empty_radix_literal_errors_point_at_literal_start() {
+    for (src, msg) in [
+        ("<?php 0x;", "Expected hex digits"),
+        ("<?php 0o;", "Expected octal digits"),
+        ("<?php 0b;", "Expected binary digits"),
+    ] {
+        let err = tokenize(src).unwrap_err();
+        assert!(err.message.contains(msg), "{src}: got {:?}", err.message);
+        assert_eq!(err.span.col, 7, "{src} should point at the literal start");
+    }
+}
+
 /// Verifies `const NAME = "test";` produces `OpenTag`, `Const`, `Identifier`,
 /// `Assign`, `StringLiteral("test")`, `Semicolon`, `Eof` — confirming const
 /// declaration parsing and string literal extraction.

--- a/tests/lexer_tests/source_structure.rs
+++ b/tests/lexer_tests/source_structure.rs
@@ -16,6 +16,15 @@ fn test_open_tag() {
     assert_eq!(t, vec![Token::OpenTag, Token::Eof]);
 }
 
+/// Verifies a leading UTF-8 BOM (U+FEFF) before `<?php` is stripped, so files saved by
+/// editors that emit BOM-prefixed UTF-8 still tokenize starting at `OpenTag`.
+#[test]
+fn test_utf8_bom_before_open_tag_is_stripped() {
+    let t = tokens("\u{feff}<?php echo \"hi\";");
+    assert_eq!(t[0], Token::OpenTag);
+    assert_eq!(t[1], Token::Echo);
+}
+
 /// Verifies `// ...` line comments are consumed and do not appear in the token stream.
 #[test]
 fn test_line_comment() {

--- a/tests/parser_tests/classes/access/methods.rs
+++ b/tests/parser_tests/classes/access/methods.rs
@@ -9,6 +9,48 @@
 
 use super::*;
 
+/// Parses `$obj->self()` and verifies a semi-reserved keyword (`self`) is accepted as a
+/// method name after `->`, producing a `MethodCall` with method "self" (PHP 8 semi-reserved).
+#[test]
+fn test_parse_keyword_method_call() {
+    let stmts = parse_source("<?php $obj->self();");
+    match &stmts[0].kind {
+        StmtKind::ExprStmt(expr) => match &expr.kind {
+            ExprKind::MethodCall { method, .. } => assert_eq!(method, "self"),
+            other => panic!("Expected MethodCall, got {:?}", other),
+        },
+        _ => panic!("Expected ExprStmt"),
+    }
+}
+
+/// Parses `$obj->list` and verifies a semi-reserved keyword (`list`) is accepted as a
+/// property name after `->`, producing a `PropertyAccess` with property "list".
+#[test]
+fn test_parse_keyword_property_access() {
+    let stmts = parse_source("<?php echo $obj->list;");
+    match &stmts[0].kind {
+        StmtKind::Echo(expr) => match &expr.kind {
+            ExprKind::PropertyAccess { property, .. } => assert_eq!(property, "list"),
+            other => panic!("Expected PropertyAccess, got {:?}", other),
+        },
+        _ => panic!("Expected Echo"),
+    }
+}
+
+/// Parses `Factory::new()` and verifies a semi-reserved keyword (`new`) is accepted as a
+/// static method name after `::`, producing a `StaticMethodCall` with method "new".
+#[test]
+fn test_parse_keyword_static_method_call() {
+    let stmts = parse_source("<?php Factory::new();");
+    match &stmts[0].kind {
+        StmtKind::ExprStmt(expr) => match &expr.kind {
+            ExprKind::StaticMethodCall { method, .. } => assert_eq!(method, "new"),
+            other => panic!("Expected StaticMethodCall, got {:?}", other),
+        },
+        _ => panic!("Expected ExprStmt"),
+    }
+}
+
 /// Parses `$obj->run(1, 2)` and verifies `MethodCall` AST with correct method name,
 /// argument count, and object expression kind (Variable).
 #[test]

--- a/tests/parser_tests/functions.rs
+++ b/tests/parser_tests/functions.rs
@@ -666,3 +666,54 @@ fn test_parse_dunder_function_magic_constant() {
         &ExprKind::MagicConstant(MagicConstant::Function)
     );
 }
+
+#[test]
+// Verifies that a trailing comma after the last call argument (PHP 7.3+) is accepted:
+// `<?php greet(1, 2,);` parses to a `FunctionCall` with exactly two arguments.
+/// Verifies that a trailing comma in a call argument list parses.
+fn test_parse_trailing_comma_in_call_args() {
+    let stmts = parse_source("<?php greet(1, 2,);");
+    if let StmtKind::ExprStmt(expr) = &stmts[0].kind {
+        if let ExprKind::FunctionCall { name, args } = &expr.kind {
+            assert_eq!(name.as_str(), "greet");
+            assert_eq!(args.len(), 2);
+        } else {
+            panic!("expected FunctionCall, got {:?}", expr.kind);
+        }
+    } else {
+        panic!("expected ExprStmt");
+    }
+}
+
+#[test]
+// Verifies that a trailing comma after the last parameter (PHP 8.0+) is accepted:
+// `<?php function foo($a, $b,) {}` parses to a `FunctionDecl` with two parameters.
+/// Verifies that a trailing comma in a parameter list parses.
+fn test_parse_trailing_comma_in_param_list() {
+    let stmts = parse_source("<?php function foo($a, $b,) { return $a; }");
+    if let StmtKind::FunctionDecl { name, params, .. } = &stmts[0].kind {
+        assert_eq!(name, "foo");
+        let param_names: Vec<&str> = params.iter().map(|(n, _, _, _)| n.as_str()).collect();
+        assert_eq!(param_names, &["a", "b"]);
+    } else {
+        panic!("expected FunctionDecl");
+    }
+}
+
+#[test]
+// Verifies that a single trailing comma after one argument is accepted:
+// `<?php greet(1,);` parses to a `FunctionCall` with exactly one argument.
+/// Verifies that a single-argument trailing comma in a call parses.
+fn test_parse_single_arg_trailing_comma_in_call() {
+    let stmts = parse_source("<?php greet(1,);");
+    if let StmtKind::ExprStmt(expr) = &stmts[0].kind {
+        if let ExprKind::FunctionCall { name, args } = &expr.kind {
+            assert_eq!(name.as_str(), "greet");
+            assert_eq!(args.len(), 1);
+        } else {
+            panic!("expected FunctionCall, got {:?}", expr.kind);
+        }
+    } else {
+        panic!("expected ExprStmt");
+    }
+}


### PR DESCRIPTION
- **fix(lexer): strip leading UTF-8 BOM and anchor empty-radix errors at the literal**
- **fix(parser): accept trailing commas and semi-reserved keywords as member names**
- **fix(codegen): stringify arrays to "Array" and fix NaN comparison semantics**
- **fix(runtime): parse string-to-int via strtoll to avoid f64 precision loss**
- **docs(types): correct runtime int-overflow behavior and document array-to-string**
