### PR TITLE
fix/null sentinel collision

### DIFF
--- a/.claude/plans/null-sentinel-collision.md
+++ b/.claude/plans/null-sentinel-collision.md
@@ -59,8 +59,44 @@ Unrelated pre-existing quirk found while locking repros: `var_dump(isset(...))` 
 
 6. **Flag.** `NullRepr::{Sentinel, Tagged}` lives in `CliConfig` → pipeline → codegen `Context`. Default `Sentinel` until Phase 4. CLI/env opt-in: `ELEPHC_NULL_REPR=tagged`. Tests force `Tagged` per-compile through an explicit parameter on the test-support compile helpers (no process-global mutation — tests run in parallel threads).
 
-7. **Rejected alternatives.**
+7. **Scope refinement (Phase 2, validated empirically).** elephc's checker is flow-sensitive
+   for locals, and `?int` params/returns/properties already lower to boxed Mixed (null-safe).
+   The §0 bugs therefore need TaggedScalar **producers** only for: int-element array reads
+   (indexed + assoc, miss-capable), and later `array_pop`/`array_shift`/`?->`-int/globals.
+   Params, returns, and properties keep their Mixed boxing — for them only the **consumers**
+   needed fixing (the shared int formatter / sentinel checks). Null-then-int locals are
+   handled by flow typing today and stay as they are.
+
+8. **Null payload canonicalization.** A tagged null carries `NULL_SENTINEL` as its payload
+   word (not zero), so boxing it into a Mixed cell produces exactly the legacy
+   `{tag 8, sentinel}` words — `__rt_mixed_strict_eq` compares payload words even for the
+   null tag, and un-audited consumers that ignore the tag see precisely the legacy encoding
+   (graceful degradation instead of new corruption).
+
+9. **Rejected alternatives.**
    - *(a) rarer sentinel value:* still collides — every i64 is a valid int.
    - *(c) box null-capable scalars as Mixed:* already today's repr for `?int` returns yet still broken (consumer-side sentinel re-check), and boxing every `array<int>` read would heap-allocate per access.
    - *Re-repr `Union([Int,Void])` without a new variant:* every existing `Union(_) => /* boxed pointer */` match arm becomes a silent hazard under the flag; a new variant turns missed paths into compile errors (exhaustive matches) or loud crashes instead of silent miscompilation.
    - *Uninit-property sentinel (`0x...fffd`):* not a value collision (separate metadata word); in scope only for the Phase 1 constant unification.
+
+### Phase 2 status & follow-ups
+
+Done under `NullRepr::Tagged` (default `Sentinel` unchanged, suite green): TaggedScalar
+variant + ABI (slots, args, returns, spills mirror `Str`), `NullRepr` flag
+(`--null-repr=` / `ELEPHC_NULL_REPR`), tag-aware consumers (echo, var_dump + generator dup,
+is_null, `??`, `??=` both copies, isset, empty, gettype, casts, string coercion, truthiness,
+numeric binops, strict `===` via the Mixed boxing path), and the int-array read producers
+(indexed + assoc, hit→tag int / miss→tag null). All §0 repros pass under `Tagged` and are
+covered by `tests/codegen/null_sentinel/tagged.rs` (macOS ARM64 + Linux x86_64 + Linux ARM64).
+
+Discovered during Phase 2 — pre-existing null-read bugs (broken in BOTH modes; Tagged fixes
+most): under the legacy sentinel repr, `$a[miss] + 1`, `$a[miss] . "s"`, `"{$a[miss]}"`,
+`$a[miss] * 3` all leak the sentinel digits; Tagged narrows them correctly.
+
+Remaining follow-ups (not blockers; behavior matches the legacy mode):
+- unary minus / `abs()` (and other int-builtin args) on a tagged null leak the sentinel
+  payload — needs narrowing in unary ops and builtin argument materialization.
+- `array_pop`/`array_shift` empty results on int arrays still return a plain-Int sentinel.
+- `?->` over int members and int globals still use the sentinel encoding.
+- `$a[$i][...]` nested reads, foreach value bindings, and by-ref interactions need an audit
+  pass with tagged reads.

--- a/.claude/plans/null-sentinel-collision.md
+++ b/.claude/plans/null-sentinel-collision.md
@@ -11,6 +11,10 @@
 - **Phase 2** — Tagged representation behind `NullRepr::{Sentinel, Tagged}` flag (default `Sentinel`); audit every producer/consumer; repros pass under `Tagged` on all 3 targets.
 - **Phase 3** — Narrowing: non-nullable `int` slots stay plain i64 (asm-inspection proof); only genuinely-nullable slots widen.
 - **Phase 4** — Flip default to `Tagged`, update docs, converge with the overflow plan.
+  **DONE** except overflow convergence (tracked in the overflow plan): default flipped,
+  `--null-repr=sentinel` kept as documented opt-out, §0 repros un-ignored, docs updated.
+  Evidence: full default-mode suite green pre-flip (3979), full Tagged-forced suite green
+  modulo two since-fixed failures plus green focused reruns, Linux x86_64/ARM64 28/28.
 
 ## Sentinel inventory
 

--- a/.claude/plans/null-sentinel-collision.md
+++ b/.claude/plans/null-sentinel-collision.md
@@ -93,10 +93,22 @@ Discovered during Phase 2 — pre-existing null-read bugs (broken in BOTH modes;
 most): under the legacy sentinel repr, `$a[miss] + 1`, `$a[miss] . "s"`, `"{$a[miss]}"`,
 `$a[miss] * 3` all leak the sentinel digits; Tagged narrows them correctly.
 
-Remaining follow-ups (not blockers; behavior matches the legacy mode):
-- unary minus / `abs()` (and other int-builtin args) on a tagged null leak the sentinel
-  payload — needs narrowing in unary ops and builtin argument materialization.
-- `array_pop`/`array_shift` empty results on int arrays still return a plain-Int sentinel.
-- `?->` over int members and int globals still use the sentinel encoding.
-- `$a[$i][...]` nested reads, foreach value bindings, and by-ref interactions need an audit
-  pass with tagged reads.
+Phase 2.3 (full suite forced to Tagged) initially failed 9/3978; all four systematic causes
+fixed: local inference now mirrors emission (TaggedScalar for miss-capable int reads, so
+array literals box and === peeks stay runtime), untyped params widen to int|null on null
+call sites (flag installed before checking), array element stores/pushes narrow the payload
+word, and local assignments reinterpret into one-word slots instead of clobbering the
+neighboring slot with the tag word. `array_pop`/`array_shift` empty results, unary minus,
+and `abs()` are tagged/narrowed. Benches (noisy, same-load comparison): plain-int parity,
+array-read loop ~45% faster under Tagged (sentinel materialization disappears), nullable
+roundtrip +9%.
+
+Remaining follow-ups (not blockers; behavior matches the legacy mode in both representations):
+- storing a null-valued tagged read into an int array keeps the in-band payload (reads
+  back as the sentinel integer, like the legacy mode); a runtime tag-branch into the boxed
+  Mixed conversion would make it PHP-exact.
+- int-builtin argument narrowing beyond abs() (e.g. intdiv on a null read) follows legacy
+  semantics; a shared builtin-arg coercion gate would make them PHP-exact.
+- undefined globals read as int 0 in both modes (PHP: null + warning) — pre-existing.
+- `?->` over int members already prints correctly via the Mixed path; enum tryFrom keeps
+  its object-pointer sentinel scheme (no int collision).

--- a/.claude/plans/null-sentinel-collision.md
+++ b/.claude/plans/null-sentinel-collision.md
@@ -1,0 +1,66 @@
+# Null-sentinel collision — Implementation Plan
+
+**Goal:** Make every valid PHP integer representable as a non-null scalar — eliminating the collision where the integer `9223372036854775806` (= `PHP_INT_MAX - 1` = the in-band null sentinel `0x7fff_ffff_ffff_fffe`) is misread as `null` — without heap-boxing every plain `int`.
+
+**Architecture:** elephc stores PHP `null` in an unboxed scalar slot using the magic i64 `0x7fff_ffff_ffff_fffe`. Because every i64 bit pattern is a valid PHP int, this in-band sentinel collides with the real integer. The fix introduces an inline 2-word `{tag, payload}` tagged scalar for scalar slots that can be null, reusing the existing runtime tag scheme, with no heap allocation. Designed to converge with the int-overflow→float work (same `{tag, payload}` shape, tag ∈ {int, float, null}).
+
+## Phases
+
+- **Phase 0** — Lock repros (`tests/codegen/null_sentinel/repros.rs`), decide representation (see DESIGN-NOTES), add microbench harness.
+- **Phase 1** — Unify the 7 file-local `NULL_SENTINEL` consts + raw literals into one canonical constant; document the incompatibility in `docs/php/types.md`. Zero behavior change.
+- **Phase 2** — Tagged representation behind `NullRepr::{Sentinel, Tagged}` flag (default `Sentinel`); audit every producer/consumer; repros pass under `Tagged` on all 3 targets.
+- **Phase 3** — Narrowing: non-nullable `int` slots stay plain i64 (asm-inspection proof); only genuinely-nullable slots widen.
+- **Phase 4** — Flip default to `Tagged`, update docs, converge with the overflow plan.
+
+## Sentinel inventory
+
+**Producers (write the null sentinel):** `expr/scalars.rs` (`emit_null_literal`), `expr/objects/nullsafe.rs` (`?->`), `expr/objects/dispatch/enums.rs` (enum `tryFrom`), `expr/objects.rs` (`emit_boxed_null`), `expr/arrays/access/indexed.rs` (array miss), `abi/symbols.rs` (globals), `stmt/assignments/properties/storage.rs` (Void property), `abi/values.rs` (Void/Never local store), `runtime/arrays/array_shift.rs`, boxed-null low-word reuses in `magic_set.rs`, `dynamic_props.rs`.
+
+**Consumers (detect null via sentinel):** `builtins/types/is_null.rs`, `stmt/io.rs` (echo), `builtins/io/var_dump.rs`, `functions/generator/emit/stmts.rs`, `expr/compare/null_coalesce.rs` (`??`), `stmt/null_coalesce_assign.rs` + dup in `stmt/assignments/locals.rs` (`??=`), `builtins/arrays/isset.rs`, `expr/coerce.rs` (`coerce_null_to_zero`), `builtins/io/stream_get_contents.rs`.
+
+---
+
+## DESIGN-NOTES (Phase 0)
+
+### Empirical findings (macOS ARM64, elephc 0.23.8, PHP 8.4.20 oracle)
+
+```
+echo 9223372036854775806;                  elephc: (empty)        PHP: 9223372036854775806
+$a=[...806]; echo $a[0]; var_dump($a[0]);  elephc: (empty)/NULL   PHP: ...806 / int(...806)
+function f():?int{return ...806;} f()      elephc: NULL           PHP: int(...806)
+$x=...806; var_dump(is_null($x));          elephc: bool(true)     PHP: bool(false)
+$x=...806; echo $x ?? 0;                   elephc: 0              PHP: ...806
+$a=[...806]; isset($a[0])                  elephc: true (correct)
+```
+
+Key discovery from asm inspection (`--emit-asm`): a `?int` return is **already boxed as a Mixed cell with the correct int tag** (`__rt_mixed_from_value(tag=0, payload=...806)`); the NULL output comes from the **shared int formatter** (`emit_var_dump_int`) re-checking the payload against the sentinel after unboxing. The collision therefore lives in (a) consumers that sentinel-check every `Int`-typed payload because the type `Int` is overloaded ("definitely int" vs "int-or-null"), and (b) producers that write the sentinel into `Int`-typed slots (array miss, etc.). The boxed Mixed path itself is sound.
+
+Unrelated pre-existing quirk found while locking repros: `var_dump(isset(...))` prints `int(1)` instead of `bool(true)` (isset result is typed int). Repro tests avoid it via ternary echo.
+
+### Decision: option (b) — inline 2-word tagged scalar, new internal `PhpType::TaggedScalar` variant
+
+1. **Carrier.** New variant `PhpType::TaggedScalar` (internal-only, like `Mixed`; the checker never produces it). It is **constructed only in codegen funnels and only when `NullRepr::Tagged` is active**. Under `NullRepr::Sentinel` (default) it is never constructed, so generated code is byte-identical and no flag plumbing is needed in `src/types/model.rs` — `stack_size`/`register_count`/`is_refcounted` for the variant are unconditional.
+
+2. **Layout.**
+   - Stack slot: 16 bytes — payload word at `offset`, tag word at `offset - 8` (mirrors `Str`: ptr at `offset`, len at `offset - 8`).
+   - `stack_size() = 16`, `register_count() = 2`, `is_refcounted() = false`, `is_float_reg() = false`.
+   - Expression result: payload in `int_result_reg` (ARM64 `x0`, x86_64 `rax`), tag in the second-word register (ARM64 `x1`, x86_64 `rdx` — same convention as `Str`'s second word). Payload-in-result-reg makes "narrow to plain int" free once non-null is proven.
+   - Arguments: 2 consecutive integer argument registers (payload, tag), reusing the existing 2-register argument machinery built for `Str`; stack spills follow the existing 2-word logic.
+
+3. **Tag domain.** Reuse `runtime_value_tag` values: `0 = int`, `2 = float` (reserved for the int-overflow plan), `3 = bool` (reserved), `8 = null`. `is_null` ⇔ `tag == 8`. The `{tag, payload}` pair is word-compatible with a Mixed cell's words 0/8, so TaggedScalar→Mixed boxing is a direct `__rt_mixed_from_value(tag, payload, 0)` and Mixed→TaggedScalar unboxing is two loads. This is the convergence point with the overflow plan.
+
+4. **Construction funnels (under `Tagged`).**
+   - Declared-type lowering (`codegen_static_type`/`codegen_declared_type` + the `Union → Mixed` collapse): `Union([Int, Void])` → `TaggedScalar` for params, returns, locals, properties.
+   - `array<int>` element reads (miss-capable): hit → `{tag=int, payload}`, miss → `{tag=null}`.
+   - `null` literal flowing into an int context; `?->` over int members; `array_shift` empty result; `stream_get_contents` failure path.
+   - **Scope:** only `int|null` widens initially. `?float`/`?bool` keep today's Mixed boxing (tag values reserved; flipping them is follow-up work). `?string` stays Mixed permanently (a string is already 2 words; `{tag, ptr, len}` would need 3). Nullable objects keep their existing pointer-sentinel scheme (separate surface, out of scope).
+
+5. **Consumers (under `Tagged`).** `is_null`, echo suppression, `var_dump`, `??`, `??=`, `isset`, `coerce_null_to_zero` dispatch on the tag word when the operand is `TaggedScalar`, and emit **no sentinel check at all** for plain `Int` operands (plain `Int` becomes "definitely int" again — this alone fixes `echo 9223372036854775806`).
+
+6. **Flag.** `NullRepr::{Sentinel, Tagged}` lives in `CliConfig` → pipeline → codegen `Context`. Default `Sentinel` until Phase 4. CLI/env opt-in: `ELEPHC_NULL_REPR=tagged`. Tests force `Tagged` per-compile through an explicit parameter on the test-support compile helpers (no process-global mutation — tests run in parallel threads).
+
+7. **Rejected alternatives.**
+   - *(a) rarer sentinel value:* still collides — every i64 is a valid int.
+   - *(c) box null-capable scalars as Mixed:* already today's repr for `?int` returns yet still broken (consumer-side sentinel re-check), and boxing every `array<int>` read would heap-allocate per access.
+   - *Re-repr `Union([Int,Void])` without a new variant:* every existing `Union(_) => /* boxed pointer */` match arm becomes a silent hazard under the flag; a new variant turns missed paths into compile errors (exhaustive matches) or loud crashes instead of silent miscompilation.
+   - *Uninit-property sentinel (`0x...fffd`):* not a value collision (separate metadata word); in scope only for the Phase 1 constant unification.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -641,7 +641,7 @@ binaries never link the bridge.
 
 - [x] Null-sentinel collision groundwork — one canonical `NULL_SENTINEL` constant (`src/codegen/sentinels.rs`) replacing seven file-local duplicates, `i64::MAX - 1` disguises, and raw `movz`/`movk` chains; collision repros locked in `tests/codegen/null_sentinel/` and the incompatibility documented in `docs/php/types.md`
 - [x] Tagged null representation behind `--null-repr=tagged` / `ELEPHC_NULL_REPR` — inline two-word `{payload, tag}` `TaggedScalar` for null-capable scalars (miss-capable int array reads, empty `array_pop`/`array_shift`), tag-aware consumers (`echo`, `var_dump`, `is_null`, `??`, `??=`, `isset`, `empty`, `gettype`, casts, arithmetic narrowing, `===` via Mixed boxing), plain-int sentinel checks removed (full 64-bit int range round-trips, including `9223372036854775806`), local inference and untyped-param widening aligned; covered on all three targets in `tests/codegen/null_sentinel/tagged.rs`
-- [ ] Flip the default null representation to `Tagged` once the full suite forced to `Tagged` and the microbench comparison are green (then drop the `docs/php/types.md` collision bullet); the `{payload, tag}` shape is the convergence point for runtime int-overflow→float promotion
+- [x] Flip the default null representation to `Tagged` (the collision bullet in `docs/php/types.md` now documents only the `--null-repr=sentinel` opt-out); the `{payload, tag}` shape is the convergence point for runtime int-overflow→float promotion
 
 ## v0.24.x — EIR introduction and register allocation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -637,6 +637,12 @@ binaries never link the bridge.
 
 - [x] Flow-sensitive type-guard narrowing — `if` / `elseif` / `else` chains guarded by `is_int()` / `is_float()` / `is_string()` / `is_bool()` (and the `is_integer` / `is_long` / `is_double` aliases) or `$var instanceof Class` narrow the guarded variable inside the matching branch, with an optional leading `!`, complement accumulation across the chain and `else`, and post-`if` narrowing when every branch diverges (`return` / `throw` / `exit` / `die` / `never`-returning calls); union members are filtered to the guarded type and `Mixed` is refined to it, while concrete non-union types are left unchanged (`src/types/checker/stmt_check/narrowing.rs`, tested in `tests/codegen/types/narrowing.rs`)
 
+### Runtime representation
+
+- [x] Null-sentinel collision groundwork — one canonical `NULL_SENTINEL` constant (`src/codegen/sentinels.rs`) replacing seven file-local duplicates, `i64::MAX - 1` disguises, and raw `movz`/`movk` chains; collision repros locked in `tests/codegen/null_sentinel/` and the incompatibility documented in `docs/php/types.md`
+- [x] Tagged null representation behind `--null-repr=tagged` / `ELEPHC_NULL_REPR` — inline two-word `{payload, tag}` `TaggedScalar` for null-capable scalars (miss-capable int array reads, empty `array_pop`/`array_shift`), tag-aware consumers (`echo`, `var_dump`, `is_null`, `??`, `??=`, `isset`, `empty`, `gettype`, casts, arithmetic narrowing, `===` via Mixed boxing), plain-int sentinel checks removed (full 64-bit int range round-trips, including `9223372036854775806`), local inference and untyped-param widening aligned; covered on all three targets in `tests/codegen/null_sentinel/tagged.rs`
+- [ ] Flip the default null representation to `Tagged` once the full suite forced to `Tagged` and the microbench comparison are green (then drop the `docs/php/types.md` collision bullet); the `{payload, tag}` shape is the convergence point for runtime int-overflow→float promotion
+
 ## v0.24.x — EIR introduction and register allocation
 
 Introduce a domain-specific intermediate representation (EIR) between the

--- a/docs/internals/memory-model.md
+++ b/docs/internals/memory-model.md
@@ -102,9 +102,10 @@ For heap-backed values, stack slots also carry compile-time ownership metadata i
 ### Null representations
 
 elephc has two representations for PHP `null` in scalar slots, selected per compilation by
-`--null-repr=sentinel|tagged` (or `ELEPHC_NULL_REPR`).
+`--null-repr=sentinel|tagged` (or `ELEPHC_NULL_REPR`). The tagged representation is the
+default; the sentinel is the legacy opt-out.
 
-#### The in-band sentinel (legacy)
+#### The in-band sentinel (legacy opt-out)
 
 `null` is represented as the integer `0x7FFFFFFFFFFFFFFE` (`PHP_INT_MAX - 1`). Because every
 64-bit pattern is a valid PHP int, this sentinel collides with the real integer
@@ -123,9 +124,9 @@ csel x0, xzr, x0, eq      ; if x0 == sentinel, replace with 0
 
 See [ARM64 Instruction Reference](arm64-instructions.md#move-and-immediate) for how `movz`/`movk` work.
 
-#### The tagged scalar representation
+#### The tagged scalar representation (default)
 
-Under `--null-repr=tagged`, null-capable scalar slots use an inline two-word
+Under the tagged representation, null-capable scalar slots use an inline two-word
 `{payload, tag}` pair (`TaggedScalar`) instead of the in-band sentinel: the payload travels
 in the integer result register (`x0`/`rax`) and the runtime tag in the adjacent register
 (`x1`/`rdx`), mirroring the string pointer/length convention. The tag reuses the runtime

--- a/docs/internals/memory-model.md
+++ b/docs/internals/memory-model.md
@@ -97,10 +97,19 @@ For heap-backed values, stack slots also carry compile-time ownership metadata i
 | `Buffer` | 8 bytes | Pointer to buffer header |
 | `Packed` | 8 bytes | Metadata-only nominal type, accessed via pointer |
 | `Union` | 8 bytes | Boxed runtime-tagged payload (same storage as Mixed) |
+| `TaggedScalar` | 16 bytes | 8-byte payload + 8-byte runtime tag (tagged null representation) |
 
-### The null sentinel
+### Null representations
 
-`null` is represented as the integer `0x7FFFFFFFFFFFFFFE` — a value chosen to be distinguishable from any real integer (it's near `INT_MAX` but not equal to it). Before arithmetic operations, the codegen checks for this sentinel and replaces it with 0:
+elephc has two representations for PHP `null` in scalar slots, selected per compilation by
+`--null-repr=sentinel|tagged` (or `ELEPHC_NULL_REPR`).
+
+#### The in-band sentinel (legacy)
+
+`null` is represented as the integer `0x7FFFFFFFFFFFFFFE` (`PHP_INT_MAX - 1`). Because every
+64-bit pattern is a valid PHP int, this sentinel collides with the real integer
+`9223372036854775806`, which is misread as `null` by null checks. Before arithmetic
+operations, the codegen checks for this sentinel and replaces it with 0:
 
 ```asm
 ; coerce null to zero
@@ -113,6 +122,33 @@ csel x0, xzr, x0, eq      ; if x0 == sentinel, replace with 0
 ```
 
 See [ARM64 Instruction Reference](arm64-instructions.md#move-and-immediate) for how `movz`/`movk` work.
+
+#### The tagged scalar representation
+
+Under `--null-repr=tagged`, null-capable scalar slots use an inline two-word
+`{payload, tag}` pair (`TaggedScalar`) instead of the in-band sentinel: the payload travels
+in the integer result register (`x0`/`rax`) and the runtime tag in the adjacent register
+(`x1`/`rdx`), mirroring the string pointer/length convention. The tag reuses the runtime
+value tag scheme (0 = int, 8 = null), so a tagged scalar is word-compatible with a boxed
+Mixed cell's tag/payload words. On the stack the payload sits at `offset` and the tag at
+`offset - 8`.
+
+Null-capable producers — miss-capable int array reads, `array_pop`/`array_shift` on int
+arrays — yield a tagged scalar; consumers (`echo`, `var_dump`, `is_null`, `??`, `??=`,
+`isset`, `empty`, `gettype`, casts, arithmetic narrowing, `===` through the Mixed boxing
+path) dispatch on the tag word. A plain non-nullable `Int` is statically never null, so its
+sentinel checks disappear entirely and the full 64-bit range round-trips:
+
+```asm
+; null check on a tagged scalar
+cmp x1, #8                ; runtime tag 8 = PHP null
+b.eq value_is_null
+```
+
+A tagged null carries the legacy sentinel as its payload word, so boxing it into a Mixed
+cell produces exactly the legacy `{tag 8, sentinel}` words and un-audited consumers degrade
+to the legacy behavior. `?int` parameters, returns, and properties keep their boxed Mixed
+representation under both modes.
 
 ### Pointer values
 

--- a/docs/php/types.md
+++ b/docs/php/types.md
@@ -187,6 +187,8 @@ Narrowing applies to function and method parameters. A parameter whose call site
 - `??=` is checked against typed assignment storage for variables, object properties, static properties, and non-append array elements. For concrete local variable types, the fallback must keep the same type or be a literal `null`.
 - Plain array numeric casts (`(int)$array`, `(float)$array`) follow elephc's existing array cast semantics (return the element count rather than PHP's `0`/`1`). Direct `iterable` numeric casts use PHP's empty/non-empty `0`/`1` semantics.
 - `__destruct` runs when an object's refcount reaches zero (scope exit, reassignment, `unset`, program end), matching PHP's timing, but **object resurrection is not supported**: re-storing `$this` so the object would outlive the destructor does not keep it alive — the object is still freed once `__destruct` returns.
+- The integer `9223372036854775806` (`PHP_INT_MAX - 1`) collides with elephc's internal null marker in unboxed scalar slots and is currently misread as `null` by `echo`, `var_dump()`, `is_null()`, `??`, and related null checks. `mixed`-typed values holding the same integer are tagged correctly but still print as `NULL` through the shared integer formatter. This affects only that single value; it is being fixed by a tagged scalar representation.
+
 ### Filesystem functions not implemented
 
 These standard PHP filesystem functions are intentionally absent from elephc because they have no meaningful semantics in a compiled native binary:

--- a/docs/php/types.md
+++ b/docs/php/types.md
@@ -187,7 +187,7 @@ Narrowing applies to function and method parameters. A parameter whose call site
 - `??=` is checked against typed assignment storage for variables, object properties, static properties, and non-append array elements. For concrete local variable types, the fallback must keep the same type or be a literal `null`.
 - Plain array numeric casts (`(int)$array`, `(float)$array`) follow elephc's existing array cast semantics (return the element count rather than PHP's `0`/`1`). Direct `iterable` numeric casts use PHP's empty/non-empty `0`/`1` semantics.
 - `__destruct` runs when an object's refcount reaches zero (scope exit, reassignment, `unset`, program end), matching PHP's timing, but **object resurrection is not supported**: re-storing `$this` so the object would outlive the destructor does not keep it alive — the object is still freed once `__destruct` returns.
-- The integer `9223372036854775806` (`PHP_INT_MAX - 1`) collides with elephc's internal null marker in unboxed scalar slots and is currently misread as `null` by `echo`, `var_dump()`, `is_null()`, `??`, and related null checks. `mixed`-typed values holding the same integer are tagged correctly but still print as `NULL` through the shared integer formatter. This affects only that single value; it is being fixed by a tagged scalar representation.
+- Under the legacy `--null-repr=sentinel` opt-out, the integer `9223372036854775806` (`PHP_INT_MAX - 1`) collides with elephc's internal null marker in unboxed scalar slots and is misread as `null` by `echo`, `var_dump()`, `is_null()`, `??`, and related null checks. The default tagged null representation does not have this collision: the full 64-bit integer range round-trips.
 
 ### Filesystem functions not implemented
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,7 +57,8 @@ pub(crate) fn parse_args(args: &[String]) -> CliConfig {
     let mut defines: HashSet<String> = HashSet::new();
     let mut null_repr = match std::env::var("ELEPHC_NULL_REPR").as_deref() {
         Ok("tagged") => crate::codegen::NullRepr::Tagged,
-        _ => crate::codegen::NullRepr::Sentinel,
+        Ok("sentinel") => crate::codegen::NullRepr::Sentinel,
+        _ => crate::codegen::NullRepr::default(),
     };
 
     let mut i = 1;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,7 @@ use std::process;
 use crate::codegen::platform::Target;
 
 /// Usage string printed to stderr when command-line arguments are invalid or missing.
-pub(crate) const USAGE: &str = "Usage: elephc [--target TARGET] [--heap-size=BYTES] [--gc-stats] [--heap-debug] [--emit-asm] [--check] [--timings] [--source-map] [--define SYMBOL] [--link LIB|-lLIB] [--link-path DIR|-LDIR] [--framework NAME] <source.php>";
+pub(crate) const USAGE: &str = "Usage: elephc [--target TARGET] [--heap-size=BYTES] [--gc-stats] [--heap-debug] [--emit-asm] [--check] [--null-repr=sentinel|tagged] [--timings] [--source-map] [--define SYMBOL] [--link LIB|-lLIB] [--link-path DIR|-LDIR] [--framework NAME] <source.php>";
 
 /// Configuration derived from command-line arguments, passed to the compile pipeline.
 /// Controls heap allocation size, debug output, code generation options, and linking behavior.
@@ -23,6 +23,7 @@ pub(crate) struct CliConfig {
     pub(crate) heap_size: usize,
     pub(crate) gc_stats: bool,
     pub(crate) heap_debug: bool,
+    pub(crate) null_repr: crate::codegen::NullRepr,
     pub(crate) emit_asm: bool,
     pub(crate) check_only: bool,
     pub(crate) emit_timings: bool,
@@ -54,6 +55,10 @@ pub(crate) fn parse_args(args: &[String]) -> CliConfig {
     let mut extra_link_paths: Vec<String> = Vec::new();
     let mut extra_frameworks: Vec<String> = Vec::new();
     let mut defines: HashSet<String> = HashSet::new();
+    let mut null_repr = match std::env::var("ELEPHC_NULL_REPR").as_deref() {
+        Ok("tagged") => crate::codegen::NullRepr::Tagged,
+        _ => crate::codegen::NullRepr::Sentinel,
+    };
 
     let mut i = 1;
     while i < args.len() {
@@ -77,6 +82,8 @@ pub(crate) fn parse_args(args: &[String]) -> CliConfig {
             emit_timings = true;
         } else if arg == "--source-map" {
             emit_source_map = true;
+        } else if let Some(value) = arg.strip_prefix("--null-repr=") {
+            null_repr = parse_null_repr(value);
         } else if arg == "--define" {
             i += 1;
             let symbol = required_value(args, i, "Missing symbol after --define");
@@ -134,6 +141,7 @@ pub(crate) fn parse_args(args: &[String]) -> CliConfig {
         heap_size,
         gc_stats,
         heap_debug,
+        null_repr,
         emit_asm,
         check_only,
         emit_timings,
@@ -160,6 +168,15 @@ fn parse_required_target(args: &[String], index: usize) -> Target {
         parse_target(&args[index])
     } else {
         fail("Missing target after --target")
+    }
+}
+
+/// Parse a `--null-repr=` value into a NullRepr, or fail with an error message.
+fn parse_null_repr(value: &str) -> crate::codegen::NullRepr {
+    match value {
+        "sentinel" => crate::codegen::NullRepr::Sentinel,
+        "tagged" => crate::codegen::NullRepr::Tagged,
+        other => fail(&format!("Unknown null representation: {}", other)),
     }
 }
 

--- a/src/codegen/abi/calls/incoming.rs
+++ b/src/codegen/abi/calls/incoming.rs
@@ -128,6 +128,31 @@ pub fn emit_store_incoming_param(
                 cursor.int_stack_only = true;
             }
         }
+        PhpType::TaggedScalar => {
+            if !cursor.int_stack_only && cursor.int_reg_idx + 1 < int_reg_limit {
+                let payload_reg = int_arg_reg_name(emitter.target, cursor.int_reg_idx);
+                let tag_reg = int_arg_reg_name(emitter.target, cursor.int_reg_idx + 1);
+                emitter.comment(&format!(
+                    "param ${} from {},{}",
+                    name, payload_reg, tag_reg
+                ));
+                store_at_offset(emitter, payload_reg, offset);                         // save the tagged scalar payload from the incoming integer-register pair
+                store_at_offset(emitter, tag_reg, offset - 8);                         // save the tagged scalar tag from the incoming integer-register pair
+                cursor.int_reg_idx += 2;
+            } else {
+                emitter.comment(&format!(
+                    "param ${} from caller stack +{}",
+                    name,
+                    cursor.caller_stack_offset
+                ));
+                load_from_caller_stack(emitter, int_spill_reg, cursor.caller_stack_offset);
+                load_from_caller_stack(emitter, int_hi_spill_reg, cursor.caller_stack_offset + 8);
+                store_at_offset(emitter, int_spill_reg, offset);                       // save the spilled tagged scalar payload into the local param slot
+                store_at_offset(emitter, int_hi_spill_reg, offset - 8);                // save the spilled tagged scalar tag into the local param slot
+                cursor.caller_stack_offset += 16;
+                cursor.int_stack_only = true;
+            }
+        }
         PhpType::Void | PhpType::Never => {}
         PhpType::Iterable
         | PhpType::Mixed

--- a/src/codegen/abi/calls/outgoing.rs
+++ b/src/codegen/abi/calls/outgoing.rs
@@ -118,7 +118,7 @@ fn emit_copy_stack_arg_slot(
             emit_load_temporary_stack_slot(emitter, float_reg, src_offset);
             emit_store_to_sp(emitter, float_reg, dst_offset);
         }
-        PhpType::Str => {
+        PhpType::Str | PhpType::TaggedScalar => {
             emit_load_temporary_stack_slot(emitter, int_reg, src_offset);
             emit_load_temporary_stack_slot(emitter, int_hi_reg, src_offset + 8);
             emit_store_to_sp(emitter, int_reg, dst_offset);
@@ -210,7 +210,7 @@ pub fn materialize_outgoing_args(
                     src_offset,
                 );
             }
-            PhpType::Str => {
+            PhpType::Str | PhpType::TaggedScalar => {
                 emit_load_temporary_stack_slot(
                     emitter,
                     int_arg_reg_name(emitter.target, assignment.start_reg),

--- a/src/codegen/abi/calls/stack.rs
+++ b/src/codegen/abi/calls/stack.rs
@@ -145,6 +145,10 @@ pub fn emit_push_result_value(emitter: &mut Emitter, ty: &PhpType) {
             let (ptr_reg, len_reg) = string_result_regs(emitter);
             emit_push_reg_pair(emitter, ptr_reg, len_reg);                              // push the current string result register pair onto the temporary arg stack
         }
+        PhpType::TaggedScalar => {
+            let tag_reg = crate::codegen::sentinels::tagged_scalar_tag_reg(emitter);
+            emit_push_reg_pair(emitter, int_result_reg(emitter), tag_reg);              // push the current tagged scalar payload/tag register pair onto the temporary arg stack
+        }
         PhpType::Void | PhpType::Never => {}
     }
 }

--- a/src/codegen/abi/symbols.rs
+++ b/src/codegen/abi/symbols.rs
@@ -9,6 +9,7 @@
 //! - Symbol relocations differ by platform and refcounted stores must preserve ownership cleanup.
 
 use crate::codegen::{emit::Emitter, platform::Arch};
+use crate::codegen::NULL_SENTINEL;
 use crate::types::PhpType;
 
 use super::calls::emit_call_label;
@@ -21,7 +22,6 @@ use super::registers::{
 };
 use super::values::{emit_decref_if_refcounted, emit_load_int_immediate};
 
-const NULL_SENTINEL: i64 = 0x7fff_ffff_ffff_fffe;
 
 /// Stores a local variable from its frame slot into a static/global symbol.
 /// Loads the value from `offset` relative to the frame pointer, then writes it

--- a/src/codegen/abi/values.rs
+++ b/src/codegen/abi/values.rs
@@ -16,6 +16,7 @@ use crate::types::PhpType;
 use super::calls::{emit_call_label, emit_pop_reg, emit_push_reg};
 use super::frame::{emit_load_from_address, load_at_offset, store_at_offset};
 use super::registers::{float_result_reg, int_result_reg, string_result_regs};
+use crate::codegen::sentinels::tagged_scalar_tag_reg;
 
 /// Stores the current result value (in result registers) of the given type at a stack frame offset.
 ///
@@ -39,6 +40,10 @@ pub fn emit_store(emitter: &mut Emitter, ty: &PhpType, offset: usize) {
         }
         PhpType::Void | PhpType::Never => {
             store_at_offset(emitter, int_result_reg(emitter), offset);                  // store null sentinel
+        }
+        PhpType::TaggedScalar => {
+            store_at_offset(emitter, int_result_reg(emitter), offset);                  // store tagged scalar payload word
+            store_at_offset(emitter, tagged_scalar_tag_reg(emitter), offset - 8);       // store tagged scalar tag word
         }
         PhpType::Iterable
         | PhpType::Mixed
@@ -164,6 +169,10 @@ pub fn emit_load(emitter: &mut Emitter, ty: &PhpType, offset: usize) {
         }
         PhpType::Void | PhpType::Never => {
             load_at_offset(emitter, int_result_reg(emitter), offset);                   // load null sentinel
+        }
+        PhpType::TaggedScalar => {
+            load_at_offset(emitter, int_result_reg(emitter), offset);                   // load tagged scalar payload word
+            load_at_offset(emitter, tagged_scalar_tag_reg(emitter), offset - 8);        // load tagged scalar tag word
         }
         PhpType::Iterable
         | PhpType::Mixed
@@ -323,6 +332,10 @@ pub fn emit_write_stdout(emitter: &mut Emitter, ty: &PhpType) {
         }
         PhpType::Bool | PhpType::Int => {
             emit_call_label(emitter, "__rt_itoa");
+            emit_write_current_string_stdout(emitter);
+        }
+        PhpType::TaggedScalar => {
+            emit_call_label(emitter, "__rt_itoa");                                      // convert the tagged scalar payload; callers suppress the null case first
             emit_write_current_string_stdout(emitter);
         }
         PhpType::Resource(_) => {

--- a/src/codegen/builtins/arrays/array_pop.rs
+++ b/src/codegen/builtins/arrays/array_pop.rs
@@ -11,6 +11,7 @@
 use super::ensure_unique_arg::emit_ensure_unique_arg;
 use super::store_mutating_arg::emit_store_mutating_arg;
 use crate::codegen::abi;
+use crate::codegen::NULL_SENTINEL;
 use crate::codegen::context::Context;
 use crate::codegen::data_section::DataSection;
 use crate::codegen::emit::Emitter;
@@ -81,7 +82,7 @@ pub fn emit(
         emitter.instruction(&format!("jmp {}", end_label));                     // skip the empty-array null sentinel path after loading the removed payload
 
         emitter.label(&empty_label);
-        abi::emit_load_int_immediate(emitter, "rax", i64::MAX - 1);            // materialize the shared null sentinel as the empty-array result on x86_64
+        abi::emit_load_int_immediate(emitter, "rax", NULL_SENTINEL);           // materialize the shared null sentinel as the empty-array result on x86_64
         emitter.label(&end_label);
 
         return Some(elem_ty);
@@ -114,10 +115,11 @@ pub fn emit(
 
     // -- empty array: return null sentinel --
     emitter.label(&empty_label);
-    emitter.instruction("movz x0, #0xFFFE");                                    // load null sentinel bits [15:0]
-    emitter.instruction("movk x0, #0xFFFF, lsl #16");                           // load null sentinel bits [31:16]
-    emitter.instruction("movk x0, #0xFFFF, lsl #32");                           // load null sentinel bits [47:32]
-    emitter.instruction("movk x0, #0x7FFF, lsl #48");                           // load null sentinel bits [63:48] = 0x7FFFFFFFFFFFFFFE
+    let sentinel = NULL_SENTINEL as u64;
+    emitter.instruction(&format!("movz x0, #0x{:X}", sentinel & 0xFFFF));       // load null sentinel bits [15:0]
+    emitter.instruction(&format!("movk x0, #0x{:X}, lsl #16", (sentinel >> 16) & 0xFFFF)); // load null sentinel bits [31:16]
+    emitter.instruction(&format!("movk x0, #0x{:X}, lsl #32", (sentinel >> 32) & 0xFFFF)); // load null sentinel bits [47:32]
+    emitter.instruction(&format!("movk x0, #0x{:X}, lsl #48", (sentinel >> 48) & 0xFFFF)); // load null sentinel bits [63:48] = 0x7FFFFFFFFFFFFFFE
 
     emitter.label(&end_label);
 

--- a/src/codegen/builtins/arrays/array_pop.rs
+++ b/src/codegen/builtins/arrays/array_pop.rs
@@ -57,6 +57,8 @@ pub fn emit(
 
     let empty_label = ctx.next_label("array_pop_empty");
     let end_label = ctx.next_label("array_pop_end");
+    let tagged_int_result =
+        crate::codegen::sentinels::null_repr_is_tagged() && matches!(elem_ty, PhpType::Int);
 
     if emitter.target.arch == Arch::X86_64 {
         emit_ensure_unique_arg(emitter, &arr_ty);
@@ -79,12 +81,22 @@ pub fn emit(
                 emitter.instruction("mov rax, QWORD PTR [r11 + r10 * 8]");      // load the removed scalar payload from the last live indexed-array slot
             }
         }
+        if tagged_int_result {
+            crate::codegen::sentinels::emit_tagged_scalar_from_int_result(emitter);
+        }
         emitter.instruction(&format!("jmp {}", end_label));                     // skip the empty-array null sentinel path after loading the removed payload
 
         emitter.label(&empty_label);
-        abi::emit_load_int_immediate(emitter, "rax", NULL_SENTINEL);           // materialize the shared null sentinel as the empty-array result on x86_64
+        if tagged_int_result {
+            crate::codegen::sentinels::emit_tagged_scalar_null(emitter);
+        } else {
+            abi::emit_load_int_immediate(emitter, "rax", NULL_SENTINEL);       // materialize the shared null sentinel as the empty-array result on x86_64
+        }
         emitter.label(&end_label);
 
+        if tagged_int_result {
+            return Some(PhpType::TaggedScalar);
+        }
         return Some(elem_ty);
     }
 
@@ -111,17 +123,27 @@ pub fn emit(
         }
         _ => {}
     }
+    if tagged_int_result {
+        crate::codegen::sentinels::emit_tagged_scalar_from_int_result(emitter);
+    }
     emitter.instruction(&format!("b {}", end_label));                           // skip empty handler
 
     // -- empty array: return null sentinel --
     emitter.label(&empty_label);
-    let sentinel = NULL_SENTINEL as u64;
-    emitter.instruction(&format!("movz x0, #0x{:X}", sentinel & 0xFFFF));       // load null sentinel bits [15:0]
-    emitter.instruction(&format!("movk x0, #0x{:X}, lsl #16", (sentinel >> 16) & 0xFFFF)); // load null sentinel bits [31:16]
-    emitter.instruction(&format!("movk x0, #0x{:X}, lsl #32", (sentinel >> 32) & 0xFFFF)); // load null sentinel bits [47:32]
-    emitter.instruction(&format!("movk x0, #0x{:X}, lsl #48", (sentinel >> 48) & 0xFFFF)); // load null sentinel bits [63:48] = 0x7FFFFFFFFFFFFFFE
+    if tagged_int_result {
+        crate::codegen::sentinels::emit_tagged_scalar_null(emitter);
+    } else {
+        let sentinel = NULL_SENTINEL as u64;
+        emitter.instruction(&format!("movz x0, #0x{:X}", sentinel & 0xFFFF));   // load null sentinel bits [15:0]
+        emitter.instruction(&format!("movk x0, #0x{:X}, lsl #16", (sentinel >> 16) & 0xFFFF)); // load null sentinel bits [31:16]
+        emitter.instruction(&format!("movk x0, #0x{:X}, lsl #32", (sentinel >> 32) & 0xFFFF)); // load null sentinel bits [47:32]
+        emitter.instruction(&format!("movk x0, #0x{:X}, lsl #48", (sentinel >> 48) & 0xFFFF)); // load null sentinel bits [63:48] = 0x7FFFFFFFFFFFFFFE
+    }
 
     emitter.label(&end_label);
 
+    if tagged_int_result {
+        return Some(PhpType::TaggedScalar);
+    }
     Some(elem_ty)
 }

--- a/src/codegen/builtins/arrays/array_shift.rs
+++ b/src/codegen/builtins/arrays/array_shift.rs
@@ -48,24 +48,56 @@ pub fn emit(
 ) -> Option<PhpType> {
     emitter.comment("array_shift()");
     let arr_ty = emit_expr(&args[0], emitter, ctx, data);
+    let elem_ty = match &arr_ty {
+        PhpType::Array(inner) => (**inner).clone(),
+        _ => PhpType::Int,
+    };
+    let tagged_int_result =
+        crate::codegen::sentinels::null_repr_is_tagged() && matches!(elem_ty, PhpType::Int);
     if emitter.target.arch == Arch::X86_64 {
         emit_ensure_unique_arg(emitter, &arr_ty);
         emit_store_mutating_arg(emitter, ctx, &args[0]);
+        if tagged_int_result {
+            // distinguish the empty-array case by length before the helper consumes the
+            // pointer, so the result can carry a real null tag instead of the sentinel
+            let empty_label = ctx.next_label("array_shift_empty");
+            let end_label = ctx.next_label("array_shift_end");
+            emitter.instruction("mov r10, QWORD PTR [rax]");                    // load the indexed-array length before deciding whether the shift is empty
+            emitter.instruction("test r10, r10");                               // check whether the indexed array currently stores any elements
+            emitter.instruction(&format!("jz {}", empty_label));                // produce a tagged null when array_shift runs on an empty indexed array
+            emitter.instruction("mov rdi, rax");                                // move the unique indexed-array pointer into the first x86_64 runtime argument register
+            abi::emit_call_label(emitter, "__rt_array_shift");                  // remove and return the first scalar indexed-array element through the x86_64 runtime helper
+            crate::codegen::sentinels::emit_tagged_scalar_from_int_result(emitter);
+            emitter.instruction(&format!("jmp {}", end_label));                 // skip the empty-array tagged-null path after the successful shift
+            emitter.label(&empty_label);
+            crate::codegen::sentinels::emit_tagged_scalar_null(emitter);
+            emitter.label(&end_label);
+            return Some(PhpType::TaggedScalar);
+        }
         emitter.instruction("mov rdi, rax");                                    // move the unique indexed-array pointer into the first x86_64 runtime argument register
         abi::emit_call_label(emitter, "__rt_array_shift");                      // remove and return the first scalar indexed-array element through the x86_64 runtime helper
-        return match arr_ty {
-            PhpType::Array(inner) => Some(*inner),
-            _ => Some(PhpType::Int),
-        };
+        return Some(elem_ty);
     }
 
     emit_ensure_unique_arg(emitter, &arr_ty);
     emit_store_mutating_arg(emitter, ctx, &args[0]);
-    // -- call runtime to remove and return first element --
-    emitter.instruction("bl __rt_array_shift");                                 // call runtime: shift first element → x0=removed element
-
-    match arr_ty {
-        PhpType::Array(inner) => Some(*inner),
-        _ => Some(PhpType::Int),
+    if tagged_int_result {
+        // distinguish the empty-array case by length before the helper consumes the
+        // pointer, so the result can carry a real null tag instead of the sentinel
+        let empty_label = ctx.next_label("array_shift_empty");
+        let end_label = ctx.next_label("array_shift_end");
+        emitter.instruction("ldr x9, [x0]");                                    // load the indexed-array length before deciding whether the shift is empty
+        emitter.instruction(&format!("cbz x9, {}", empty_label));               // produce a tagged null when array_shift runs on an empty indexed array
+        emitter.instruction("bl __rt_array_shift");                             // call runtime: shift first element -> x0=removed element
+        crate::codegen::sentinels::emit_tagged_scalar_from_int_result(emitter);
+        emitter.instruction(&format!("b {}", end_label));                       // skip the empty-array tagged-null path after the successful shift
+        emitter.label(&empty_label);
+        crate::codegen::sentinels::emit_tagged_scalar_null(emitter);
+        emitter.label(&end_label);
+        return Some(PhpType::TaggedScalar);
     }
+    // -- call runtime to remove and return first element --
+    emitter.instruction("bl __rt_array_shift");                                 // call runtime: shift first element -> x0=removed element
+
+    Some(elem_ty)
 }

--- a/src/codegen/builtins/arrays/call_user_func_array.rs
+++ b/src/codegen/builtins/arrays/call_user_func_array.rs
@@ -1202,6 +1202,9 @@ pub(crate) fn emit_loaded_array_callback_call(
             }
         }
         match stored_ty {
+            PhpType::TaggedScalar => {
+                unreachable!("TaggedScalar must be narrowed or boxed before variadic array storage")
+            }
             PhpType::Int
             | PhpType::Bool
             | PhpType::Resource(_)

--- a/src/codegen/builtins/arrays/hash_value_type_tag.rs
+++ b/src/codegen/builtins/arrays/hash_value_type_tag.rs
@@ -36,5 +36,8 @@ pub(super) fn hash_value_type_tag(ty: &PhpType) -> u8 {
         PhpType::Void => 8,
         PhpType::Resource(_) => 9,
         PhpType::Callable | PhpType::Pointer(_) | PhpType::Buffer(_) | PhpType::Packed(_) | PhpType::Never => 0,
+        PhpType::TaggedScalar => {
+            unreachable!("TaggedScalar must be narrowed or boxed before hash storage")
+        }
     }
 }

--- a/src/codegen/builtins/arrays/isset.rs
+++ b/src/codegen/builtins/arrays/isset.rs
@@ -13,6 +13,7 @@ use crate::codegen::data_section::DataSection;
 use crate::codegen::emit::Emitter;
 use crate::codegen::expr::emit_expr;
 use crate::codegen::{abi, platform::Arch};
+use crate::codegen::NULL_SENTINEL;
 use crate::parser::ast::{Expr, ExprKind};
 use crate::types::PhpType;
 
@@ -20,7 +21,6 @@ use crate::types::PhpType;
 ///
 /// This value is distinct from all valid PHP scalar values (integers, booleans, floats)
 /// and is used by the runtime to distinguish a loaded null from false, zero, or empty.
-const NULL_SENTINEL: i64 = 0x7fff_ffff_ffff_fffe;
 
 /// Emits PHP `isset(...)` for one or more arguments.
 ///

--- a/src/codegen/builtins/arrays/isset.rs
+++ b/src/codegen/builtins/arrays/isset.rs
@@ -124,6 +124,10 @@ fn emit_loaded_result_isset(ty: &PhpType, emitter: &mut Emitter) {
     match ty.codegen_repr() {
         PhpType::Void | PhpType::Never => emit_bool_result(false, emitter),
         PhpType::Mixed => emit_mixed_result_not_null(emitter),
+        PhpType::TaggedScalar => emit_tagged_scalar_result_not_null(emitter),
+        PhpType::Int | PhpType::Bool if crate::codegen::sentinels::null_repr_is_tagged() => {
+            emit_bool_result(true, emitter)
+        }
         PhpType::Int | PhpType::Bool => emit_scalar_result_not_null(emitter),
         _ => emit_bool_result(true, emitter),
     }
@@ -303,6 +307,22 @@ fn emit_mixed_result_not_null(emitter: &mut Emitter) {
             emitter.instruction("cmp rax, 8");                                  // runtime tag 8 means the Mixed payload is PHP null
             emitter.instruction("setne al");                                    // set the low result byte when the Mixed payload is not null
             emitter.instruction("movzx rax, al");                               // widen the Mixed null-check result into the integer result register
+        }
+    }
+}
+
+/// Emits the result of an `isset` check on a tagged scalar runtime value: true unless
+/// the runtime tag word marks the value as PHP null.
+fn emit_tagged_scalar_result_not_null(emitter: &mut Emitter) {
+    match emitter.target.arch {
+        Arch::AArch64 => {
+            emitter.instruction("cmp x1, #8");                                  // runtime tag 8 means the tagged scalar is PHP null
+            emitter.instruction("cset x0, ne");                                 // return true only when the tagged scalar is not null
+        }
+        Arch::X86_64 => {
+            emitter.instruction("cmp rdx, 8");                                  // runtime tag 8 means the tagged scalar is PHP null
+            emitter.instruction("setne al");                                    // set the low result byte when the tagged scalar is not null
+            emitter.instruction("movzx rax, al");                               // widen the tagged null-check result into the integer result register
         }
     }
 }

--- a/src/codegen/builtins/io/stream_get_contents.rs
+++ b/src/codegen/builtins/io/stream_get_contents.rs
@@ -29,12 +29,12 @@ use crate::codegen::driver_support::emit_box_current_value_as_mixed;
 use crate::codegen::emit::Emitter;
 use crate::codegen::expr::emit_expr;
 use crate::codegen::{abi, platform::Arch};
+use crate::codegen::NULL_SENTINEL;
 use crate::parser::ast::{Expr, ExprKind};
 use crate::types::PhpType;
 
 use super::stream_arg::emit_stream_fd_arg;
 
-const NULL_SENTINEL: i64 = 0x7fff_ffff_ffff_fffe;
 
 /// Returns true when a `$length`/`$offset` argument is a compile-time literal
 /// meaning "read to EOF" / "do not seek" — i.e. `null` or a negative integer

--- a/src/codegen/builtins/io/var_dump.rs
+++ b/src/codegen/builtins/io/var_dump.rs
@@ -124,6 +124,12 @@ fn emit_write_current_string(emitter: &mut Emitter) {
 /// * `ctx` - Codegen context (used for label allocation)
 /// * `data` - Data section for literal strings
 fn emit_var_dump_int(emitter: &mut Emitter, ctx: &mut Context, data: &mut DataSection) {
+    if crate::codegen::sentinels::null_repr_is_tagged() {
+        // Under the tagged representation a plain Int is never null; print the payload
+        // directly so the full i64 range (including PHP_INT_MAX - 1) round-trips.
+        emit_var_dump_int_payload(emitter, data);
+        return;
+    }
     let not_null = ctx.next_label("vd_not_null");
     let done = ctx.next_label("vd_done");
     let result_reg = abi::int_result_reg(emitter);
@@ -134,12 +140,34 @@ fn emit_var_dump_int(emitter: &mut Emitter, ctx: &mut Context, data: &mut DataSe
     emit_write_literal(emitter, data, b"NULL\n");
     abi::emit_jump(emitter, &done);                                             // skip the int formatter after printing NULL
     emitter.label(&not_null);
+    emit_var_dump_int_payload(emitter, data);
+    emitter.label(&done);
+}
+
+/// Emits `int(N)\n` for the integer payload in the result register without any null check.
+/// Used directly for values that are statically known to be real ints (tagged scalar
+/// non-null branch), and by `emit_var_dump_int` after its sentinel test.
+fn emit_var_dump_int_payload(emitter: &mut Emitter, data: &mut DataSection) {
+    let result_reg = abi::int_result_reg(emitter);
     abi::emit_push_reg(emitter, result_reg);                                    // preserve the integer payload before prefix writes clobber the integer result register
     emit_write_literal(emitter, data, b"int(");
     abi::emit_pop_reg(emitter, result_reg);                                     // restore the integer payload after the prefix write
     abi::emit_call_label(emitter, "__rt_itoa");                                 // convert the integer payload to decimal text through the target-aware runtime helper
     emit_write_current_string(emitter);                                         // write the converted decimal text to stdout
     emit_write_literal(emitter, data, b")\n");
+}
+
+/// Emits var_dump output for a tagged scalar: `NULL\n` when the runtime tag is null,
+/// otherwise `int(N)\n` for the payload with no in-band sentinel check (the full i64
+/// range is printable).
+fn emit_var_dump_tagged_scalar(emitter: &mut Emitter, ctx: &mut Context, data: &mut DataSection) {
+    let null_case = ctx.next_label("vd_tagged_null");
+    let done = ctx.next_label("vd_tagged_done");
+    crate::codegen::sentinels::emit_branch_if_tagged_scalar_null(emitter, &null_case);
+    emit_var_dump_int_payload(emitter, data);
+    abi::emit_jump(emitter, &done);                                             // skip the NULL literal after printing the tagged scalar payload
+    emitter.label(&null_case);
+    emit_var_dump_null(emitter, data);
     emitter.label(&done);
 }
 
@@ -438,6 +466,7 @@ pub fn emit(
     let ty = emit_expr(&args[0], emitter, ctx, data);
     match &ty {
         PhpType::Int => emit_var_dump_int(emitter, ctx, data),
+        PhpType::TaggedScalar => emit_var_dump_tagged_scalar(emitter, ctx, data),
         PhpType::Float => emit_var_dump_float(emitter, data),
         PhpType::Str => emit_var_dump_string(emitter, data),
         PhpType::Bool => emit_var_dump_bool(emitter, ctx, data),

--- a/src/codegen/builtins/io/var_dump.rs
+++ b/src/codegen/builtins/io/var_dump.rs
@@ -9,6 +9,7 @@
 //! - Output is a side effect, and refcounted values must be inspected without consuming ownership.
 
 use crate::codegen::context::Context;
+use crate::codegen::NULL_SENTINEL;
 use crate::codegen::data_section::DataSection;
 use crate::codegen::emit::Emitter;
 use crate::codegen::expr::emit_expr;
@@ -127,7 +128,7 @@ fn emit_var_dump_int(emitter: &mut Emitter, ctx: &mut Context, data: &mut DataSe
     let done = ctx.next_label("vd_done");
     let result_reg = abi::int_result_reg(emitter);
     let scratch_reg = abi::symbol_scratch_reg(emitter);
-    abi::emit_load_int_immediate(emitter, scratch_reg, 0x7fff_ffff_ffff_fffe_u64 as i64); // materialize the shared null sentinel used by int-valued locals
+    abi::emit_load_int_immediate(emitter, scratch_reg, NULL_SENTINEL); // materialize the shared null sentinel used by int-valued locals
     emitter.instruction(&format!("cmp {}, {}", result_reg, scratch_reg));       // compare the incoming integer payload against the null sentinel
     emit_branch_if_ne(emitter, &not_null);                                      // branch to the ordinary int path when the payload is not null
     emit_write_literal(emitter, data, b"NULL\n");

--- a/src/codegen/builtins/math/abs.rs
+++ b/src/codegen/builtins/math/abs.rs
@@ -42,6 +42,10 @@ pub fn emit(
 ) -> Option<PhpType> {
     emitter.comment("abs()");
     let ty = emit_expr(&args[0], emitter, ctx, data);
+    if matches!(ty, PhpType::TaggedScalar) {
+        // narrow a tagged scalar (null -> 0) before the integer absolute-value sequence
+        crate::codegen::sentinels::emit_tagged_scalar_to_int_null_as_zero(emitter);
+    }
     if matches!(ty, PhpType::Mixed | PhpType::Union(_)) {
         // The operand is a boxed Mixed cell pointer, not a raw scalar; the runtime helper
         // unboxes it, applies the integer or float absolute value per the stored tag, and

--- a/src/codegen/builtins/types/empty.rs
+++ b/src/codegen/builtins/types/empty.rs
@@ -43,8 +43,8 @@ pub fn emit(
     emitter.comment("empty()");
     let ty = emit_expr(&args[0], emitter, ctx, data);
     match &ty {
-        PhpType::Int => {
-            // -- int is empty if it equals zero --
+        PhpType::Int | PhpType::TaggedScalar => {
+            // -- int is empty if it equals zero; a null tagged scalar narrows to zero --
             crate::codegen::expr::coerce_null_to_zero(emitter, &ty);
             match emitter.target.arch {
                 Arch::AArch64 => {

--- a/src/codegen/builtins/types/gettype.rs
+++ b/src/codegen/builtins/types/gettype.rs
@@ -305,6 +305,18 @@ pub fn emit(
         return Some(PhpType::Str);
     }
 
+    if matches!(&ty, PhpType::TaggedScalar) {
+        let null_case = ctx.next_label("gettype_tagged_null");
+        let done = ctx.next_label("gettype_tagged_done");
+        crate::codegen::sentinels::emit_branch_if_tagged_scalar_null(emitter, &null_case);
+        emit_type_name_result(emitter, data, b"integer");
+        abi::emit_jump(emitter, &done);                                         // skip the NULL literal after selecting the integer type name
+        emitter.label(&null_case);
+        emit_type_name_result(emitter, data, b"NULL");
+        emitter.label(&done);
+        return Some(PhpType::Str);
+    }
+
     let type_str = match &ty {
         PhpType::Int => b"integer".as_slice(),
         PhpType::Float => b"double".as_slice(),
@@ -320,6 +332,7 @@ pub fn emit(
         PhpType::Resource(_) => b"resource".as_slice(),
         PhpType::Iterable => unreachable!("iterable handled above via runtime heap-kind dispatch"),
         PhpType::Mixed | PhpType::Union(_) => unreachable!("mixed handled above"),
+        PhpType::TaggedScalar => unreachable!("tagged scalar handled above via runtime tag dispatch"),
     };
     emit_type_name_result(emitter, data, type_str)
 }

--- a/src/codegen/builtins/types/is_null.rs
+++ b/src/codegen/builtins/types/is_null.rs
@@ -58,6 +58,22 @@ pub fn emit(
                 emitter.instruction("movzx rax, al");                           // widen the boolean byte into the integer result register
             }
         }
+    } else if matches!(ty, PhpType::TaggedScalar) {
+        // Tagged scalars carry a runtime tag word — null means tag 8
+        match emitter.target.arch {
+            Arch::AArch64 => {
+                emitter.instruction("cmp x1, #8");                              // runtime tag 8 means the tagged scalar is PHP null
+                emitter.instruction("cset x0, eq");                             // x0 = 1 if the tagged scalar is null, 0 otherwise
+            }
+            Arch::X86_64 => {
+                emitter.instruction("cmp rdx, 8");                              // runtime tag 8 means the tagged scalar is PHP null
+                emitter.instruction("sete al");                                 // set al when the tagged scalar is null
+                emitter.instruction("movzx rax, al");                           // widen the boolean byte into the integer result register
+            }
+        }
+    } else if matches!(ty, PhpType::Int) && crate::codegen::sentinels::null_repr_is_tagged() {
+        // Under the tagged representation a plain Int can never hold null
+        abi::emit_load_int_immediate(emitter, abi::int_result_reg(emitter), 0);
     } else {
         // Scalar types — check directly against the null sentinel
         match emitter.target.arch {

--- a/src/codegen/builtins/types/is_null.rs
+++ b/src/codegen/builtins/types/is_null.rs
@@ -9,6 +9,7 @@
 //! - Predicate behavior must match PHP sentinel, Mixed tag, and object/interface layout conventions.
 
 use crate::codegen::context::Context;
+use crate::codegen::NULL_SENTINEL;
 use crate::codegen::data_section::DataSection;
 use crate::codegen::emit::Emitter;
 use crate::codegen::expr::emit_expr;
@@ -61,15 +62,16 @@ pub fn emit(
         // Scalar types — check directly against the null sentinel
         match emitter.target.arch {
             Arch::AArch64 => {
-                emitter.instruction("movz x9, #0xFFFE");                        // load null sentinel bits [15:0]
-                emitter.instruction("movk x9, #0xFFFF, lsl #16");               // load null sentinel bits [31:16]
-                emitter.instruction("movk x9, #0xFFFF, lsl #32");               // load null sentinel bits [47:32]
-                emitter.instruction("movk x9, #0x7FFF, lsl #48");               // load null sentinel bits [63:48]
+                let sentinel = NULL_SENTINEL as u64;
+                emitter.instruction(&format!("movz x9, #0x{:X}", sentinel & 0xFFFF)); // load null sentinel bits [15:0]
+                emitter.instruction(&format!("movk x9, #0x{:X}, lsl #16", (sentinel >> 16) & 0xFFFF)); // load null sentinel bits [31:16]
+                emitter.instruction(&format!("movk x9, #0x{:X}, lsl #32", (sentinel >> 32) & 0xFFFF)); // load null sentinel bits [47:32]
+                emitter.instruction(&format!("movk x9, #0x{:X}, lsl #48", (sentinel >> 48) & 0xFFFF)); // load null sentinel bits [63:48]
                 emitter.instruction("cmp x0, x9");                              // compare value against null sentinel
                 emitter.instruction("cset x0, eq");                             // x0 = 1 if value is null, 0 otherwise
             }
             Arch::X86_64 => {
-                abi::emit_load_int_immediate(emitter, "r10", 0x7FFF_FFFF_FFFF_FFFEu64 as i64);
+                abi::emit_load_int_immediate(emitter, "r10", NULL_SENTINEL);
                 emitter.instruction("cmp rax, r10");                            // compare value against the runtime null sentinel
                 emitter.instruction("sete al");                                 // set al when the value is null
                 emitter.instruction("movzx rax, al");                           // widen the boolean byte into the integer result register

--- a/src/codegen/builtins/types/unset.rs
+++ b/src/codegen/builtins/types/unset.rs
@@ -9,6 +9,7 @@
 //! - Unset is mutating and must release owned refcounted values without touching unrelated aliases.
 
 use crate::codegen::abi;
+use crate::codegen::NULL_SENTINEL;
 use crate::codegen::context::{Context, HeapOwnership};
 use crate::codegen::data_section::DataSection;
 use crate::codegen::emit::Emitter;
@@ -99,7 +100,7 @@ fn emit_unset_arg(
         }
 
         // -- set variable to null sentinel value (0x7FFFFFFFFFFFFFFFE) --
-        abi::emit_load_int_immediate(emitter, abi::int_result_reg(emitter), i64::MAX - 1); // materialize the shared null sentinel in the target integer result register
+        abi::emit_load_int_immediate(emitter, abi::int_result_reg(emitter), NULL_SENTINEL); // materialize the shared null sentinel in the target integer result register
         abi::store_at_offset(emitter, abi::int_result_reg(emitter), offset);     // store the null sentinel back into the variable slot
         ctx.update_var_type_and_ownership(name, PhpType::Void, HeapOwnership::NonHeap);
     }

--- a/src/codegen/callable_descriptor.rs
+++ b/src/codegen/callable_descriptor.rs
@@ -599,6 +599,9 @@ fn type_tag(ty: &PhpType) -> u64 {
         PhpType::Buffer(_) => 13,
         PhpType::Packed(_) => 14,
         PhpType::Never => 15,
+        PhpType::TaggedScalar => {
+            unreachable!("callable signatures use the boxed Mixed representation for nullable scalars")
+        }
     }
 }
 

--- a/src/codegen/driver_support.rs
+++ b/src/codegen/driver_support.rs
@@ -371,6 +371,9 @@ pub(crate) fn runtime_value_tag(ty: &PhpType) -> u8 {
         PhpType::Void => 8,
         PhpType::Resource(_) => 9,
         PhpType::Callable | PhpType::Pointer(_) | PhpType::Buffer(_) | PhpType::Packed(_) | PhpType::Never => 0,
+        PhpType::TaggedScalar => {
+            unreachable!("TaggedScalar carries its runtime tag in the tag register, not a static tag")
+        }
     }
 }
 
@@ -405,6 +408,21 @@ pub(crate) fn emit_box_current_value_as_mixed(emitter: &mut Emitter, ty: &PhpTyp
     match ty {
         PhpType::Mixed | PhpType::Union(_) => {}
         PhpType::Iterable => emit_box_iterable_as_mixed(emitter),
+        PhpType::TaggedScalar => match emitter.target.arch {
+            Arch::AArch64 => {
+                emitter.instruction("mov x9, x0");                              // stage the tagged scalar payload while the tag moves into the helper tag register
+                emitter.instruction("mov x0, x1");                              // pass the dynamic runtime tag as the mixed boxing helper tag argument
+                emitter.instruction("mov x1, x9");                              // pass the tagged scalar payload as the mixed boxing helper low word
+                emitter.instruction("mov x2, xzr");                             // tagged scalar payloads do not use a second word
+                emitter.instruction("bl __rt_mixed_from_value");                // box the tagged scalar payload into a mixed cell
+            }
+            Arch::X86_64 => {
+                emitter.instruction("mov rdi, rax");                            // pass the tagged scalar payload as the mixed boxing helper low word
+                emitter.instruction("mov rax, rdx");                            // pass the dynamic runtime tag as the mixed boxing helper tag argument
+                emitter.instruction("xor rsi, rsi");                            // tagged scalar payloads do not use a second word
+                emitter.instruction("call __rt_mixed_from_value");              // box the tagged scalar payload into a mixed cell
+            }
+        },
         PhpType::Int | PhpType::Bool | PhpType::Void | PhpType::Never | PhpType::Resource(_) => match emitter.target.arch {
             Arch::AArch64 => {
                 emitter.instruction("mov x1, x0");                              // move the current scalar payload into the mixed helper argument register

--- a/src/codegen/driver_support.rs
+++ b/src/codegen/driver_support.rs
@@ -20,11 +20,9 @@ use super::functions;
 use super::platform::{Arch, Target};
 use super::runtime;
 use super::runtime_features::RuntimeFeatures;
+use super::sentinels::UNINITIALIZED_TYPED_PROPERTY_SENTINEL;
 
 const X86_64_HEAP_MAGIC_HI32: u64 = 0x454C5048;
-/// Sentinel value written to typed static properties that have no initializer expression,
-/// signaling that the property has never been accessed at runtime.
-pub(crate) const UNINITIALIZED_TYPED_PROPERTY_SENTINEL: i64 = 0x7fff_ffff_ffff_fffd;
 
 /// Emits a write syscall for a labeled literal string to stderr, using the given
 /// label (from the data section) and its byte length. Handles target-specific

--- a/src/codegen/expr/arrays/access/indexed.rs
+++ b/src/codegen/expr/arrays/access/indexed.rs
@@ -9,6 +9,7 @@
 //! - Element layout and boxed Mixed handling must stay aligned with array runtime helpers.
 
 use crate::codegen::abi;
+use crate::codegen::NULL_SENTINEL;
 use crate::codegen::context::Context;
 use crate::codegen::data_section::DataSection;
 use crate::codegen::emit::Emitter;
@@ -249,7 +250,7 @@ pub(crate) fn emit_array_access_with_loaded_base(
                     if boxed_assoc_fallback {
                         objects_boxed_null_for_array_access(emitter);
                     } else {
-                        abi::emit_load_int_immediate(emitter, abi::int_result_reg(emitter), i64::MAX - 1);
+                        abi::emit_load_int_immediate(emitter, abi::int_result_reg(emitter), NULL_SENTINEL);
                     }
                     emitter.instruction(&format!("b {}", done));                // skip hash lookup when the boxed value is false/null
                     emitter.label(&hash_payload);
@@ -266,7 +267,7 @@ pub(crate) fn emit_array_access_with_loaded_base(
                     if boxed_assoc_fallback {
                         objects_boxed_null_for_array_access(emitter);
                     } else {
-                        abi::emit_load_int_immediate(emitter, abi::int_result_reg(emitter), i64::MAX - 1);
+                        abi::emit_load_int_immediate(emitter, abi::int_result_reg(emitter), NULL_SENTINEL);
                     }
                     emitter.instruction(&format!("jmp {}", done));              // skip hash lookup when the boxed value is false/null
                     emitter.label(&hash_payload);
@@ -559,7 +560,7 @@ fn emit_typed_null_fallback(emitter: &mut Emitter, ty: &PhpType) {
         _ => abi::emit_load_int_immediate(
             emitter,
             abi::int_result_reg(emitter),
-            0x7fff_ffff_ffff_fffe,
+            NULL_SENTINEL,
         ), // integer/bool/resource/callable null sentinel
     }
 }
@@ -569,7 +570,7 @@ fn objects_boxed_null_for_array_access(emitter: &mut Emitter) {
     abi::emit_load_int_immediate(
         emitter,
         abi::int_result_reg(emitter),
-        0x7fff_ffff_ffff_fffe,
+        NULL_SENTINEL,
     );
     crate::codegen::emit_box_current_value_as_mixed(emitter, &PhpType::Void);
 }

--- a/src/codegen/expr/arrays/access/indexed.rs
+++ b/src/codegen/expr/arrays/access/indexed.rs
@@ -249,6 +249,10 @@ pub(crate) fn emit_array_access_with_loaded_base(
                     abi::emit_release_temporary_stack(emitter, 32);             // discard the saved key and boxed base before returning the null-like fallback
                     if boxed_assoc_fallback {
                         objects_boxed_null_for_array_access(emitter);
+                    } else if crate::codegen::sentinels::null_repr_is_tagged()
+                        && matches!(val_ty, PhpType::Int)
+                    {
+                        crate::codegen::sentinels::emit_tagged_scalar_null(emitter);
                     } else {
                         abi::emit_load_int_immediate(emitter, abi::int_result_reg(emitter), NULL_SENTINEL);
                     }
@@ -266,6 +270,10 @@ pub(crate) fn emit_array_access_with_loaded_base(
                     abi::emit_release_temporary_stack(emitter, 32);             // discard the saved key and boxed base before returning the null-like fallback
                     if boxed_assoc_fallback {
                         objects_boxed_null_for_array_access(emitter);
+                    } else if crate::codegen::sentinels::null_repr_is_tagged()
+                        && matches!(val_ty, PhpType::Int)
+                    {
+                        crate::codegen::sentinels::emit_tagged_scalar_null(emitter);
                     } else {
                         abi::emit_load_int_immediate(emitter, abi::int_result_reg(emitter), NULL_SENTINEL);
                     }
@@ -293,6 +301,9 @@ pub(crate) fn emit_array_access_with_loaded_base(
                 }
             }
         }
+        let tagged_int_result = crate::codegen::sentinels::null_repr_is_tagged()
+            && matches!(val_ty, PhpType::Int)
+            && !box_assoc_result;
         emitter.comment("assoc array access");
         abi::emit_call_label(emitter, "__rt_hash_get");                            // lookup key and return found-flag plus borrowed payload words through the target runtime ABI
 
@@ -355,15 +366,23 @@ pub(crate) fn emit_array_access_with_loaded_base(
         if box_assoc_result {
             crate::codegen::emit_box_current_value_as_mixed(emitter, &val_ty);
         }
+        if tagged_int_result {
+            crate::codegen::sentinels::emit_tagged_scalar_from_int_result(emitter);
+        }
         abi::emit_jump(emitter, &done);                                           // skip the not-found fallback after materializing the successful lookup result
 
         emitter.label(&not_found);
         if boxed_assoc_fallback {
             objects_boxed_null_for_array_access(emitter);
+        } else if tagged_int_result {
+            crate::codegen::sentinels::emit_tagged_scalar_null(emitter);
         } else {
             emit_typed_null_fallback(emitter, &val_ty); // type-aware null: empty Str / 0.0 Float / int sentinel (no stale ptr/len/fp regs)
         }
         emitter.label(&done);
+        if tagged_int_result {
+            return PhpType::TaggedScalar;
+        }
         return if box_assoc_result { PhpType::Mixed } else { val_ty };
     }
 
@@ -376,6 +395,9 @@ pub(crate) fn emit_array_access_with_loaded_base(
     abi::emit_pop_reg(emitter, array_reg);                                      // restore the array pointer into a scratch register
     emitter.comment("array access");
     let (elem_ty, boxed_indexed_base) = indexed_array_element_type(arr_ty, box_nullable_base);
+    let tagged_int_result = crate::codegen::sentinels::null_repr_is_tagged()
+        && matches!(elem_ty, PhpType::Int)
+        && !boxed_indexed_base;
 
     let null_label = ctx.next_label("arr_null");
     let ok_label = ctx.next_label("arr_ok");
@@ -485,6 +507,9 @@ pub(crate) fn emit_array_access_with_loaded_base(
     if boxed_indexed_base {
         crate::codegen::emit_box_current_value_as_mixed(emitter, &elem_ty);
     }
+    if tagged_int_result {
+        crate::codegen::sentinels::emit_tagged_scalar_from_int_result(emitter);
+    }
     match emitter.target.arch {
         Arch::AArch64 => emitter.instruction(&format!("b {ok_label}")),         // skip null sentinel fallback
         Arch::X86_64 => emitter.instruction(&format!("jmp {ok_label}")),        // skip null sentinel fallback
@@ -494,11 +519,16 @@ pub(crate) fn emit_array_access_with_loaded_base(
     emit_undefined_index_warning(emitter);
     if boxed_indexed_base || matches!(elem_ty, PhpType::Mixed | PhpType::Union(_)) {
         objects_boxed_null_for_array_access(emitter);
+    } else if tagged_int_result {
+        crate::codegen::sentinels::emit_tagged_scalar_null(emitter);
     } else {
         emit_typed_null_fallback(emitter, &elem_ty); // type-aware null: empty Str / 0.0 Float / int sentinel (no stale ptr/len/fp regs)
     }
     emitter.label(&ok_label);
 
+    if tagged_int_result {
+        return PhpType::TaggedScalar;
+    }
     if boxed_indexed_base { PhpType::Mixed } else { elem_ty }
 }
 

--- a/src/codegen/expr/arrays/indexed.rs
+++ b/src/codegen/expr/arrays/indexed.rs
@@ -25,7 +25,7 @@ pub(crate) fn emit_array_literal(
     data: &mut DataSection,
 ) -> PhpType {
     let literal_elem_ty = infer_indexed_literal_element_type(elems, ctx);
-    if matches!(literal_elem_ty, PhpType::Mixed)
+    if matches!(literal_elem_ty, PhpType::Mixed | PhpType::TaggedScalar)
         && !elems.iter().any(|e| matches!(e.kind, ExprKind::Spread(_)))
     {
         return emit_mixed_array_literal(elems, emitter, ctx, data);
@@ -544,8 +544,8 @@ fn merge_indexed_literal_element_type(
     if matches!(next, PhpType::Never) {
         return existing.clone();
     }
-    if matches!(existing, PhpType::Mixed | PhpType::Union(_))
-        || matches!(next, PhpType::Mixed | PhpType::Union(_))
+    if matches!(existing, PhpType::Mixed | PhpType::Union(_) | PhpType::TaggedScalar)
+        || matches!(next, PhpType::Mixed | PhpType::Union(_) | PhpType::TaggedScalar)
     {
         return PhpType::Mixed;
     }

--- a/src/codegen/expr/binops/arithmetic.rs
+++ b/src/codegen/expr/binops/arithmetic.rs
@@ -142,6 +142,10 @@ pub(super) fn emit_numeric_binop(
     let left_stack_ty = if dynamic_candidate && left_ty == PhpType::Void {
         coerce_null_to_zero(emitter, &left_ty);
         PhpType::Int
+    } else if left_ty == PhpType::TaggedScalar {
+        // narrow a tagged scalar (null -> 0) before the operand is spilled as one word
+        coerce_null_to_zero(emitter, &left_ty);
+        PhpType::Int
     } else if dynamic_candidate {
         left_ty.clone()
     } else {

--- a/src/codegen/expr/calls/args/common.rs
+++ b/src/codegen/expr/calls/args/common.rs
@@ -228,6 +228,12 @@ fn store_pushed_value_to_ref_cell(emitter: &mut Emitter, cell_reg: &str, val_ty:
             abi::emit_load_int_immediate(emitter, temp_reg, 9);
             abi::emit_store_to_address(emitter, temp_reg, cell_reg, 8);
         }
+        PhpType::TaggedScalar => {
+            let tag_temp_reg = abi::tertiary_scratch_reg(emitter);
+            abi::emit_pop_reg_pair(emitter, temp_reg, tag_temp_reg);
+            abi::emit_store_to_address(emitter, temp_reg, cell_reg, 0);
+            abi::emit_store_to_address(emitter, tag_temp_reg, cell_reg, 8);
+        }
         PhpType::Mixed | PhpType::Union(_) | PhpType::Iterable => {
             abi::emit_pop_reg(emitter, temp_reg);
             abi::emit_store_to_address(emitter, temp_reg, cell_reg, 0);

--- a/src/codegen/expr/coerce.rs
+++ b/src/codegen/expr/coerce.rs
@@ -9,6 +9,7 @@
 //! - Coercions may allocate, retain, or box values, so ownership state must be updated with the result.
 
 use crate::codegen::context::Context;
+use crate::codegen::NULL_SENTINEL;
 use crate::codegen::data_section::DataSection;
 use crate::codegen::emit::Emitter;
 use crate::codegen::{abi, platform::Arch};
@@ -235,17 +236,18 @@ pub fn coerce_null_to_zero(emitter: &mut Emitter, ty: &PhpType) {
     } else if *ty == PhpType::Int {
         match emitter.target.arch {
             Arch::AArch64 => {
-                emitter.instruction("movz x9, #0xFFFE");                        // build null sentinel in x9: bits 0-15
-                emitter.instruction("movk x9, #0xFFFF, lsl #16");               // null sentinel bits 16-31
-                emitter.instruction("movk x9, #0xFFFF, lsl #32");               // null sentinel bits 32-47
-                emitter.instruction("movk x9, #0x7FFF, lsl #48");               // null sentinel bits 48-63, completing value
+                let sentinel = NULL_SENTINEL as u64;
+                emitter.instruction(&format!("movz x9, #0x{:X}", sentinel & 0xFFFF)); // build null sentinel in x9: bits 0-15
+                emitter.instruction(&format!("movk x9, #0x{:X}, lsl #16", (sentinel >> 16) & 0xFFFF)); // null sentinel bits 16-31
+                emitter.instruction(&format!("movk x9, #0x{:X}, lsl #32", (sentinel >> 32) & 0xFFFF)); // null sentinel bits 32-47
+                emitter.instruction(&format!("movk x9, #0x{:X}, lsl #48", (sentinel >> 48) & 0xFFFF)); // null sentinel bits 48-63, completing value
                 emitter.instruction("cmp x0, x9");                              // compare value against null sentinel
                 emitter.instruction("csel x0, xzr, x0, eq");                    // if x0 == sentinel, replace with zero
             }
             Arch::X86_64 => {
                 let sentinel_reg = abi::temp_int_reg(emitter.target);
                 let zero_reg = abi::symbol_scratch_reg(emitter);
-                emitter.instruction(&format!("mov {}, 9223372036854775806", sentinel_reg)); // materialize the runtime null sentinel in a scratch register
+                emitter.instruction(&format!("mov {}, {}", sentinel_reg, NULL_SENTINEL)); // materialize the runtime null sentinel in a scratch register
                 emitter.instruction(&format!("xor {}, {}", zero_reg, zero_reg)); // materialize an integer zero in a second scratch register
                 emitter.instruction(&format!("cmp {}, {}", abi::int_result_reg(emitter), sentinel_reg)); // compare the current integer result against the runtime null sentinel
                 emitter.instruction(&format!("cmove {}, {}", abi::int_result_reg(emitter), zero_reg)); // replace the sentinel with zero while leaving ordinary integers unchanged

--- a/src/codegen/expr/coerce.rs
+++ b/src/codegen/expr/coerce.rs
@@ -112,6 +112,24 @@ fn coerce_to_string_inner(
                 }
             }
         }
+        PhpType::TaggedScalar => {
+            // -- tagged scalar: null -> empty string, int payload -> decimal text --
+            let null_label = ctx.next_label("tagged_to_str_null");
+            let done_label = ctx.next_label("tagged_to_str_done");
+            crate::codegen::sentinels::emit_branch_if_tagged_scalar_null(emitter, &null_label);
+            abi::emit_call_label(emitter, "__rt_itoa");                         // convert the non-null tagged scalar payload to decimal text
+            abi::emit_jump(emitter, &done_label);                               // skip the empty-string fallback after conversion
+            emitter.label(&null_label);
+            match emitter.target.arch {
+                Arch::AArch64 => {
+                    emitter.instruction("mov x2, #0");                          // null produces empty string (length = 0)
+                }
+                Arch::X86_64 => {
+                    emitter.instruction("mov rdx, 0");                          // null produces empty string (length = 0)
+                }
+            }
+            emitter.label(&done_label);
+        }
         PhpType::Mixed | PhpType::Union(_) => {
             // -- mixed strings dispatch on the boxed payload at runtime --
             abi::emit_call_label(emitter, "__rt_mixed_cast_string");            // cast the boxed mixed payload to string in the ABI string result registers
@@ -233,6 +251,10 @@ pub fn coerce_null_to_zero(emitter: &mut Emitter, ty: &PhpType) {
         // Bool is already 0/1 in x0, compatible with Int arithmetic
     } else if *ty == PhpType::Float {
         // Float is already in d0, no null sentinel to check
+    } else if *ty == PhpType::TaggedScalar {
+        crate::codegen::sentinels::emit_tagged_scalar_to_int_null_as_zero(emitter);
+    } else if *ty == PhpType::Int && crate::codegen::sentinels::null_repr_is_tagged() {
+        // Under the tagged representation a plain Int can never hold the null sentinel
     } else if *ty == PhpType::Int {
         match emitter.target.arch {
             Arch::AArch64 => {

--- a/src/codegen/expr/compare/casts.rs
+++ b/src/codegen/expr/compare/casts.rs
@@ -78,6 +78,9 @@ pub(in crate::codegen::expr) fn emit_cast(
                 PhpType::Mixed | PhpType::Union(_) => {
                     abi::emit_call_label(emitter, "__rt_mixed_cast_int");       // cast the boxed mixed payload to int through the target-aware helper
                 }
+                PhpType::TaggedScalar => {
+                    crate::codegen::sentinels::emit_tagged_scalar_to_int_null_as_zero(emitter);
+                }
                 PhpType::Callable
                 | PhpType::Object(_)
                 | PhpType::Buffer(_)
@@ -89,6 +92,10 @@ pub(in crate::codegen::expr) fn emit_cast(
         CastType::Float => {
             match &src_ty {
                 PhpType::Float => {}
+                PhpType::TaggedScalar => {
+                    crate::codegen::sentinels::emit_tagged_scalar_to_int_null_as_zero(emitter);
+                    abi::emit_int_result_to_float_result(emitter);              // signed int to double conversion
+                }
                 PhpType::Int | PhpType::Bool => {
                     abi::emit_int_result_to_float_result(emitter);              // signed int to double conversion
                 }

--- a/src/codegen/expr/compare/null_coalesce.rs
+++ b/src/codegen/expr/compare/null_coalesce.rs
@@ -9,6 +9,7 @@
 //! - Null, type-tag, and string comparisons must follow PHP semantics before emitting boolean results.
 
 use crate::codegen::abi;
+use crate::codegen::NULL_SENTINEL;
 use crate::codegen::context::Context;
 use crate::codegen::data_section::DataSection;
 use crate::codegen::emit::Emitter;
@@ -67,7 +68,7 @@ pub(in crate::codegen::expr) fn emit_null_coalesce(
         }
     } else {
         let null_reg = abi::symbol_scratch_reg(emitter);
-        abi::emit_load_int_immediate(emitter, null_reg, 0x7fff_ffff_ffff_fffe_u64 as i64); // materialize the shared null sentinel for the direct null test
+        abi::emit_load_int_immediate(emitter, null_reg, NULL_SENTINEL); // materialize the shared null sentinel for the direct null test
         if val_ty == PhpType::Float {
             match emitter.target.arch {
                 crate::codegen::platform::Arch::AArch64 => {

--- a/src/codegen/expr/compare/null_coalesce.rs
+++ b/src/codegen/expr/compare/null_coalesce.rs
@@ -51,9 +51,16 @@ pub(in crate::codegen::expr) fn emit_null_coalesce(
     let default_ty = crate::codegen::functions::infer_contextual_type(default, ctx);
     let result_ty = widen_codegen_type(&val_ty, &default_ty);
 
+    if matches!(val_ty, PhpType::Int) && crate::codegen::sentinels::null_repr_is_tagged() {
+        // Under the tagged representation a plain Int is never null: ?? always keeps it.
+        return val_ty;
+    }
+
     let use_value_label = ctx.next_label("nc_keep");
     let end_label = ctx.next_label("nc_end");
-    if matches!(val_ty, PhpType::Mixed | PhpType::Union(_)) {
+    if matches!(val_ty, PhpType::TaggedScalar) {
+        crate::codegen::sentinels::emit_branch_if_tagged_scalar_not_null(emitter, &use_value_label);
+    } else if matches!(val_ty, PhpType::Mixed | PhpType::Union(_)) {
         abi::emit_push_reg(emitter, abi::int_result_reg(emitter));              // save the boxed mixed/union value across the null check and fallback evaluation
         abi::emit_call_label(emitter, "__rt_mixed_unbox");                      // inspect the boxed payload tag before deciding whether ?? should fall back
         match emitter.target.arch {

--- a/src/codegen/expr/compare/strict.rs
+++ b/src/codegen/expr/compare/strict.rs
@@ -57,6 +57,16 @@ pub(in crate::codegen::expr) fn emit_strict_compare(
         {
             true
         }
+        // Under the tagged representation an Int-peeked expression can evaluate to a
+        // TaggedScalar holding null (array-miss reads), so int/null combinations must be
+        // compared at runtime instead of being constant-folded to a type mismatch.
+        (Some(l), Some(r))
+            if crate::codegen::sentinels::null_repr_is_tagged()
+                && matches!(l, PhpType::Int | PhpType::Void | PhpType::TaggedScalar)
+                && matches!(r, PhpType::Int | PhpType::Void | PhpType::TaggedScalar) =>
+        {
+            true
+        }
         (Some(l), Some(r)) => l == r,
         _ => true,
     };
@@ -75,6 +85,10 @@ pub(in crate::codegen::expr) fn emit_strict_compare(
             PhpType::Mixed => {
                 abi::emit_push_reg(emitter, abi::int_result_reg(emitter));      // push the left boxed mixed pointer for payload-aware strict comparison through the target-aware helper
             }
+            PhpType::TaggedScalar => {
+                let tag_reg = crate::codegen::sentinels::tagged_scalar_tag_reg(emitter);
+                abi::emit_push_reg_pair(emitter, abi::int_result_reg(emitter), tag_reg); // push the left tagged scalar payload/tag pair for later comparison
+            }
             _ => {
                 abi::emit_push_reg(emitter, abi::int_result_reg(emitter));      // push the left scalar or pointer-like value for later comparison through the target-aware helper
             }
@@ -82,8 +96,8 @@ pub(in crate::codegen::expr) fn emit_strict_compare(
 
         let rt = emit_expr(right, emitter, ctx, data);
 
-        if matches!(lt, PhpType::Mixed | PhpType::Union(_))
-            || matches!(rt, PhpType::Mixed | PhpType::Union(_))
+        if matches!(lt, PhpType::Mixed | PhpType::Union(_) | PhpType::TaggedScalar)
+            || matches!(rt, PhpType::Mixed | PhpType::Union(_) | PhpType::TaggedScalar)
         {
             let left_box_temp = !matches!(lt, PhpType::Mixed | PhpType::Union(_));
             let right_box_temp = !matches!(rt, PhpType::Mixed | PhpType::Union(_));
@@ -97,6 +111,10 @@ pub(in crate::codegen::expr) fn emit_strict_compare(
                 PhpType::Str => {
                     let (ptr_reg, len_reg) = abi::string_result_regs(emitter);
                     abi::emit_push_reg_pair(emitter, ptr_reg, len_reg);         // spill the right string payload before reloading the left operand into the same registers
+                }
+                PhpType::TaggedScalar => {
+                    let tag_reg = crate::codegen::sentinels::tagged_scalar_tag_reg(emitter);
+                    abi::emit_push_reg_pair(emitter, abi::int_result_reg(emitter), tag_reg); // spill the right tagged scalar payload/tag pair before reloading the left operand
                 }
                 _ => {
                     abi::emit_push_reg(emitter, abi::int_result_reg(emitter));  // spill the right scalar/pointer/mixed box before reloading the left operand into the same register
@@ -130,6 +148,20 @@ pub(in crate::codegen::expr) fn emit_strict_compare(
                         }
                     }
                 }
+                PhpType::TaggedScalar => {
+                    let tag_reg = crate::codegen::sentinels::tagged_scalar_tag_reg(emitter);
+                    abi::emit_load_temporary_stack_slot(emitter, abi::int_result_reg(emitter), 16); // reload the saved left tagged scalar payload from the lower comparison stack slot
+                    abi::emit_load_temporary_stack_slot(emitter, tag_reg, 24);  // reload the saved left tagged scalar tag from the lower comparison stack slot
+                    crate::codegen::emit_box_current_value_as_mixed(emitter, &lt);  // box the left tagged scalar so mixed comparison can inspect its runtime tag
+                    match emitter.target.arch {
+                        crate::codegen::platform::Arch::AArch64 => {
+                            emitter.instruction("str x0, [sp, #16]");           // replace the old left comparison slot with the boxed left mixed pointer
+                        }
+                        crate::codegen::platform::Arch::X86_64 => {
+                            emitter.instruction("mov QWORD PTR [rsp + 16], rax"); // replace the old left comparison slot with the boxed left mixed pointer
+                        }
+                    }
+                }
                 _ => {
                     abi::emit_load_temporary_stack_slot(emitter, abi::int_result_reg(emitter), 16); // reload the saved left scalar/pointer operand from the lower comparison stack slot
                     crate::codegen::emit_box_current_value_as_mixed(emitter, &lt);  // box the left operand when it is not already mixed
@@ -152,6 +184,11 @@ pub(in crate::codegen::expr) fn emit_strict_compare(
                     let (ptr_reg, len_reg) = abi::string_result_regs(emitter);
                     abi::emit_load_temporary_stack_slot(emitter, ptr_reg, 0);   // restore the spilled right string pointer after boxing the left operand
                     abi::emit_load_temporary_stack_slot(emitter, len_reg, 8);   // restore the spilled right string length after boxing the left operand
+                }
+                PhpType::TaggedScalar => {
+                    let tag_reg = crate::codegen::sentinels::tagged_scalar_tag_reg(emitter);
+                    abi::emit_load_temporary_stack_slot(emitter, abi::int_result_reg(emitter), 0); // restore the spilled right tagged scalar payload after boxing the left operand
+                    abi::emit_load_temporary_stack_slot(emitter, tag_reg, 8);   // restore the spilled right tagged scalar tag after boxing the left operand
                 }
                 _ => {
                     abi::emit_load_temporary_stack_slot(emitter, abi::int_result_reg(emitter), 0); // restore the spilled right scalar/pointer/mixed box after boxing the left operand
@@ -232,6 +269,9 @@ pub(in crate::codegen::expr) fn emit_strict_compare(
         }
 
         match &lt {
+            PhpType::TaggedScalar => {
+                unreachable!("TaggedScalar strict comparison is routed through the mixed boxing path")
+            }
             PhpType::Int | PhpType::Bool | PhpType::Void | PhpType::Never | PhpType::Resource(_) => {
                 let left_reg = abi::symbol_scratch_reg(emitter);
                 abi::emit_pop_reg(emitter, left_reg);                           // pop the saved left scalar or pointer-like value from the temporary comparison stack

--- a/src/codegen/expr/helpers.rs
+++ b/src/codegen/expr/helpers.rs
@@ -42,6 +42,15 @@ pub(super) fn widen_codegen_type(a: &PhpType, b: &PhpType) -> PhpType {
     if *a == PhpType::Str || *b == PhpType::Str {
         return PhpType::Str;
     }
+    if matches!(a, PhpType::TaggedScalar) || matches!(b, PhpType::TaggedScalar) {
+        let other = if matches!(a, PhpType::TaggedScalar) { b } else { a };
+        return match other {
+            PhpType::Int | PhpType::Bool | PhpType::Void | PhpType::TaggedScalar => {
+                PhpType::TaggedScalar
+            }
+            _ => PhpType::Mixed,
+        };
+    }
     if *a == PhpType::Float || *b == PhpType::Float {
         return PhpType::Float;
     }
@@ -93,6 +102,46 @@ pub(crate) fn coerce_result_to_type(
                 }
             },
             PhpType::Mixed | PhpType::Union(_) => {}
+            PhpType::TaggedScalar => match emitter.target.arch {
+                crate::codegen::platform::Arch::AArch64 => {
+                    crate::codegen::abi::emit_call_label(emitter, "__rt_mixed_unbox");
+                    emitter.instruction("mov x9, x1");                          // stage the unboxed payload while the tag moves into the tag register
+                    emitter.instruction("mov x1, x0");                          // place the unboxed runtime tag in the tagged scalar tag register
+                    emitter.instruction("mov x0, x9");                          // place the unboxed payload in the tagged scalar payload register
+                }
+                crate::codegen::platform::Arch::X86_64 => {
+                    crate::codegen::abi::emit_call_label(emitter, "__rt_mixed_unbox");
+                    emitter.instruction("mov rdx, rax");                        // place the unboxed runtime tag in the tagged scalar tag register
+                    emitter.instruction("mov rax, rdi");                        // place the unboxed payload in the tagged scalar payload register
+                }
+            },
+            _ => {}
+        }
+    } else if matches!(source_ty, PhpType::TaggedScalar) {
+        match target_ty.codegen_repr() {
+            PhpType::Int | PhpType::Bool | PhpType::Resource(_) | PhpType::Pointer(_) => {
+                crate::codegen::sentinels::emit_tagged_scalar_to_int_null_as_zero(emitter);
+            }
+            PhpType::Float => {
+                crate::codegen::sentinels::emit_tagged_scalar_to_int_null_as_zero(emitter);
+                crate::codegen::abi::emit_int_result_to_float_result(emitter);  // widen the narrowed payload into the float result register
+            }
+            PhpType::Str => {
+                super::coerce_to_string(emitter, ctx, data, source_ty);
+            }
+            PhpType::Mixed | PhpType::Union(_) => {
+                crate::codegen::emit_box_current_value_as_mixed(emitter, source_ty);
+            }
+            _ => {}
+        }
+    } else if matches!(target_ty, PhpType::TaggedScalar) {
+        match source_ty {
+            PhpType::Int | PhpType::Bool => {
+                crate::codegen::sentinels::emit_tagged_scalar_from_int_result(emitter);
+            }
+            PhpType::Void | PhpType::Never => {
+                crate::codegen::sentinels::emit_tagged_scalar_null(emitter);
+            }
             _ => {}
         }
     } else if matches!(target_ty, PhpType::Mixed | PhpType::Union(_)) {
@@ -137,6 +186,25 @@ pub(crate) fn can_coerce_result_to_type(source_ty: &PhpType, target_ty: &PhpType
                 | PhpType::Object(_)
                 | PhpType::Mixed
                 | PhpType::Union(_)
+        );
+    }
+    if matches!(source_ty, PhpType::TaggedScalar) {
+        return matches!(
+            target_ty.codegen_repr(),
+            PhpType::Int
+                | PhpType::Bool
+                | PhpType::Resource(_)
+                | PhpType::Pointer(_)
+                | PhpType::Float
+                | PhpType::Str
+                | PhpType::Mixed
+                | PhpType::Union(_)
+        );
+    }
+    if matches!(target_ty, PhpType::TaggedScalar) {
+        return matches!(
+            source_ty,
+            PhpType::Int | PhpType::Bool | PhpType::Void | PhpType::Never
         );
     }
     matches!(target_ty, PhpType::Mixed | PhpType::Union(_))

--- a/src/codegen/expr/objects.rs
+++ b/src/codegen/expr/objects.rs
@@ -24,6 +24,7 @@ use super::super::data_section::DataSection;
 use super::super::emit::Emitter;
 use super::scalars;
 use crate::codegen::abi;
+use crate::codegen::NULL_SENTINEL;
 use crate::codegen::platform::Arch;
 use crate::names::php_symbol_key;
 use crate::parser::ast::{Expr, ExprKind, InstanceOfTarget, StaticReceiver};
@@ -760,7 +761,7 @@ pub(super) fn emit_boxed_null(emitter: &mut Emitter) {
     abi::emit_load_int_immediate(
         emitter,
         abi::int_result_reg(emitter),
-        0x7fff_ffff_ffff_fffe,
+        NULL_SENTINEL,
     );
     crate::codegen::emit_box_current_value_as_mixed(emitter, &PhpType::Void);
 }

--- a/src/codegen/expr/objects/access.rs
+++ b/src/codegen/expr/objects/access.rs
@@ -131,6 +131,9 @@ pub(super) fn emit_property_access(
             PhpType::Bool | PhpType::Int | PhpType::Void | PhpType::Never | PhpType::Resource(_) => {
                 abi::emit_load_from_address(emitter, abi::int_result_reg(emitter), pointer_reg, 0);
             }
+            PhpType::TaggedScalar => {
+                unreachable!("nullable scalar properties use the boxed Mixed representation")
+            }
             PhpType::Iterable
             | PhpType::Mixed
             | PhpType::Union(_)
@@ -160,6 +163,9 @@ pub(super) fn emit_property_access(
         }
         PhpType::Bool | PhpType::Int | PhpType::Void | PhpType::Never | PhpType::Resource(_) => {
             abi::emit_load_from_address(emitter, abi::int_result_reg(emitter), object_reg, offset);
+        }
+        PhpType::TaggedScalar => {
+            unreachable!("nullable scalar properties use the boxed Mixed representation")
         }
         PhpType::Iterable
         | PhpType::Mixed
@@ -773,6 +779,9 @@ fn emit_loaded_object_property_value(
             PhpType::Bool | PhpType::Int | PhpType::Void | PhpType::Never | PhpType::Resource(_) => {
                 abi::emit_load_from_address(emitter, abi::int_result_reg(emitter), pointer_reg, 0);
             }
+            PhpType::TaggedScalar => {
+                unreachable!("nullable scalar properties use the boxed Mixed representation")
+            }
             PhpType::Iterable
             | PhpType::Mixed
             | PhpType::Union(_)
@@ -802,6 +811,9 @@ fn emit_loaded_object_property_value(
         }
         PhpType::Bool | PhpType::Int | PhpType::Void | PhpType::Never | PhpType::Resource(_) => {
             abi::emit_load_from_address(emitter, abi::int_result_reg(emitter), object_reg, offset);
+        }
+        PhpType::TaggedScalar => {
+            unreachable!("nullable scalar properties use the boxed Mixed representation")
         }
         PhpType::Iterable
         | PhpType::Mixed

--- a/src/codegen/expr/objects/allocation.rs
+++ b/src/codegen/expr/objects/allocation.rs
@@ -238,6 +238,9 @@ pub(super) fn emit_new_object_core(
                     abi::emit_store_to_address(emitter, abi::int_result_reg(emitter), object_reg, offset);
                     abi::emit_store_zero_to_address(emitter, object_reg, offset + 8);
                 }
+                PhpType::TaggedScalar => {
+                    unreachable!("nullable scalar properties use the boxed Mixed representation")
+                }
                 PhpType::Resource(_) => {
                     abi::emit_store_to_address(emitter, abi::int_result_reg(emitter), object_reg, offset);
                     let tag_reg = abi::temp_int_reg(emitter.target);

--- a/src/codegen/expr/objects/allocation.rs
+++ b/src/codegen/expr/objects/allocation.rs
@@ -16,7 +16,7 @@ use crate::codegen::data_section::DataSection;
 use crate::codegen::emit::Emitter;
 use crate::codegen::expr::calls::args as call_args;
 use crate::codegen::platform::Arch;
-use crate::codegen::UNINITIALIZED_TYPED_PROPERTY_SENTINEL;
+use crate::codegen::{NULL_SENTINEL, UNINITIALIZED_TYPED_PROPERTY_SENTINEL};
 use crate::names::method_symbol;
 use crate::parser::ast::{CallableTarget, Expr, ExprKind};
 use crate::types::{FunctionSig, PhpType};
@@ -29,7 +29,6 @@ use super::super::{
 use super::dispatch::emit_dispatch_interface_method;
 
 const X86_64_HEAP_MAGIC_HI32: u64 = 0x454C5048;
-const NULL_SENTINEL: i64 = 0x7fff_ffff_ffff_fffe;
 const ITERATOR_ITERATOR_DOWNCAST_MESSAGE: &str =
     "Class to downcast to not found or not base class or does not implement Traversable";
 

--- a/src/codegen/expr/objects/dispatch/enums.rs
+++ b/src/codegen/expr/objects/dispatch/enums.rs
@@ -9,6 +9,7 @@
 //! - Receiver ownership, late/static binding, and vtable slot layout must match class metadata emission.
 
 use crate::codegen::abi;
+use crate::codegen::NULL_SENTINEL;
 use crate::codegen::context::Context;
 use crate::codegen::data_section::DataSection;
 use crate::codegen::emit::Emitter;
@@ -377,7 +378,7 @@ fn emit_null_into_x0(emitter: &mut Emitter) {
     abi::emit_load_int_immediate(
         emitter,
         abi::int_result_reg(emitter),
-        0x7fff_ffff_ffff_fffe_u64 as i64,
+        NULL_SENTINEL,
     ); // materialize the shared null sentinel in the active integer result register
 }
 

--- a/src/codegen/expr/objects/nullsafe.rs
+++ b/src/codegen/expr/objects/nullsafe.rs
@@ -14,6 +14,7 @@ use crate::codegen::data_section::DataSection;
 use crate::codegen::emit::Emitter;
 use crate::codegen::functions;
 use crate::codegen::platform::Arch;
+use crate::codegen::NULL_SENTINEL;
 use crate::names::php_symbol_key;
 use crate::parser::ast::Expr;
 use crate::types::PhpType;
@@ -23,7 +24,6 @@ use crate::codegen::expr::emit_expr;
 
 /// Sentinel value representing a plain (non-boxed) null in the runtime.
 /// Uses an unlikely bit pattern to distinguish from valid object pointers.
-const NULL_SENTINEL: i64 = 0x7fff_ffff_ffff_fffe;
 
 /// Lowers `$obj?->property` with a short-circuit null result when the receiver is null.
 pub(super) fn emit_nullsafe_property_access(

--- a/src/codegen/expr/scalars.rs
+++ b/src/codegen/expr/scalars.rs
@@ -95,6 +95,10 @@ pub(super) fn emit_negate(
 ) -> PhpType {
     let ty = super::emit_expr(inner, emitter, ctx, data);
     emitter.comment("negate");
+    if ty == PhpType::TaggedScalar {
+        // narrow a tagged scalar (null -> 0) before the two's-complement negate
+        crate::codegen::sentinels::emit_tagged_scalar_to_int_null_as_zero(emitter);
+    }
     if ty == PhpType::Float {
         match emitter.target.arch {
             Arch::AArch64 => {

--- a/src/codegen/expr/scalars.rs
+++ b/src/codegen/expr/scalars.rs
@@ -9,6 +9,7 @@
 //! - Literal storage must match data-section labels and the result conventions expected by coercion helpers.
 
 use crate::codegen::platform::Arch;
+use crate::codegen::NULL_SENTINEL;
 
 use super::super::abi;
 use super::super::context::Context;
@@ -16,7 +17,6 @@ use super::super::data_section::DataSection;
 use super::super::emit::Emitter;
 use super::{Expr, PhpType};
 
-const NULL_SENTINEL: i64 = 0x7fff_ffff_ffff_fffe;
 
 /// Emits a boolean literal as an integer into the integer result register.
 /// `true` becomes 1, `false` becomes 0.
@@ -213,7 +213,7 @@ mod tests {
 
         let out = emitter.output();
         assert!(out.contains("    mov rax, 1\n"));
-        assert!(out.contains("    mov rax, 9223372036854775806\n"));
+        assert!(out.contains(&format!("    mov rax, {}\n", NULL_SENTINEL)));
         assert!(out.contains("    lea rax, [rip + "));
         assert!(out.contains("    mov rdx, 2\n"));
         assert!(out.contains("    mov rax, 42\n"));

--- a/src/codegen/expr/ternary.rs
+++ b/src/codegen/expr/ternary.rs
@@ -197,6 +197,10 @@ fn pop_saved_result_value(emitter: &mut Emitter, ty: &PhpType) {
             let (ptr_reg, len_reg) = abi::string_result_regs(emitter);
             abi::emit_pop_reg_pair(emitter, ptr_reg, len_reg);
         }
+        PhpType::TaggedScalar => {
+            let tag_reg = crate::codegen::sentinels::tagged_scalar_tag_reg(emitter);
+            abi::emit_pop_reg_pair(emitter, abi::int_result_reg(emitter), tag_reg);
+        }
     }
 }
 

--- a/src/codegen/functions/generator/emit/stmts.rs
+++ b/src/codegen/functions/generator/emit/stmts.rs
@@ -177,6 +177,18 @@ fn emit_var_dump_boxed_mixed(
 
 /// Emits `var_dump` output for an integer payload in the active result register.
 fn emit_var_dump_int(emitter: &mut Emitter, data: &mut DataSection, ctx: &mut ResumeCtx) {
+    if crate::codegen::sentinels::null_repr_is_tagged() {
+        // Under the tagged representation a plain Int is never null; print the payload
+        // directly so the full i64 range (including PHP_INT_MAX - 1) round-trips.
+        let result_reg = abi::int_result_reg(emitter);
+        abi::emit_push_reg(emitter, result_reg);                                // preserve the integer payload before prefix writes clobber the result register
+        emit_write_literal(emitter, data, b"int(");
+        abi::emit_pop_reg(emitter, result_reg);                                 // restore the integer payload after the prefix write
+        abi::emit_call_label(emitter, "__rt_itoa");                             // convert the integer payload to decimal text
+        emit_write_current_string(emitter);
+        emit_write_literal(emitter, data, b")\n");
+        return;
+    }
     let not_null = ctx.fresh_label("vd_not_null");
     let done = ctx.fresh_label("vd_done");
     let result_reg = abi::int_result_reg(emitter);

--- a/src/codegen/functions/generator/emit/stmts.rs
+++ b/src/codegen/functions/generator/emit/stmts.rs
@@ -27,6 +27,7 @@ use super::yields::{
 use super::{preserved_scratch_reg, slot_offset, LoopLabels, ResumeCtx};
 use super::super::model::*;
 use crate::codegen::abi;
+use crate::codegen::NULL_SENTINEL;
 use crate::codegen::data_section::DataSection;
 use crate::codegen::emit::Emitter;
 use crate::codegen::platform::Arch;
@@ -180,7 +181,7 @@ fn emit_var_dump_int(emitter: &mut Emitter, data: &mut DataSection, ctx: &mut Re
     let done = ctx.fresh_label("vd_done");
     let result_reg = abi::int_result_reg(emitter);
     let scratch_reg = abi::symbol_scratch_reg(emitter);
-    abi::emit_load_int_immediate(emitter, scratch_reg, 0x7fff_ffff_ffff_fffe_u64 as i64); // materialize the shared null sentinel used by int-valued locals
+    abi::emit_load_int_immediate(emitter, scratch_reg, NULL_SENTINEL); // materialize the shared null sentinel used by int-valued locals
     emitter.instruction(&format!("cmp {}, {}", result_reg, scratch_reg));       // compare the incoming integer payload against the null sentinel
     match emitter.target.arch {
         Arch::AArch64 => {

--- a/src/codegen/functions/types/builtins.rs
+++ b/src/codegen/functions/types/builtins.rs
@@ -229,6 +229,21 @@ pub(super) fn infer_function_call_type(
                 PhpType::Int
             }
         }
+        "array_pop" | "array_shift" => {
+            // mirror the emitters: int-element pops/shifts evaluate to a tagged scalar
+            // under the tagged null representation (empty array -> tagged null)
+            let elem_ty = match args.first().map(|arg| infer_local_type(arg, sig, ctx)) {
+                Some(PhpType::Array(elem)) => *elem,
+                _ => PhpType::Int,
+            };
+            if matches!(elem_ty, PhpType::Int)
+                && crate::codegen::sentinels::null_repr_is_tagged()
+            {
+                PhpType::TaggedScalar
+            } else {
+                elem_ty
+            }
+        }
         "min" | "max" => {
             if args.len() >= 2 {
                 let t0 = infer_local_type(&args[0], sig, ctx);

--- a/src/codegen/functions/types/mod.rs
+++ b/src/codegen/functions/types/mod.rs
@@ -141,7 +141,20 @@ pub(super) fn infer_local_type(
         }
         ExprKind::ArrayAccess { array, .. } => match infer_local_type(array, sig, ctx) {
             PhpType::Str => PhpType::Str,
+            // Under the tagged null representation, int-element reads are miss-capable and
+            // evaluate to a TaggedScalar; the local inference must agree with emission.
+            PhpType::Array(t) if matches!(*t, PhpType::Int)
+                && crate::codegen::sentinels::null_repr_is_tagged() =>
+            {
+                PhpType::TaggedScalar
+            }
             PhpType::Array(t) => *t,
+            PhpType::AssocArray { value, .. }
+                if matches!(*value, PhpType::Int)
+                    && crate::codegen::sentinels::null_repr_is_tagged() =>
+            {
+                PhpType::TaggedScalar
+            }
             PhpType::AssocArray { value, .. } => *value,
             PhpType::Object(class_name) => ctx
                 .filter(|ctx| ctx.object_type_implements_interface(&class_name, "ArrayAccess"))

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -35,7 +35,7 @@ mod program_usage;
 mod reflection;
 mod runtime;
 mod runtime_features;
-mod sentinels;
+pub(crate) mod sentinels;
 mod stmt;
 
 use std::cell::{Cell, RefCell};
@@ -124,7 +124,7 @@ pub(crate) use driver_support::{
     runtime_value_tag,
 };
 pub(crate) use sentinels::{NULL_SENTINEL, UNINITIALIZED_TYPED_PROPERTY_SENTINEL};
-pub use sentinels::NullRepr;
+pub use sentinels::{set_null_repr, NullRepr};
 #[allow(unused_imports)]
 pub use driver_support::{generate_runtime, generate_runtime_with_features};
 pub use runtime_features::{

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -35,6 +35,7 @@ mod program_usage;
 mod reflection;
 mod runtime;
 mod runtime_features;
+mod sentinels;
 mod stmt;
 
 use std::cell::{Cell, RefCell};
@@ -120,8 +121,9 @@ pub(crate) use driver_support::{
     emit_box_current_expr_value_as_mixed_for_container, emit_box_current_value_as_mixed,
     emit_box_iterable_value_for_mixed_container, emit_box_runtime_payload_as_mixed,
     emit_normalized_hash_key, emit_release_pushed_refcounted_temp_after_array_push,
-    runtime_value_tag, UNINITIALIZED_TYPED_PROPERTY_SENTINEL,
+    runtime_value_tag,
 };
+pub(crate) use sentinels::{NULL_SENTINEL, UNINITIALIZED_TYPED_PROPERTY_SENTINEL};
 #[allow(unused_imports)]
 pub use driver_support::{generate_runtime, generate_runtime_with_features};
 pub use runtime_features::{

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -124,6 +124,7 @@ pub(crate) use driver_support::{
     runtime_value_tag,
 };
 pub(crate) use sentinels::{NULL_SENTINEL, UNINITIALIZED_TYPED_PROPERTY_SENTINEL};
+pub use sentinels::NullRepr;
 #[allow(unused_imports)]
 pub use driver_support::{generate_runtime, generate_runtime_with_features};
 pub use runtime_features::{
@@ -165,7 +166,9 @@ pub fn generate_user_asm(
     heap_debug: bool,
     target: Target,
     requires_elephc_tls: bool,
+    null_repr: NullRepr,
 ) -> String {
+    sentinels::set_null_repr(null_repr);
     let mut emitter = Emitter::new(target);
     if target.arch == platform::Arch::X86_64 {
         emitter.emit_text_prelude();
@@ -939,6 +942,7 @@ pub fn generate(
     heap_debug: bool,
     target: Target,
     requires_elephc_tls: bool,
+    null_repr: NullRepr,
 ) -> (String, String) {
     let user_asm = generate_user_asm(
         program,
@@ -959,6 +963,7 @@ pub fn generate(
         heap_debug,
         target,
         requires_elephc_tls,
+        null_repr,
     );
     let runtime_features = runtime_features_for_program_and_classes(program, classes);
     let runtime_asm = generate_runtime_with_features(heap_size, target, runtime_features);

--- a/src/codegen/runtime/arrays/array_shift.rs
+++ b/src/codegen/runtime/arrays/array_shift.rs
@@ -9,6 +9,7 @@
 //! - Array helpers operate on runtime array headers and element cells; mutations must respect capacity and COW contracts.
 
 use crate::codegen::emit::Emitter;
+use crate::codegen::NULL_SENTINEL;
 use crate::codegen::platform::Arch;
 
 /// Emits the `__rt_array_shift` runtime helper that removes and returns the first
@@ -44,10 +45,11 @@ pub fn emit_array_shift(emitter: &mut Emitter) {
     emitter.instruction("cbnz x9, __rt_array_shift_notempty");                  // if length != 0, proceed normally
 
     // -- empty array: return null sentinel --
-    emitter.instruction("movz x0, #0xFFFE");                                    // load null sentinel bits [15:0]
-    emitter.instruction("movk x0, #0xFFFF, lsl #16");                           // load null sentinel bits [31:16]
-    emitter.instruction("movk x0, #0xFFFF, lsl #32");                           // load null sentinel bits [47:32]
-    emitter.instruction("movk x0, #0x7FFF, lsl #48");                           // load null sentinel bits [63:48] = 0x7FFFFFFFFFFFFFFE
+    let sentinel = NULL_SENTINEL as u64;
+    emitter.instruction(&format!("movz x0, #0x{:X}", sentinel & 0xFFFF));       // load null sentinel bits [15:0]
+    emitter.instruction(&format!("movk x0, #0x{:X}, lsl #16", (sentinel >> 16) & 0xFFFF)); // load null sentinel bits [31:16]
+    emitter.instruction(&format!("movk x0, #0x{:X}, lsl #32", (sentinel >> 32) & 0xFFFF)); // load null sentinel bits [47:32]
+    emitter.instruction(&format!("movk x0, #0x{:X}, lsl #48", (sentinel >> 48) & 0xFFFF)); // load null sentinel bits [63:48] = 0x7FFFFFFFFFFFFFFE
     emitter.instruction("ret");                                                 // return null to caller
 
     // -- array is not empty, proceed --
@@ -101,7 +103,7 @@ fn emit_array_shift_linux_x86_64(emitter: &mut Emitter) {
     emitter.instruction("mov r10, QWORD PTR [rdi]");                            // load the current indexed-array length before checking whether the shift operation is empty
     emitter.instruction("test r10, r10");                                       // check whether the indexed array currently stores any live scalar payloads
     emitter.instruction("jnz __rt_array_shift_notempty_x86");                   // continue with the scalar left-shift loop when the indexed array is not empty
-    emitter.instruction("mov rax, 0x7ffffffffffffffe");                         // materialize the shared null sentinel as the empty-array shift result on x86_64
+    emitter.instruction(&format!("mov rax, 0x{:x}", NULL_SENTINEL));            // materialize the shared null sentinel as the empty-array shift result on x86_64
     emitter.instruction("ret");                                                 // return the null sentinel immediately when array_shift runs on an empty indexed array
 
     emitter.label("__rt_array_shift_notempty_x86");

--- a/src/codegen/runtime/data/user.rs
+++ b/src/codegen/runtime/data/user.rs
@@ -625,6 +625,9 @@ pub(crate) fn emit_runtime_data_user(
                     PhpType::Object(_) => 6,
                     PhpType::Mixed | PhpType::Union(_) | PhpType::Iterable => 7,
                     PhpType::Resource(_) => 9,
+                    PhpType::TaggedScalar => {
+                        unreachable!("nullable scalar properties use the boxed Mixed representation")
+                    }
                     PhpType::Callable
                     | PhpType::Pointer(_)
                     | PhpType::Buffer(_)
@@ -668,6 +671,9 @@ pub(crate) fn emit_runtime_data_user(
                         PhpType::Union(_) => 7,
                         PhpType::Iterable => 7,
                         PhpType::Resource(_) => 9,
+                        PhpType::TaggedScalar => {
+                            unreachable!("nullable scalar properties use the boxed Mixed representation")
+                        }
                         PhpType::Callable
                         | PhpType::Pointer(_)
                         | PhpType::Buffer(_)

--- a/src/codegen/sentinels.rs
+++ b/src/codegen/sentinels.rs
@@ -23,15 +23,16 @@ use super::platform::Arch;
 
 /// Selects how codegen represents PHP `null` in scalar slots.
 ///
-/// `Sentinel` (default) stores the in-band `NULL_SENTINEL` i64, which collides with the real
-/// integer `9223372036854775806`. `Tagged` gives null-capable scalar slots the inline two-word
+/// `Tagged` (default) gives null-capable scalar slots the inline two-word
 /// `PhpType::TaggedScalar` representation, making the full i64 range representable.
+/// `Sentinel` is the legacy opt-out: it stores the in-band `NULL_SENTINEL` i64, which
+/// collides with the real integer `9223372036854775806`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum NullRepr {
-    /// In-band `PHP_INT_MAX - 1` sentinel in one-word scalar slots (legacy default).
-    #[default]
+    /// In-band `PHP_INT_MAX - 1` sentinel in one-word scalar slots (legacy opt-out).
     Sentinel,
-    /// Inline two-word `{payload, tag}` scalars for null-capable slots.
+    /// Inline two-word `{payload, tag}` scalars for null-capable slots (default).
+    #[default]
     Tagged,
 }
 
@@ -39,7 +40,7 @@ thread_local! {
     /// Active null representation for the compilation running on this thread. One compilation
     /// is single-threaded, so a thread-local avoids threading the flag through every emitter
     /// signature; `generate`/`generate_user_asm` set it unconditionally at entry.
-    static NULL_REPR: Cell<NullRepr> = const { Cell::new(NullRepr::Sentinel) };
+    static NULL_REPR: Cell<NullRepr> = const { Cell::new(NullRepr::Tagged) };
 }
 
 /// Installs the null representation for the compilation running on this thread. Must run

--- a/src/codegen/sentinels.rs
+++ b/src/codegen/sentinels.rs
@@ -42,8 +42,9 @@ thread_local! {
     static NULL_REPR: Cell<NullRepr> = const { Cell::new(NullRepr::Sentinel) };
 }
 
-/// Installs the null representation for the compilation running on this thread.
-pub(crate) fn set_null_repr(repr: NullRepr) {
+/// Installs the null representation for the compilation running on this thread. Must run
+/// before type checking: parameter specialization consults it for null-capable widening.
+pub fn set_null_repr(repr: NullRepr) {
     NULL_REPR.with(|cell| cell.set(repr));
 }
 

--- a/src/codegen/sentinels.rs
+++ b/src/codegen/sentinels.rs
@@ -1,16 +1,56 @@
 //! Purpose:
-//! Canonical home for the in-band runtime sentinel constants shared across codegen.
-//! Owns the null sentinel and the uninitialized-typed-property sentinel.
+//! Canonical home for the in-band runtime sentinel constants and the tagged-scalar
+//! (`PhpType::TaggedScalar`) value helpers shared across codegen.
 //!
 //! Called from:
-//! - `crate::codegen` emitters that produce or detect sentinel-encoded values.
+//! - `crate::codegen` emitters that produce or detect sentinel-encoded or tagged null values.
 //!
 //! Key details:
 //! - The null sentinel is an in-band i64 (`PHP_INT_MAX - 1`): every i64 bit pattern is a valid
 //!   PHP int, so the real integer `9223372036854775806` collides with it. The structural fix
-//!   (`NullRepr::Tagged`) replaces sentinel checks with a tagged scalar representation.
+//!   (`NullRepr::Tagged`) replaces sentinel checks with the tagged scalar representation.
 //! - The uninitialized-property sentinel lives in a separate metadata word (`offset + 8`),
 //!   never in the value word, so it does not collide with property values.
+//! - A tagged scalar is two words: payload in the integer result register (`x0`/`rax`), tag in
+//!   the adjacent register (`x1`/`rdx`); on the stack the payload sits at `offset` and the tag
+//!   at `offset - 8`, mirroring the `Str` pointer/length layout. Tag values reuse the runtime
+//!   value tag scheme so a tagged scalar is word-compatible with a Mixed cell's tag/payload.
+
+use std::cell::Cell;
+
+use super::emit::Emitter;
+use super::platform::Arch;
+
+/// Selects how codegen represents PHP `null` in scalar slots.
+///
+/// `Sentinel` (default) stores the in-band `NULL_SENTINEL` i64, which collides with the real
+/// integer `9223372036854775806`. `Tagged` gives null-capable scalar slots the inline two-word
+/// `PhpType::TaggedScalar` representation, making the full i64 range representable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NullRepr {
+    /// In-band `PHP_INT_MAX - 1` sentinel in one-word scalar slots (legacy default).
+    #[default]
+    Sentinel,
+    /// Inline two-word `{payload, tag}` scalars for null-capable slots.
+    Tagged,
+}
+
+thread_local! {
+    /// Active null representation for the compilation running on this thread. One compilation
+    /// is single-threaded, so a thread-local avoids threading the flag through every emitter
+    /// signature; `generate`/`generate_user_asm` set it unconditionally at entry.
+    static NULL_REPR: Cell<NullRepr> = const { Cell::new(NullRepr::Sentinel) };
+}
+
+/// Installs the null representation for the compilation running on this thread.
+pub(crate) fn set_null_repr(repr: NullRepr) {
+    NULL_REPR.with(|cell| cell.set(repr));
+}
+
+/// Returns true when the active compilation uses the tagged null representation.
+pub(crate) fn null_repr_is_tagged() -> bool {
+    NULL_REPR.with(|cell| cell.get()) == NullRepr::Tagged
+}
 
 /// In-band null marker for unboxed scalar slots: `0x7fff_ffff_ffff_fffe` (= `PHP_INT_MAX - 1`).
 pub(crate) const NULL_SENTINEL: i64 = 0x7fff_ffff_ffff_fffe;
@@ -18,6 +58,98 @@ pub(crate) const NULL_SENTINEL: i64 = 0x7fff_ffff_ffff_fffe;
 /// Marker stored in a typed property's metadata word while the property is uninitialized:
 /// `0x7fff_ffff_ffff_fffd` (= `PHP_INT_MAX - 2`).
 pub(crate) const UNINITIALIZED_TYPED_PROPERTY_SENTINEL: i64 = 0x7fff_ffff_ffff_fffd;
+
+/// Runtime value tag carried by a tagged scalar holding a PHP int (matches
+/// `runtime_value_tag(PhpType::Int)`).
+pub(crate) const TAGGED_SCALAR_TAG_INT: i64 = 0;
+
+/// Runtime value tag carried by a tagged scalar holding PHP null (matches
+/// `runtime_value_tag(PhpType::Void)`).
+pub(crate) const TAGGED_SCALAR_TAG_NULL: i64 = 8;
+
+/// Returns the register holding a tagged scalar's tag word; the payload word lives in the
+/// integer result register. AArch64: `x1`. x86_64: `rdx` (mirrors the `Str` second word).
+pub(crate) fn tagged_scalar_tag_reg(emitter: &Emitter) -> &'static str {
+    match emitter.target.arch {
+        Arch::AArch64 => "x1",
+        Arch::X86_64 => "rdx",
+    }
+}
+
+/// Materializes PHP null as a tagged scalar: the canonical null payload word plus the null
+/// tag in the tag register. The payload uses `NULL_SENTINEL` (not zero) so boxing a tagged
+/// null into a Mixed cell produces exactly the same `{tag 8, sentinel payload}` words as the
+/// legacy boxed null — `__rt_mixed_strict_eq` compares payload words even for the null tag.
+pub(crate) fn emit_tagged_scalar_null(emitter: &mut Emitter) {
+    match emitter.target.arch {
+        Arch::AArch64 => {
+            super::abi::emit_load_int_immediate(emitter, "x0", NULL_SENTINEL);
+            emitter.instruction(&format!("mov x1, #{}", TAGGED_SCALAR_TAG_NULL)); // runtime tag 8 marks the tagged scalar as PHP null
+        }
+        Arch::X86_64 => {
+            super::abi::emit_load_int_immediate(emitter, "rax", NULL_SENTINEL);
+            emitter.instruction(&format!("mov rdx, {}", TAGGED_SCALAR_TAG_NULL)); // runtime tag 8 marks the tagged scalar as PHP null
+        }
+    }
+}
+
+/// Tags the integer currently in the result register as a non-null tagged scalar by loading
+/// the int tag into the tag register. The payload word is left untouched.
+pub(crate) fn emit_tagged_scalar_from_int_result(emitter: &mut Emitter) {
+    match emitter.target.arch {
+        Arch::AArch64 => {
+            emitter.instruction(&format!("mov x1, #{}", TAGGED_SCALAR_TAG_INT)); // runtime tag 0 marks the tagged scalar payload as an int
+        }
+        Arch::X86_64 => {
+            emitter.instruction(&format!("mov rdx, {}", TAGGED_SCALAR_TAG_INT)); // runtime tag 0 marks the tagged scalar payload as an int
+        }
+    }
+}
+
+/// Branches to `label` when the tagged scalar in the result registers is PHP null
+/// (tag register == null tag).
+pub(crate) fn emit_branch_if_tagged_scalar_null(emitter: &mut Emitter, label: &str) {
+    match emitter.target.arch {
+        Arch::AArch64 => {
+            emitter.instruction(&format!("cmp x1, #{}", TAGGED_SCALAR_TAG_NULL)); // does the tagged scalar carry the runtime null tag?
+            emitter.instruction(&format!("b.eq {}", label));                    // branch when the tagged scalar is PHP null
+        }
+        Arch::X86_64 => {
+            emitter.instruction(&format!("cmp rdx, {}", TAGGED_SCALAR_TAG_NULL)); // does the tagged scalar carry the runtime null tag?
+            emitter.instruction(&format!("je {}", label));                      // branch when the tagged scalar is PHP null
+        }
+    }
+}
+
+/// Branches to `label` when the tagged scalar in the result registers is NOT PHP null.
+pub(crate) fn emit_branch_if_tagged_scalar_not_null(emitter: &mut Emitter, label: &str) {
+    match emitter.target.arch {
+        Arch::AArch64 => {
+            emitter.instruction(&format!("cmp x1, #{}", TAGGED_SCALAR_TAG_NULL)); // does the tagged scalar carry the runtime null tag?
+            emitter.instruction(&format!("b.ne {}", label));                    // branch when the tagged scalar holds a real value
+        }
+        Arch::X86_64 => {
+            emitter.instruction(&format!("cmp rdx, {}", TAGGED_SCALAR_TAG_NULL)); // does the tagged scalar carry the runtime null tag?
+            emitter.instruction(&format!("jne {}", label));                     // branch when the tagged scalar holds a real value
+        }
+    }
+}
+
+/// Narrows the tagged scalar in the result registers to a plain int, coercing null to zero
+/// (PHP `(int)null === 0`). Leaves the int payload in the integer result register.
+pub(crate) fn emit_tagged_scalar_to_int_null_as_zero(emitter: &mut Emitter) {
+    match emitter.target.arch {
+        Arch::AArch64 => {
+            emitter.instruction(&format!("cmp x1, #{}", TAGGED_SCALAR_TAG_NULL)); // does the tagged scalar carry the runtime null tag?
+            emitter.instruction("csel x0, xzr, x0, eq");                        // replace the payload with zero when the tagged scalar is null
+        }
+        Arch::X86_64 => {
+            emitter.instruction("xor r11, r11");                                // materialize the zero replacement for a null tagged scalar payload
+            emitter.instruction(&format!("cmp rdx, {}", TAGGED_SCALAR_TAG_NULL)); // does the tagged scalar carry the runtime null tag?
+            emitter.instruction("cmove rax, r11");                              // replace the payload with zero when the tagged scalar is null
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/codegen/sentinels.rs
+++ b/src/codegen/sentinels.rs
@@ -1,0 +1,42 @@
+//! Purpose:
+//! Canonical home for the in-band runtime sentinel constants shared across codegen.
+//! Owns the null sentinel and the uninitialized-typed-property sentinel.
+//!
+//! Called from:
+//! - `crate::codegen` emitters that produce or detect sentinel-encoded values.
+//!
+//! Key details:
+//! - The null sentinel is an in-band i64 (`PHP_INT_MAX - 1`): every i64 bit pattern is a valid
+//!   PHP int, so the real integer `9223372036854775806` collides with it. The structural fix
+//!   (`NullRepr::Tagged`) replaces sentinel checks with a tagged scalar representation.
+//! - The uninitialized-property sentinel lives in a separate metadata word (`offset + 8`),
+//!   never in the value word, so it does not collide with property values.
+
+/// In-band null marker for unboxed scalar slots: `0x7fff_ffff_ffff_fffe` (= `PHP_INT_MAX - 1`).
+pub(crate) const NULL_SENTINEL: i64 = 0x7fff_ffff_ffff_fffe;
+
+/// Marker stored in a typed property's metadata word while the property is uninitialized:
+/// `0x7fff_ffff_ffff_fffd` (= `PHP_INT_MAX - 2`).
+pub(crate) const UNINITIALIZED_TYPED_PROPERTY_SENTINEL: i64 = 0x7fff_ffff_ffff_fffd;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Locks the canonical null sentinel bit pattern shared by every producer and consumer.
+    #[test]
+    fn null_sentinel_constant_value() {
+        assert_eq!(NULL_SENTINEL, 0x7fff_ffff_ffff_fffe_u64 as i64);
+        assert_eq!(NULL_SENTINEL, i64::MAX - 1);
+    }
+
+    /// Locks the uninitialized-typed-property sentinel bit pattern used in property metadata.
+    #[test]
+    fn uninitialized_property_sentinel_constant_value() {
+        assert_eq!(
+            UNINITIALIZED_TYPED_PROPERTY_SENTINEL,
+            0x7fff_ffff_ffff_fffd_u64 as i64
+        );
+        assert_eq!(UNINITIALIZED_TYPED_PROPERTY_SENTINEL, i64::MAX - 2);
+    }
+}

--- a/src/codegen/stmt/arrays/assign/assoc.rs
+++ b/src/codegen/stmt/arrays/assign/assoc.rs
@@ -65,6 +65,11 @@ pub(super) fn emit_assoc_array_assign(
     abi::emit_push_reg_pair(emitter, key_ptr_reg, key_len_reg);                       // preserve the computed key pointer and length while evaluating the value expression
 
     let mut val_ty = emit_expr(value, emitter, ctx, data);
+    if matches!(val_ty, PhpType::TaggedScalar) {
+        // store the tagged scalar payload word as a plain int: a null payload carries the
+        // legacy in-band sentinel, matching the sentinel representation for stored nulls
+        val_ty = PhpType::Int;
+    }
     if matches!(val_ty, PhpType::Mixed | PhpType::Union(_))
         && !matches!(target.elem_ty, PhpType::Mixed | PhpType::Union(_))
         && crate::codegen::expr::can_coerce_result_to_type(&val_ty, &target.elem_ty)

--- a/src/codegen/stmt/arrays/assign/indexed/prepare.rs
+++ b/src/codegen/stmt/arrays/assign/indexed/prepare.rs
@@ -79,6 +79,11 @@ pub(super) fn prepare_indexed_array_assign(
     coerce_result_to_type(emitter, ctx, data, &index_ty, &PhpType::Int);
     emitter.instruction("str x0, [sp, #-16]!");                                 // push computed index onto stack
     let mut val_ty = emit_expr(value, emitter, ctx, data);
+    if matches!(val_ty, PhpType::TaggedScalar) {
+        // store the tagged scalar payload word as a plain int: a null payload carries the
+        // legacy in-band sentinel, matching the sentinel representation for stored nulls
+        val_ty = PhpType::Int;
+    }
     if matches!(val_ty, PhpType::Mixed | PhpType::Union(_))
         && !matches!(target.elem_ty, PhpType::Mixed | PhpType::Union(_))
         && crate::codegen::expr::can_coerce_result_to_type(&val_ty, &target.elem_ty)
@@ -221,6 +226,11 @@ fn prepare_indexed_array_assign_linux_x86_64(
     coerce_result_to_type(emitter, ctx, data, &index_ty, &PhpType::Int);
     abi::emit_push_reg(emitter, "rax");                                           // preserve the computed target index while evaluating the assigned value
     let mut val_ty = emit_expr(value, emitter, ctx, data);
+    if matches!(val_ty, PhpType::TaggedScalar) {
+        // store the tagged scalar payload word as a plain int: a null payload carries the
+        // legacy in-band sentinel, matching the sentinel representation for stored nulls
+        val_ty = PhpType::Int;
+    }
     if matches!(val_ty, PhpType::Mixed | PhpType::Union(_))
         && !matches!(target.elem_ty, PhpType::Mixed | PhpType::Union(_))
         && crate::codegen::expr::can_coerce_result_to_type(&val_ty, &target.elem_ty)

--- a/src/codegen/stmt/arrays/push.rs
+++ b/src/codegen/stmt/arrays/push.rs
@@ -95,6 +95,11 @@ pub(super) fn emit_array_push_stmt(
     };
     let source_owned = expr_result_heap_ownership(value) == HeapOwnership::Owned;
     let mut val_ty = emit_expr(value, emitter, ctx, data);
+    if matches!(val_ty, PhpType::TaggedScalar) {
+        // store the tagged scalar payload word as a plain int: a null payload carries the
+        // legacy in-band sentinel, matching the sentinel representation for stored nulls
+        val_ty = PhpType::Int;
+    }
     let boxed_iterable =
         crate::codegen::emit_box_iterable_value_for_mixed_container(emitter, &mut val_ty);
     let effective_elem_ty = effective_indexed_push_type(&elem_ty, &val_ty, ctx);
@@ -219,6 +224,11 @@ fn emit_assoc_array_push_stmt(
     abi::emit_push_reg(emitter, table_reg);                                    // preserve the hash-table pointer while evaluating the appended value
 
     let mut val_ty = emit_expr(value, emitter, ctx, data);
+    if matches!(val_ty, PhpType::TaggedScalar) {
+        // store the tagged scalar payload word as a plain int: a null payload carries the
+        // legacy in-band sentinel, matching the sentinel representation for stored nulls
+        val_ty = PhpType::Int;
+    }
     if matches!(val_ty, PhpType::Mixed | PhpType::Union(_))
         && !matches!(assoc_value_ty, PhpType::Mixed | PhpType::Union(_))
         && crate::codegen::expr::can_coerce_result_to_type(&val_ty, &assoc_value_ty)
@@ -334,6 +344,11 @@ fn emit_array_push_stmt_linux_x86_64(
     };
     let source_owned = expr_result_heap_ownership(value) == HeapOwnership::Owned;
     let mut val_ty = emit_expr(value, emitter, ctx, data);
+    if matches!(val_ty, PhpType::TaggedScalar) {
+        // store the tagged scalar payload word as a plain int: a null payload carries the
+        // legacy in-band sentinel, matching the sentinel representation for stored nulls
+        val_ty = PhpType::Int;
+    }
     let boxed_iterable =
         crate::codegen::emit_box_iterable_value_for_mixed_container(emitter, &mut val_ty);
     let effective_elem_ty = effective_indexed_push_type(&elem_ty, &val_ty, ctx);

--- a/src/codegen/stmt/assignments/locals.rs
+++ b/src/codegen/stmt/assignments/locals.rs
@@ -856,6 +856,14 @@ fn emit_null_coalesce_assign_stmt(
 /// sentinel. ARM64 and x86_64 produce architecturally appropriate comparison + branch
 /// sequences.
 fn emit_branch_if_result_non_null(ty: &PhpType, keep_label: &str, emitter: &mut Emitter) {
+    if matches!(ty, PhpType::TaggedScalar) {
+        crate::codegen::sentinels::emit_branch_if_tagged_scalar_not_null(emitter, keep_label);
+        return;
+    }
+    if matches!(ty, PhpType::Int) && crate::codegen::sentinels::null_repr_is_tagged() {
+        abi::emit_jump(emitter, keep_label);                                    // a plain Int is never null under the tagged representation; always keep it
+        return;
+    }
     if matches!(ty, PhpType::Mixed | PhpType::Union(_)) {
         abi::emit_call_label(emitter, "__rt_mixed_unbox");                      // inspect the boxed value tag before deciding whether ??= should store
         match emitter.target.arch {

--- a/src/codegen/stmt/assignments/locals.rs
+++ b/src/codegen/stmt/assignments/locals.rs
@@ -9,6 +9,7 @@
 //! - Local writes must release replaced heap values only when the frame owns the previous value.
 
 use super::super::super::abi;
+use super::super::super::NULL_SENTINEL;
 use super::super::super::callable_descriptor;
 use super::super::super::context::{Context, HeapOwnership};
 use super::super::super::data_section::DataSection;
@@ -871,7 +872,7 @@ fn emit_branch_if_result_non_null(ty: &PhpType, keep_label: &str, emitter: &mut 
     }
 
     let null_reg = abi::symbol_scratch_reg(emitter);
-    abi::emit_load_int_immediate(emitter, null_reg, 0x7fff_ffff_ffff_fffe_u64 as i64);
+    abi::emit_load_int_immediate(emitter, null_reg, NULL_SENTINEL);
     if ty == &PhpType::Float {
         match emitter.target.arch {
             crate::codegen::platform::Arch::AArch64 => {

--- a/src/codegen/stmt/assignments/locals.rs
+++ b/src/codegen/stmt/assignments/locals.rs
@@ -187,6 +187,23 @@ pub(crate) fn emit_assign_stmt(
         };
         let offset = var.stack_offset;
         let old_ty = var.ty.clone();
+        let slot_size = var.slot_size;
+        if matches!(ty, PhpType::TaggedScalar)
+            && slot_size < 16
+            && matches!(
+                old_ty,
+                PhpType::Int
+                    | PhpType::Bool
+                    | PhpType::Void
+                    | PhpType::Never
+                    | PhpType::Resource(_)
+            )
+        {
+            // The local slot is one word: keep the tagged scalar payload as a plain int.
+            // A null payload carries the legacy in-band sentinel, so storage matches the
+            // sentinel representation instead of writing the tag into the neighboring slot.
+            ty = PhpType::Int;
+        }
         if matches!(ty, PhpType::Mixed | PhpType::Union(_))
             && !matches!(old_ty, PhpType::Mixed | PhpType::Union(_))
             && super::super::super::expr::can_coerce_result_to_type(&ty, &old_ty)

--- a/src/codegen/stmt/assignments/properties/dynamic_props.rs
+++ b/src/codegen/stmt/assignments/properties/dynamic_props.rs
@@ -13,6 +13,7 @@
 //!   runtime paths.
 
 use crate::codegen::abi;
+use crate::codegen::NULL_SENTINEL;
 use crate::codegen::context::Context;
 use crate::codegen::data_section::DataSection;
 use crate::codegen::emit::Emitter;
@@ -56,7 +57,7 @@ pub(super) fn emit_dynamic_property_set(
                 emitter.instruction("bl __rt_mixed_from_value");                // box null into an owned Mixed cell
             }
             Arch::X86_64 => {
-                emitter.instruction("mov rdi, 9223372036854775806");            // runtime null sentinel as the boxed null payload low word
+                emitter.instruction(&format!("mov rdi, {}", NULL_SENTINEL));    // runtime null sentinel as the boxed null payload low word
                 emitter.instruction("xor rsi, rsi");                            // null mixed payloads carry no high word
                 emitter.instruction("mov rax, 8");                              // runtime tag 8 = null payload for Mixed boxing
                 emitter.instruction("call __rt_mixed_from_value");              // box null into an owned Mixed cell
@@ -199,7 +200,7 @@ pub(crate) fn emit_dynamic_property_get(
             emitter.instruction("mov rax, rdi");                                // result = mixed cell pointer
             emitter.instruction(&format!("jmp {}", done_label));                // skip the null-return path
             emitter.label(&miss_label);
-            emitter.instruction("mov rdi, 9223372036854775806");                // null sentinel low word for boxed Mixed null
+            emitter.instruction(&format!("mov rdi, {}", NULL_SENTINEL));        // null sentinel low word for boxed Mixed null
             emitter.instruction("xor rsi, rsi");                                // value_hi unused for null
             emitter.instruction("mov rax, 8");                                  // tag 8 = null
             emitter.instruction("call __rt_mixed_from_value");                  // rax = boxed null Mixed cell pointer

--- a/src/codegen/stmt/assignments/properties/magic_set.rs
+++ b/src/codegen/stmt/assignments/properties/magic_set.rs
@@ -9,6 +9,7 @@
 //! - Property writes must respect declared types, visibility checks, and runtime object layout.
 
 use crate::codegen::context::Context;
+use crate::codegen::NULL_SENTINEL;
 use crate::codegen::data_section::DataSection;
 use crate::codegen::emit::Emitter;
 use crate::codegen::{abi, platform::Arch};
@@ -64,7 +65,7 @@ pub(super) fn emit_magic_set_call(
                 emitter.instruction("bl __rt_mixed_from_value");                // box null into an owned Mixed cell for __set
             }
             Arch::X86_64 => {
-                emitter.instruction("mov rdi, 9223372036854775806");            // use the runtime null sentinel as the boxed null payload low word
+                emitter.instruction(&format!("mov rdi, {}", NULL_SENTINEL));    // use the runtime null sentinel as the boxed null payload low word
                 emitter.instruction("xor rsi, rsi");                            // null mixed payloads have no high word
                 emitter.instruction("mov rax, 8");                              // runtime tag 8 = null payload for Mixed boxing
                 emitter.instruction("call __rt_mixed_from_value");              // box null into an owned Mixed cell for __set

--- a/src/codegen/stmt/assignments/properties/storage.rs
+++ b/src/codegen/stmt/assignments/properties/storage.rs
@@ -9,10 +9,10 @@
 //! - Property writes must respect declared types, visibility checks, and runtime object layout.
 
 use crate::codegen::abi;
+use crate::codegen::NULL_SENTINEL;
 use crate::codegen::emit::Emitter;
 use crate::types::PhpType;
 
-const NULL_SENTINEL: i64 = 0x7fff_ffff_ffff_fffe;
 /// Sentinel value stored in a property slot's first word to represent `Void`
 /// when the upper word is also zeroed. Chosen to be an invalid pointer
 /// representation that avoids confusing null pointers with uninitialized slots.

--- a/src/codegen/stmt/assignments/properties/storage.rs
+++ b/src/codegen/stmt/assignments/properties/storage.rs
@@ -70,6 +70,12 @@ pub(super) fn store_property_value(emitter: &mut Emitter, object_reg: &str, val_
             abi::emit_load_int_immediate(emitter, temp_reg, 9);
             abi::emit_store_to_address(emitter, temp_reg, object_reg, offset + 8);
         }
+        PhpType::TaggedScalar => {
+            let tag_temp_reg = abi::tertiary_scratch_reg(emitter);
+            abi::emit_pop_reg_pair(emitter, temp_reg, tag_temp_reg);
+            abi::emit_store_to_address(emitter, temp_reg, object_reg, offset);
+            abi::emit_store_to_address(emitter, tag_temp_reg, object_reg, offset + 8);
+        }
         PhpType::Mixed | PhpType::Union(_) | PhpType::Iterable => {
             abi::emit_pop_reg(emitter, temp_reg);
             abi::emit_store_to_address(emitter, temp_reg, object_reg, offset);
@@ -206,6 +212,9 @@ pub(super) fn store_referenced_value(
         PhpType::Resource(_) => {
             abi::emit_pop_reg(emitter, temp_reg);
             abi::emit_store_to_address(emitter, temp_reg, pointer_reg, 0);
+        }
+        PhpType::TaggedScalar => {
+            unreachable!("TaggedScalar must be narrowed or boxed before a by-reference store")
         }
         PhpType::Mixed | PhpType::Union(_) | PhpType::Iterable => {
             abi::emit_pop_reg(emitter, temp_reg);

--- a/src/codegen/stmt/io.rs
+++ b/src/codegen/stmt/io.rs
@@ -59,19 +59,31 @@ pub(crate) fn emit_expr_to_stdout(
             emitter.label(&skip_label);
         }
         PhpType::Int => {
-            let skip_label = ctx.next_label("echo_skip_null");
-            let sentinel_reg = abi::symbol_scratch_reg(emitter);
-            abi::emit_load_int_immediate(emitter, sentinel_reg, NULL_SENTINEL);
-            match emitter.target.arch {
-                Arch::AArch64 => {
-                    emitter.instruction(&format!("cmp {}, {}", abi::int_result_reg(emitter), sentinel_reg)); // compare integer value against the runtime null sentinel
-                    emitter.instruction(&format!("b.eq {}", skip_label));       // skip echo if value is the null sentinel
+            if crate::codegen::sentinels::null_repr_is_tagged() {
+                // Under the tagged representation a plain Int is never null, so the full
+                // i64 range (including PHP_INT_MAX - 1) is printable without a skip check.
+                abi::emit_write_stdout(emitter, &ty);
+            } else {
+                let skip_label = ctx.next_label("echo_skip_null");
+                let sentinel_reg = abi::symbol_scratch_reg(emitter);
+                abi::emit_load_int_immediate(emitter, sentinel_reg, NULL_SENTINEL);
+                match emitter.target.arch {
+                    Arch::AArch64 => {
+                        emitter.instruction(&format!("cmp {}, {}", abi::int_result_reg(emitter), sentinel_reg)); // compare integer value against the runtime null sentinel
+                        emitter.instruction(&format!("b.eq {}", skip_label));   // skip echo if value is the null sentinel
+                    }
+                    Arch::X86_64 => {
+                        emitter.instruction(&format!("cmp {}, {}", abi::int_result_reg(emitter), sentinel_reg)); // compare integer value against the runtime null sentinel
+                        emitter.instruction(&format!("je {}", skip_label));     // skip echo if value is the null sentinel
+                    }
                 }
-                Arch::X86_64 => {
-                    emitter.instruction(&format!("cmp {}, {}", abi::int_result_reg(emitter), sentinel_reg)); // compare integer value against the runtime null sentinel
-                    emitter.instruction(&format!("je {}", skip_label));         // skip echo if value is the null sentinel
-                }
+                abi::emit_write_stdout(emitter, &ty);
+                emitter.label(&skip_label);
             }
+        }
+        PhpType::TaggedScalar => {
+            let skip_label = ctx.next_label("echo_skip_null");
+            crate::codegen::sentinels::emit_branch_if_tagged_scalar_null(emitter, &skip_label);
             abi::emit_write_stdout(emitter, &ty);
             emitter.label(&skip_label);
         }
@@ -154,6 +166,11 @@ fn stabilize_x86_64_echo_result(emitter: &mut Emitter, ty: &PhpType) {
         PhpType::Float => {
             abi::emit_push_float_reg(emitter, abi::float_result_reg(emitter));  // spill floating-point x86_64 echo results through a temporary slot before helper calls consume them
             abi::emit_pop_float_reg(emitter, abi::float_result_reg(emitter));   // reload the stabilized x86_64 echo result back into the canonical floating-point result register
+        }
+        PhpType::TaggedScalar => {
+            let tag_reg = crate::codegen::sentinels::tagged_scalar_tag_reg(emitter);
+            abi::emit_push_reg_pair(emitter, abi::int_result_reg(emitter), tag_reg); // spill the tagged scalar payload/tag pair through a temporary slot before helper calls consume them
+            abi::emit_pop_reg_pair(emitter, abi::int_result_reg(emitter), tag_reg); // reload the stabilized tagged scalar payload/tag pair
         }
         PhpType::Str | PhpType::Void | PhpType::Never => {}
     }

--- a/src/codegen/stmt/io.rs
+++ b/src/codegen/stmt/io.rs
@@ -9,6 +9,7 @@
 //! - String temporaries must stay alive through the write and be released only when this path owns them.
 
 use super::super::abi;
+use super::super::NULL_SENTINEL;
 use super::super::context::Context;
 use super::super::data_section::DataSection;
 use super::super::emit::Emitter;
@@ -60,7 +61,7 @@ pub(crate) fn emit_expr_to_stdout(
         PhpType::Int => {
             let skip_label = ctx.next_label("echo_skip_null");
             let sentinel_reg = abi::symbol_scratch_reg(emitter);
-            abi::emit_load_int_immediate(emitter, sentinel_reg, 0x7fff_ffff_ffff_fffe);
+            abi::emit_load_int_immediate(emitter, sentinel_reg, NULL_SENTINEL);
             match emitter.target.arch {
                 Arch::AArch64 => {
                     emitter.instruction(&format!("cmp {}, {}", abi::int_result_reg(emitter), sentinel_reg)); // compare integer value against the runtime null sentinel

--- a/src/codegen/stmt/null_coalesce_assign.rs
+++ b/src/codegen/stmt/null_coalesce_assign.rs
@@ -9,6 +9,7 @@
 //! - The left-hand side must be evaluated once and only assigned when the observed value is null.
 
 use super::super::abi;
+use super::super::NULL_SENTINEL;
 use super::super::emit::Emitter;
 use crate::parser::ast::{Expr, ExprKind, StaticReceiver};
 use crate::types::PhpType;
@@ -250,7 +251,7 @@ pub(crate) fn emit_branch_if_result_non_null(
     }
 
     let null_reg = abi::symbol_scratch_reg(emitter);
-    abi::emit_load_int_immediate(emitter, null_reg, 0x7fff_ffff_ffff_fffe_u64 as i64);
+    abi::emit_load_int_immediate(emitter, null_reg, NULL_SENTINEL);
     if ty == &PhpType::Float {
         match emitter.target.arch {
             crate::codegen::platform::Arch::AArch64 => {

--- a/src/codegen/stmt/null_coalesce_assign.rs
+++ b/src/codegen/stmt/null_coalesce_assign.rs
@@ -235,6 +235,14 @@ pub(crate) fn emit_branch_if_result_non_null(
     keep_label: &str,
     emitter: &mut Emitter,
 ) {
+    if matches!(ty, PhpType::TaggedScalar) {
+        crate::codegen::sentinels::emit_branch_if_tagged_scalar_not_null(emitter, keep_label);
+        return;
+    }
+    if matches!(ty, PhpType::Int) && crate::codegen::sentinels::null_repr_is_tagged() {
+        abi::emit_jump(emitter, keep_label);                                    // a plain Int is never null under the tagged representation; always keep it
+        return;
+    }
     if matches!(ty, PhpType::Mixed | PhpType::Union(_)) {
         abi::emit_call_label(emitter, "__rt_mixed_unbox");                      // inspect the boxed value tag before deciding whether ??= should store
         match emitter.target.arch {

--- a/src/codegen/stmt/storage/extern_globals.rs
+++ b/src/codegen/stmt/storage/extern_globals.rs
@@ -45,6 +45,7 @@ pub(super) fn emit_extern_global_store(emitter: &mut Emitter, name: &str, ty: &P
         | PhpType::Iterable
         | PhpType::Mixed
         | PhpType::Union(_)
+        | PhpType::TaggedScalar
         | PhpType::Array(_)
         | PhpType::AssocArray { .. }
         | PhpType::Object(_) => {
@@ -90,6 +91,7 @@ pub(super) fn emit_extern_global_load(emitter: &mut Emitter, name: &str, ty: &Ph
         | PhpType::Iterable
         | PhpType::Mixed
         | PhpType::Union(_)
+        | PhpType::TaggedScalar
         | PhpType::Array(_)
         | PhpType::AssocArray { .. }
         | PhpType::Object(_) => {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -49,6 +49,7 @@ pub(crate) fn compile(config: CliConfig) {
         defines,
     } = config;
     let filename = filename.as_str();
+    codegen::set_null_repr(null_repr);
     let parent = Path::new(filename).parent().unwrap_or(Path::new("."));
     let output_paths = output_paths(filename);
     let mut timings = CompileTimings::new(emit_timings);

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -37,6 +37,7 @@ pub(crate) fn compile(config: CliConfig) {
         heap_size,
         gc_stats,
         heap_debug,
+        null_repr,
         emit_asm,
         check_only,
         emit_timings,
@@ -222,6 +223,7 @@ pub(crate) fn compile(config: CliConfig) {
         heap_debug,
         target,
         requires_elephc_tls,
+        null_repr,
     );
     timings.record_since("codegen", phase_started);
 

--- a/src/types/checker/extern_decl.rs
+++ b/src/types/checker/extern_decl.rs
@@ -75,6 +75,7 @@ impl Checker {
                 | PhpType::Iterable
                 | PhpType::Mixed
                 | PhpType::Union(_)
+                | PhpType::TaggedScalar
                 | PhpType::Array(_)
                 | PhpType::AssocArray { .. }
                 | PhpType::Object(_)

--- a/src/types/checker/functions/resolution/specialization.rs
+++ b/src/types/checker/functions/resolution/specialization.rs
@@ -220,10 +220,9 @@ impl Checker {
                     .get(seen_idx)
                     .copied()
                     .unwrap_or(false)
-                && !matches!(
-                    actual_ty,
-                    PhpType::Void | PhpType::Never | PhpType::Callable
-                )
+                && !matches!(actual_ty, PhpType::Never | PhpType::Callable)
+                && (!matches!(actual_ty, PhpType::Void)
+                    || crate::codegen::sentinels::null_repr_is_tagged())
             {
                 let key = (name.to_string(), seen_idx);
                 let seen = self.param_specialization_seen.contains(&key);

--- a/src/types/checker/functions/returns.rs
+++ b/src/types/checker/functions/returns.rs
@@ -442,6 +442,14 @@ impl Checker {
     pub(crate) fn union_param_type(a: &PhpType, b: &PhpType) -> PhpType {
         match (a, b) {
             _ if a == b => a.clone(),
+            // Under the tagged null representation a null call-site argument makes the
+            // parameter genuinely nullable: widen scalar params to int|null instead of
+            // riding null in as the in-band sentinel of a plain Int.
+            (PhpType::Void, PhpType::Int) | (PhpType::Int, PhpType::Void)
+                if crate::codegen::sentinels::null_repr_is_tagged() =>
+            {
+                PhpType::Union(vec![PhpType::Int, PhpType::Void])
+            }
             (PhpType::Void | PhpType::Never, other) | (other, PhpType::Void | PhpType::Never) => {
                 other.clone()
             }

--- a/src/types/model.rs
+++ b/src/types/model.rs
@@ -36,6 +36,12 @@ pub enum PhpType {
     Pointer(Option<String>), // None = opaque ptr, Some("Class") = typed ptr<Class>
     Resource(Option<String>), // None = generic resource, Some("stream") = file/stdio stream
     Union(Vec<PhpType>),
+    /// Codegen-internal inline nullable scalar: two words `{payload, tag}` with no heap
+    /// allocation. The tag reuses the runtime value tag scheme (0 = int, 8 = null), so the
+    /// pair is word-compatible with a boxed Mixed cell. The checker never produces this
+    /// type; codegen funnels construct it from `int|null` unions only under
+    /// `NullRepr::Tagged`. Under the default sentinel representation it never exists.
+    TaggedScalar,
 }
 
 impl PhpType {
@@ -78,6 +84,7 @@ impl PhpType {
             PhpType::Pointer(_) => 8,        // 64-bit address
             PhpType::Resource(_) => 8,       // runtime resource id / native handle
             PhpType::Union(_) => 8,          // boxed runtime-tagged payload (same storage as Mixed)
+            PhpType::TaggedScalar => 16,     // inline nullable scalar: payload word + tag word
         }
     }
 
@@ -101,6 +108,7 @@ impl PhpType {
             PhpType::Pointer(_) => 1,
             PhpType::Resource(_) => 1,
             PhpType::Union(_) => 1,
+            PhpType::TaggedScalar => 2,
         }
     }
 
@@ -158,6 +166,7 @@ impl fmt::Display for PhpType {
             PhpType::Pointer(None) => write!(f, "ptr"),
             PhpType::Resource(Some(kind)) => write!(f, "resource<{}>", kind),
             PhpType::Resource(None) => write!(f, "resource"),
+            PhpType::TaggedScalar => write!(f, "int|null"),
             PhpType::Union(members) => {
                 for (i, member) in members.iter().enumerate() {
                     if i > 0 {

--- a/tests/codegen/io/streams.rs
+++ b/tests/codegen/io/streams.rs
@@ -2871,14 +2871,17 @@ fn test_fopen_ftp_invalid_url_is_false() {
     assert_eq!(out, "false");
 }
 
-/// Minimal one-shot HTTP/1.0 server for the `http://` codegen test. Binds the
-/// port immediately, then serves one client on a thread: it drains the request
-/// headers and writes a close-framed response whose body is `content`.
-fn spawn_http_server(port: u16, content: &'static [u8]) -> std::thread::JoinHandle<()> {
+/// Minimal one-shot HTTP/1.0 server for the `http://` codegen test. Binds an
+/// ephemeral port immediately (returned alongside the handle, so parallel and
+/// orphaned test processes can never collide), then serves one client on a
+/// thread: it drains the request headers and writes a close-framed response
+/// whose body is `content`.
+fn spawn_http_server(content: &'static [u8]) -> (std::thread::JoinHandle<()>, u16) {
     use std::io::{Read, Write};
     let listener =
-        std::net::TcpListener::bind(("127.0.0.1", port)).expect("http test: bind port");
-    std::thread::spawn(move || {
+        std::net::TcpListener::bind(("127.0.0.1", 0)).expect("http test: bind port");
+    let port = listener.local_addr().expect("http test: local addr").port();
+    let handle = std::thread::spawn(move || {
         let (mut sock, _) = listener.accept().expect("http test: accept");
         // Drain the request up to the blank line that ends the headers.
         let mut req = Vec::new();
@@ -2896,17 +2899,19 @@ fn spawn_http_server(port: u16, content: &'static [u8]) -> std::thread::JoinHand
         sock.write_all(header.as_bytes()).unwrap();
         sock.write_all(content).unwrap();
         // Dropping the socket closes the connection so the client sees EOF.
-    })
+    });
+    (handle, port)
 }
 
 /// Same shape as `spawn_http_server` but echoes the received request bytes
 /// back as the response body so tests can assert on the exact wire format
 /// (method, path, headers, AND body) the elephc-built request produced.
-fn spawn_http_echo_server(port: u16) -> std::thread::JoinHandle<()> {
+fn spawn_http_echo_server() -> (std::thread::JoinHandle<()>, u16) {
     use std::io::{Read, Write};
     let listener =
-        std::net::TcpListener::bind(("127.0.0.1", port)).expect("http test: bind port");
-    std::thread::spawn(move || {
+        std::net::TcpListener::bind(("127.0.0.1", 0)).expect("http test: bind port");
+    let port = listener.local_addr().expect("http test: local addr").port();
+    let handle = std::thread::spawn(move || {
         let (mut sock, _) = listener.accept().expect("http test: accept");
         let mut req = Vec::new();
         let mut byte = [0u8; 1];
@@ -2942,7 +2947,8 @@ fn spawn_http_echo_server(port: u16) -> std::thread::JoinHandle<()> {
         );
         sock.write_all(header.as_bytes()).unwrap();
         sock.write_all(&req).unwrap();
-    })
+    });
+    (handle, port)
 }
 
 /// Serves two HTTP responses on the same port: the first is a 302 with a
@@ -2950,15 +2956,17 @@ fn spawn_http_echo_server(port: u16) -> std::thread::JoinHandle<()> {
 /// the second is a 200 with `body`. Used to exercise the follow_location
 /// path through both relative and absolute Location values.
 fn spawn_http_redirect_server(
-    port: u16,
-    location: &'static str,
+    location: &str,
     final_path: &'static str,
     body: &'static [u8],
-) -> std::thread::JoinHandle<()> {
+) -> (std::thread::JoinHandle<()>, u16) {
     use std::io::{Read, Write};
     let listener =
-        std::net::TcpListener::bind(("127.0.0.1", port)).expect("http redirect: bind port");
-    std::thread::spawn(move || {
+        std::net::TcpListener::bind(("127.0.0.1", 0)).expect("http redirect: bind port");
+    let port = listener.local_addr().expect("http redirect: local addr").port();
+    // the absolute-URL fixture needs the ephemeral port inside the Location header
+    let location = location.replace("{PORT}", &port.to_string());
+    let handle = std::thread::spawn(move || {
         let read_until_double_crlf = |sock: &mut std::net::TcpStream| {
             let mut req = Vec::new();
             let mut byte = [0u8; 1];
@@ -2995,7 +3003,8 @@ fn spawn_http_redirect_server(
         );
         let _ = s2.write_all(r2.as_bytes());
         let _ = s2.write_all(body);
-    })
+    });
+    (handle, port)
 }
 
 /// Naive bytes-substring search — avoids pulling in extra crates for the
@@ -3061,13 +3070,15 @@ MYQgldWOaXCRMQsHgapn+orK7iF89zA+4UDACVNiHEYS9q8CGynLckruklWdiyi3
 ";
 
 /// Minimal one-shot HTTPS server for deterministic `https://` wrapper tests.
-fn spawn_https_server(port: u16, content: &'static [u8]) -> std::thread::JoinHandle<()> {
+/// Binds an ephemeral port and returns it alongside the handle.
+fn spawn_https_server(content: &'static [u8]) -> (std::thread::JoinHandle<()>, u16) {
     use std::io::{Read, Write};
     use std::sync::Arc;
 
     let listener =
-        std::net::TcpListener::bind(("127.0.0.1", port)).expect("https test: bind port");
-    std::thread::spawn(move || {
+        std::net::TcpListener::bind(("127.0.0.1", 0)).expect("https test: bind port");
+    let port = listener.local_addr().expect("https test: local addr").port();
+    let handle = std::thread::spawn(move || {
         let _ = rustls::crypto::ring::default_provider().install_default();
         let mut cert_reader = TEST_HTTPS_CERT_PEM.as_bytes();
         let certs = rustls_pemfile::certs(&mut cert_reader)
@@ -3094,7 +3105,8 @@ fn spawn_https_server(port: u16, content: &'static [u8]) -> std::thread::JoinHan
         tls.write_all(headers.as_bytes()).expect("https test: write headers");
         tls.write_all(content).expect("https test: write body");
         tls.flush().expect("https test: flush response");
-    })
+    });
+    (handle, port)
 }
 
 /// Verifies compiled PHP output for fopen http method default is get.
@@ -3103,14 +3115,15 @@ fn test_fopen_http_method_default_is_get() {
     // Without a stream context, the request method falls back to "GET".
     // The echo server reflects the request bytes; the response body must
     // start with "GET /path HTTP/1.0\r\n".
-    let _server = spawn_http_echo_server(54995);
+    let (_server, port) = spawn_http_echo_server();
     let out = compile_and_run(
-        r#"<?php
-$f = fopen("http://127.0.0.1:54995/echo", "r");
+        &r#"<?php
+$f = fopen("http://127.0.0.1:PHP_TEST_PORT/echo", "r");
 $req = stream_get_contents($f);
 fclose($f);
 echo substr($req, 0, 19);
-"#,
+"#
+        .replace("PHP_TEST_PORT", &port.to_string()),
     );
     assert_eq!(out, "GET /echo HTTP/1.0\r");
 }
@@ -3121,15 +3134,16 @@ fn test_fopen_http_method_overrides_via_context() {
     // Phase 11 B2: stream_context_create(['http' => ['method' => 'POST']])
     // propagates through __rt_http_build_request → the request line
     // starts with "POST" instead of the default "GET".
-    let _server = spawn_http_echo_server(54996);
+    let (_server, port) = spawn_http_echo_server();
     let out = compile_and_run(
-        r#"<?php
+        &r#"<?php
 stream_context_set_option(stream_context_get_default(), "http", "method", "POST");
-$f = fopen("http://127.0.0.1:54996/api", "r");
+$f = fopen("http://127.0.0.1:PHP_TEST_PORT/api", "r");
 $req = stream_get_contents($f);
 fclose($f);
 echo substr($req, 0, 21);
-"#,
+"#
+        .replace("PHP_TEST_PORT", &port.to_string()),
     );
     assert_eq!(out, "POST /api HTTP/1.0\r\nH");
 }
@@ -3140,15 +3154,16 @@ fn test_fopen_http_header_inserted_via_context() {
     // Phase 11 B2: stream_context_create(['http' => ['header' => ...]])
     // propagates through __rt_http_build_request — the supplied header
     // line lands between the Host: line and the Connection: close line.
-    let _server = spawn_http_echo_server(54997);
+    let (_server, port) = spawn_http_echo_server();
     let out = compile_and_run(
-        r#"<?php
+        &r#"<?php
 stream_context_set_option(stream_context_get_default(), "http", "header", "X-Trace: abc");
-$f = fopen("http://127.0.0.1:54997/path", "r");
+$f = fopen("http://127.0.0.1:PHP_TEST_PORT/path", "r");
 $req = stream_get_contents($f);
 fclose($f);
 echo strpos($req, "\r\nX-Trace: abc\r\n") !== false ? "has-header" : "no-header";
-"#,
+"#
+        .replace("PHP_TEST_PORT", &port.to_string()),
     );
     assert_eq!(out, "has-header");
 }
@@ -3159,17 +3174,18 @@ fn test_fopen_http_content_only_emits_body() {
     // Reduced repro of the POST + content gap: set only ['http']['content']
     // without 'method'. If this passes, the bug is in set_option_4's two-call
     // sub-hash merge; if this fails, it's in the content lookup or emission.
-    let _server = spawn_http_echo_server(53999);
+    let (_server, port) = spawn_http_echo_server();
     let out = compile_and_run(
-        r#"<?php
+        &r#"<?php
 stream_context_set_option(stream_context_get_default(), "http", "content", "x=y");
-$f = fopen("http://127.0.0.1:53999/p", "r");
+$f = fopen("http://127.0.0.1:PHP_TEST_PORT/p", "r");
 $req = stream_get_contents($f);
 fclose($f);
 $has_clen = strpos($req, "\r\nContent-Length: 3\r\n") !== false;
 $has_body = strpos($req, "\r\n\r\nx=y") !== false;
 echo ($has_clen ? "clen-ok" : "clen-MISSING") . "|" . ($has_body ? "body-ok" : "body-MISSING");
-"#,
+"#
+        .replace("PHP_TEST_PORT", &port.to_string()),
     );
     assert_eq!(out, "clen-ok|body-ok");
 }
@@ -3181,18 +3197,19 @@ fn test_fopen_http_content_post_body_with_content_length() {
     // ['method' => 'POST'] propagates a Content-Length: N header and writes
     // the body bytes after the blank line. The echo server reflects the
     // raw request bytes so we can grep for both the header and the body.
-    let _server = spawn_http_echo_server(53998);
+    let (_server, port) = spawn_http_echo_server();
     let out = compile_and_run(
-        r#"<?php
+        &r#"<?php
 stream_context_set_option(stream_context_get_default(), "http", "method", "POST");
 stream_context_set_option(stream_context_get_default(), "http", "content", "foo=bar&baz=qux");
-$f = fopen("http://127.0.0.1:53998/submit", "r");
+$f = fopen("http://127.0.0.1:PHP_TEST_PORT/submit", "r");
 $req = stream_get_contents($f);
 fclose($f);
 $has_clen = strpos($req, "\r\nContent-Length: 15\r\n") !== false;
 $has_body = strpos($req, "\r\n\r\nfoo=bar&baz=qux") !== false;
 echo ($has_clen ? "clen-ok" : "clen-MISSING") . "|" . ($has_body ? "body-ok" : "body-MISSING");
-"#,
+"#
+        .replace("PHP_TEST_PORT", &port.to_string()),
     );
     assert_eq!(out, "clen-ok|body-ok");
 }
@@ -3202,14 +3219,14 @@ echo ($has_clen ? "clen-ok" : "clen-MISSING") . "|" . ($has_body ? "body-ok" : "
 fn test_fopen_http_retrieves_body() {
     // fopen("http://...") issues an HTTP GET and exposes the response body
     // with the headers stripped as a readable stream.
-    let _server = spawn_http_server(54971, b"body delivered over http");
-    let out = compile_and_run(
+    let (_server, port) = spawn_http_server(b"body delivered over http");
+    let out = compile_and_run(&format!(
         r#"<?php
-$f = fopen("http://127.0.0.1:54971/page.txt", "r");
+$f = fopen("http://127.0.0.1:{port}/page.txt", "r");
 echo stream_get_contents($f);
 fclose($f);
-"#,
-    );
+"#
+    ));
     assert_eq!(out, "body delivered over http");
 }
 
@@ -3219,12 +3236,12 @@ fclose($f);
 /// The owned-heap copy (via `__rt_str_persist`) survives the concat below.
 #[test]
 fn test_file_get_contents_over_http() {
-    let _server = spawn_http_server(54973, b"fgc over http body");
-    let out = compile_and_run(
+    let (_server, port) = spawn_http_server(b"fgc over http body");
+    let out = compile_and_run(&format!(
         r#"<?php
-echo "[" . file_get_contents("http://127.0.0.1:54973/page.txt") . "]";
-"#,
-    );
+echo "[" . file_get_contents("http://127.0.0.1:{port}/page.txt") . "]";
+"#
+    ));
     assert_eq!(out, "[fgc over http body]");
 }
 
@@ -3232,13 +3249,13 @@ echo "[" . file_get_contents("http://127.0.0.1:54973/page.txt") . "]";
 /// through the HTTP wrapper instead of the plain filesystem reader.
 #[test]
 fn test_file_get_contents_dynamic_http_url() {
-    let _server = spawn_http_server(54974, b"dynamic fgc over http");
-    let out = compile_and_run(
+    let (_server, port) = spawn_http_server(b"dynamic fgc over http");
+    let out = compile_and_run(&format!(
         r#"<?php
-$url = "http://127.0.0.1:54974/page.txt";
+$url = "http://127.0.0.1:{port}/page.txt";
 echo "[" . file_get_contents($url) . "]";
-"#,
-    );
+"#
+    ));
     assert_eq!(out, "[dynamic fgc over http]");
 }
 
@@ -3246,13 +3263,13 @@ echo "[" . file_get_contents($url) . "]";
 /// proving the literal HTTPS wrapper path returns an owned response body.
 #[test]
 fn test_file_get_contents_over_https_local_server() {
-    let _server = spawn_https_server(54975, b"fgc over local https");
-    let out = compile_and_run(
+    let (_server, port) = spawn_https_server(b"fgc over local https");
+    let out = compile_and_run(&format!(
         r#"<?php
 stream_context_set_option(stream_context_get_default(), "ssl", "verify_peer", "0");
-echo "[" . file_get_contents("https://127.0.0.1:54975/page.txt") . "]";
-"#,
-    );
+echo "[" . file_get_contents("https://127.0.0.1:{port}/page.txt") . "]";
+"#
+    ));
     assert_eq!(out, "[fgc over local https]");
 }
 
@@ -3260,14 +3277,14 @@ echo "[" . file_get_contents("https://127.0.0.1:54975/page.txt") . "]";
 /// `https://`, covering the non-literal dynamic URL dispatcher.
 #[test]
 fn test_file_get_contents_dynamic_https_local_server() {
-    let _server = spawn_https_server(54976, b"dynamic fgc over local https");
-    let out = compile_and_run(
+    let (_server, port) = spawn_https_server(b"dynamic fgc over local https");
+    let out = compile_and_run(&format!(
         r#"<?php
 stream_context_set_option(stream_context_get_default(), "ssl", "verify_peer", "0");
-$url = "https://127.0.0.1:54976/page.txt";
+$url = "https://127.0.0.1:{port}/page.txt";
 echo "[" . file_get_contents($url) . "]";
-"#,
-    );
+"#
+    ));
     assert_eq!(out, "[dynamic fgc over local https]");
 }
 
@@ -3305,16 +3322,16 @@ echo $r === false ? "false" : "got";
 fn test_fopen_http_follow_location_relative_path() {
     // 302 with a Location: /new redirects to the same host. The redirect
     // loop in __rt_http_open re-issues GET /new and serves the second body.
-    let _server = spawn_http_redirect_server(53901, "/new", "/new", b"after-relative-redirect");
-    let out = compile_and_run(
+    let (_server, port) = spawn_http_redirect_server("/new", "/new", b"after-relative-redirect");
+    let out = compile_and_run(&format!(
         r#"<?php
 stream_context_set_option(stream_context_get_default(), "http", "follow_location", "1");
 stream_context_set_option(stream_context_get_default(), "http", "max_redirects", "5");
-$f = fopen("http://127.0.0.1:53901/start", "r");
+$f = fopen("http://127.0.0.1:{port}/start", "r");
 echo stream_get_contents($f);
 fclose($f);
-"#,
-    );
+"#
+    ));
     assert_eq!(out, "after-relative-redirect");
 }
 
@@ -3326,21 +3343,20 @@ fn test_fopen_http_follow_location_absolute_same_host() {
     // redirect. The fixture rejects any path other than /final, so this
     // test fails if the host:port parsing leaves stray prefix bytes in the
     // redirect path buffer.
-    let _server = spawn_http_redirect_server(
-        53902,
-        "http://127.0.0.1:53902/final",
+    let (_server, port) = spawn_http_redirect_server(
+        "http://127.0.0.1:{PORT}/final",
         "/final",
         b"after-absolute-redirect",
     );
-    let out = compile_and_run(
+    let out = compile_and_run(&format!(
         r#"<?php
 stream_context_set_option(stream_context_get_default(), "http", "follow_location", "1");
 stream_context_set_option(stream_context_get_default(), "http", "max_redirects", "5");
-$f = fopen("http://127.0.0.1:53902/start", "r");
+$f = fopen("http://127.0.0.1:{port}/start", "r");
 echo stream_get_contents($f);
 fclose($f);
-"#,
-    );
+"#
+    ));
     assert_eq!(out, "after-absolute-redirect");
 }
 
@@ -3351,22 +3367,21 @@ fn test_fopen_http_follow_location_cross_host_is_not_followed() {
     // (cross-host redirect requires reconnecting, deferred for v1). The
     // initial 302 response is surfaced as-is; the body is empty because the
     // redirect response itself has Content-Length: 0.
-    let _server = spawn_http_redirect_server(
-        53903,
+    let (_server, port) = spawn_http_redirect_server(
         "http://other-host.invalid:80/whatever",
         "/never-reached",
         b"unreachable",
     );
-    let out = compile_and_run(
+    let out = compile_and_run(&format!(
         r#"<?php
 stream_context_set_option(stream_context_get_default(), "http", "follow_location", "1");
 stream_context_set_option(stream_context_get_default(), "http", "max_redirects", "5");
 stream_context_set_option(stream_context_get_default(), "http", "ignore_errors", "1");
-$f = fopen("http://127.0.0.1:53903/start", "r");
+$f = fopen("http://127.0.0.1:{port}/start", "r");
 echo strlen(stream_get_contents($f));
 fclose($f);
-"#,
-    );
+"#
+    ));
     assert_eq!(out, "0");
 }
 
@@ -5791,12 +5806,12 @@ fn test_fopen_http_content_emits_content_length_header() {
     // landed the body append but left the Content-Length emission stubbed
     // with a TEMPORARILY-DISABLED branch on ARM64; this verifies the
     // re-enabled path puts the right bytes on the wire.)
-    let _server = spawn_http_echo_server(56001);
+    let (_server, port) = spawn_http_echo_server();
     let out = compile_and_run(
-        r#"<?php
+        &r#"<?php
 stream_context_set_option(stream_context_get_default(), "http", "method", "POST");
 stream_context_set_option(stream_context_get_default(), "http", "content", "hello body");
-$f = fopen("http://127.0.0.1:56001/", "r");
+$f = fopen("http://127.0.0.1:PHP_TEST_PORT/", "r");
 $req = stream_get_contents($f);
 fclose($f);
 // The echo server replays the request headers (bytes up to the blank
@@ -5809,7 +5824,8 @@ for ($i = 0; $i + $nlen <= strlen($req); $i++) {
     if (substr($req, $i, $nlen) === $needle) { $found = true; break; }
 }
 echo $found ? "ok" : "MISS:" . strlen($req);
-"#,
+"#
+        .replace("PHP_TEST_PORT", &port.to_string()),
     );
     assert_eq!(out, "ok");
 }
@@ -5854,11 +5870,11 @@ echo (is_string($r) ? "s" : "n") . "|" . ($miss === false ? "f" : "x");
 /// Verifies compiled PHP output for fopen http user agent in request.
 #[test]
 fn test_fopen_http_user_agent_in_request() {
-    let _server = spawn_http_echo_server(56010);
+    let (_server, port) = spawn_http_echo_server();
     let out = compile_and_run(
-        r#"<?php
+        &r#"<?php
 stream_context_set_option(stream_context_get_default(), "http", "user_agent", "MyApp/2.0");
-$f = fopen("http://127.0.0.1:56010/", "r");
+$f = fopen("http://127.0.0.1:PHP_TEST_PORT/", "r");
 $req = stream_get_contents($f);
 fclose($f);
 $needle = "User-Agent: MyApp/2.0";
@@ -5868,7 +5884,8 @@ for ($i = 0; $i + $nlen <= strlen($req); $i++) {
     if (substr($req, $i, $nlen) === $needle) { $found = true; break; }
 }
 echo $found ? "ok" : "MISS";
-"#,
+"#
+        .replace("PHP_TEST_PORT", &port.to_string()),
     );
     assert_eq!(out, "ok");
 }
@@ -5876,11 +5893,11 @@ echo $found ? "ok" : "MISS";
 /// Verifies compiled PHP output for fopen http protocol version 1 1.
 #[test]
 fn test_fopen_http_protocol_version_1_1() {
-    let _server = spawn_http_echo_server(56011);
+    let (_server, port) = spawn_http_echo_server();
     let out = compile_and_run(
-        r#"<?php
+        &r#"<?php
 stream_context_set_option(stream_context_get_default(), "http", "protocol_version", "1.1");
-$f = fopen("http://127.0.0.1:56011/", "r");
+$f = fopen("http://127.0.0.1:PHP_TEST_PORT/", "r");
 $req = stream_get_contents($f);
 fclose($f);
 $needle = "HTTP/1.1";
@@ -5890,7 +5907,8 @@ for ($i = 0; $i + $nlen <= strlen($req); $i++) {
     if (substr($req, $i, $nlen) === $needle) { $found = true; break; }
 }
 echo $found ? "ok" : "MISS";
-"#,
+"#
+        .replace("PHP_TEST_PORT", &port.to_string()),
     );
     assert_eq!(out, "ok");
 }
@@ -5912,21 +5930,22 @@ fclose($f);
 #[test]
 #[ignore = "reliable standalone but flakes in parallel sweep (fixed-port echo server, port-binding race); run with --ignored --test-threads=1. The request_fulluri absolute-form URI now includes the non-default port (fixed in parse_http_url)"]
 fn test_fopen_http_request_fulluri_in_request_line() {
-    let _server = spawn_http_echo_server(56012);
+    let (_server, port) = spawn_http_echo_server();
     let out = compile_and_run(
-        r#"<?php
+        &r#"<?php
 stream_context_set_option(stream_context_get_default(), "http", "request_fulluri", "1");
-$f = fopen("http://127.0.0.1:56012/path", "r");
+$f = fopen("http://127.0.0.1:PHP_TEST_PORT/path", "r");
 $req = stream_get_contents($f);
 fclose($f);
-$needle = "GET http://127.0.0.1:56012/path HTTP/1.0";
+$needle = "GET http://127.0.0.1:PHP_TEST_PORT/path HTTP/1.0";
 $nlen = strlen($needle);
 $found = false;
 for ($i = 0; $i + $nlen <= strlen($req); $i++) {
     if (substr($req, $i, $nlen) === $needle) { $found = true; break; }
 }
 echo $found ? "ok" : "MISS";
-"#,
+"#
+        .replace("PHP_TEST_PORT", &port.to_string()),
     );
     assert_eq!(out, "ok");
 }

--- a/tests/codegen/mod.rs
+++ b/tests/codegen/mod.rs
@@ -12,6 +12,7 @@ mod fibers;
 mod buffers;
 mod preprocessor;
 mod namespaces;
+mod null_sentinel;
 mod case_insensitive_symbols;
 mod cli;
 mod benchmarks;

--- a/tests/codegen/null_sentinel.rs
+++ b/tests/codegen/null_sentinel.rs
@@ -14,3 +14,5 @@ use crate::support::*;
 mod benches;
 #[path = "null_sentinel/repros.rs"]
 mod repros;
+#[path = "null_sentinel/tagged.rs"]
+mod tagged;

--- a/tests/codegen/null_sentinel.rs
+++ b/tests/codegen/null_sentinel.rs
@@ -1,0 +1,16 @@
+//! Purpose:
+//! Groups the null-sentinel collision integration test submodules into the parent suite.
+//!
+//! Called from:
+//! - `cargo test` through Rust's test harness.
+//!
+//! Key details:
+//! - Covers the in-band null sentinel (`PHP_INT_MAX - 1` = `0x7fff_ffff_ffff_fffe`) colliding
+//!   with the real integer of the same bit pattern in unboxed scalar slots.
+
+use crate::support::*;
+
+#[path = "null_sentinel/benches.rs"]
+mod benches;
+#[path = "null_sentinel/repros.rs"]
+mod repros;

--- a/tests/codegen/null_sentinel/benches.rs
+++ b/tests/codegen/null_sentinel/benches.rs
@@ -1,0 +1,81 @@
+//! Purpose:
+//! Manual microbenchmarks bounding the cost of the null representation on int-heavy code.
+//! Compares plain-int hot loops against nullable-int (`?int` / array-miss / `??`) hot loops.
+//!
+//! Called from:
+//! - `cargo test -- --ignored null_sentinel::benches` (manual, before/after representation work).
+//!
+//! Key details:
+//! - Timings include compile+assemble+link overhead; fixtures loop enough iterations that the
+//!   native run dominates. Compare like-for-like between NullRepr modes, not absolute numbers.
+
+use super::*;
+use std::time::Instant;
+
+/// Runs a fixture through compile_and_run, asserting output and printing elapsed wall time.
+/// The first run warms OS caches; the second run's timing is reported.
+fn bench(label: &str, source: &str, expected: &str) {
+    compile_and_run(source);
+    let started = Instant::now();
+    let out = compile_and_run(source);
+    let elapsed = started.elapsed();
+    assert_eq!(out, expected);
+    println!("bench {label}: {:?}", elapsed);
+}
+
+/// Baseline: a plain-int hot loop with no null capability anywhere. Phase 3 requires this
+/// to stay at parity with the pre-Tagged baseline (non-nullable ints must remain plain i64).
+#[test]
+#[ignore = "manual microbench: run before/after NullRepr changes"]
+fn bench_plain_int_sum_loop() {
+    let source = r#"<?php
+$sum = 0;
+for ($i = 0; $i < 100000000; $i++) {
+    $sum = $sum + $i;
+}
+echo $sum;
+"#;
+    bench("plain_int_sum_loop", source, "4999999950000000");
+}
+
+/// Nullable-heavy: every iteration routes the accumulator through a `?int` function return
+/// and a `??` default. Bounds the per-value cost of the wide null-capable representation.
+#[test]
+#[ignore = "manual microbench: run before/after NullRepr changes"]
+fn bench_nullable_int_roundtrip_loop() {
+    let source = r#"<?php
+function step(int $i): ?int {
+    if ($i < 0) {
+        return null;
+    }
+    return $i;
+}
+$sum = 0;
+for ($i = 0; $i < 5000000; $i++) {
+    $sum = $sum + (step($i) ?? 0);
+}
+echo $sum;
+"#;
+    bench("nullable_int_roundtrip_loop", source, "12499997500000");
+}
+
+/// Array-read-heavy: sums array<int> elements read back by index. Array element reads are
+/// miss-capable, so this bounds the tagged-read cost on the hottest null-capable producer.
+#[test]
+#[ignore = "manual microbench: run before/after NullRepr changes"]
+fn bench_array_int_read_loop() {
+    let source = r#"<?php
+$a = [];
+for ($i = 0; $i < 1000; $i++) {
+    $a[] = $i;
+}
+$sum = 0;
+for ($r = 0; $r < 100000; $r++) {
+    for ($i = 0; $i < 1000; $i++) {
+        $sum = $sum + $a[$i];
+    }
+}
+echo $sum;
+"#;
+    bench("array_int_read_loop", source, "49950000000");
+}

--- a/tests/codegen/null_sentinel/repros.rs
+++ b/tests/codegen/null_sentinel/repros.rs
@@ -13,7 +13,6 @@ use super::*;
 
 /// Verifies the integer PHP_INT_MAX-1 (== the null sentinel bit pattern) echoes as itself
 /// instead of being suppressed as null.
-#[ignore = "TODO(null-sentinel): misread as null under NullRepr::Sentinel - un-ignore in Phase 2"]
 #[test]
 fn test_int_at_null_sentinel_echoes_as_integer() {
     let out = compile_and_run("<?php echo 9223372036854775806;");
@@ -22,7 +21,6 @@ fn test_int_at_null_sentinel_echoes_as_integer() {
 
 /// Verifies the sentinel-valued integer survives a variable round-trip through echo and
 /// var_dump instead of printing empty / NULL.
-#[ignore = "TODO(null-sentinel): misread as null under NullRepr::Sentinel - un-ignore in Phase 2"]
 #[test]
 fn test_int_at_null_sentinel_var_roundtrips() {
     let out =
@@ -32,7 +30,6 @@ fn test_int_at_null_sentinel_var_roundtrips() {
 
 /// Verifies the sentinel-valued integer read back from an array prints and var_dumps as
 /// int(...), not NULL — the array element store/load path must not misread it as a miss.
-#[ignore = "TODO(null-sentinel): misread as null under NullRepr::Sentinel - un-ignore in Phase 2"]
 #[test]
 fn test_int_at_null_sentinel_in_array_roundtrips() {
     let out = compile_and_run(
@@ -43,7 +40,6 @@ fn test_int_at_null_sentinel_in_array_roundtrips() {
 
 /// Verifies a nullable-int function returning the sentinel-valued integer var_dumps as
 /// int(...), not NULL — the ?int return channel must distinguish the value from null.
-#[ignore = "TODO(null-sentinel): misread as null under NullRepr::Sentinel - un-ignore in Phase 2"]
 #[test]
 fn test_int_at_null_sentinel_nullable_return_is_not_null() {
     let out = compile_and_run(
@@ -53,7 +49,6 @@ fn test_int_at_null_sentinel_nullable_return_is_not_null() {
 }
 
 /// Verifies is_null() rejects the sentinel-valued integer: a real int is never null.
-#[ignore = "TODO(null-sentinel): misread as null under NullRepr::Sentinel - un-ignore in Phase 2"]
 #[test]
 fn test_int_at_null_sentinel_is_not_null() {
     let out = compile_and_run("<?php $x = 9223372036854775806; var_dump(is_null($x));");
@@ -61,7 +56,6 @@ fn test_int_at_null_sentinel_is_not_null() {
 }
 
 /// Verifies ?? does not treat the sentinel-valued integer as null: the left operand wins.
-#[ignore = "TODO(null-sentinel): misread as null under NullRepr::Sentinel - un-ignore in Phase 2"]
 #[test]
 fn test_int_at_null_sentinel_null_coalesce_keeps_value() {
     let out = compile_and_run("<?php $x = 9223372036854775806; echo $x ?? 0;");

--- a/tests/codegen/null_sentinel/repros.rs
+++ b/tests/codegen/null_sentinel/repros.rs
@@ -1,0 +1,80 @@
+//! Purpose:
+//! Regression repros for the null-sentinel collision (`0x7fff_ffff_ffff_fffe`): the integer
+//! `9223372036854775806` (= `PHP_INT_MAX - 1`) must behave as a real int, never as `null`.
+//!
+//! Called from:
+//! - `cargo test` through Rust's test harness.
+//!
+//! Key details:
+//! - PHP-cross-checked expectations (PHP 8.4); the fixture value equals the null sentinel bit
+//!   pattern, deliberately distinct from the uninitialized-property sentinel (`PHP_INT_MAX - 2`).
+
+use super::*;
+
+/// Verifies the integer PHP_INT_MAX-1 (== the null sentinel bit pattern) echoes as itself
+/// instead of being suppressed as null.
+#[ignore = "TODO(null-sentinel): misread as null under NullRepr::Sentinel - un-ignore in Phase 2"]
+#[test]
+fn test_int_at_null_sentinel_echoes_as_integer() {
+    let out = compile_and_run("<?php echo 9223372036854775806;");
+    assert_eq!(out, "9223372036854775806");
+}
+
+/// Verifies the sentinel-valued integer survives a variable round-trip through echo and
+/// var_dump instead of printing empty / NULL.
+#[ignore = "TODO(null-sentinel): misread as null under NullRepr::Sentinel - un-ignore in Phase 2"]
+#[test]
+fn test_int_at_null_sentinel_var_roundtrips() {
+    let out =
+        compile_and_run("<?php $x = 9223372036854775806; echo $x, \"|\"; var_dump($x);");
+    assert_eq!(out, "9223372036854775806|int(9223372036854775806)\n");
+}
+
+/// Verifies the sentinel-valued integer read back from an array prints and var_dumps as
+/// int(...), not NULL — the array element store/load path must not misread it as a miss.
+#[ignore = "TODO(null-sentinel): misread as null under NullRepr::Sentinel - un-ignore in Phase 2"]
+#[test]
+fn test_int_at_null_sentinel_in_array_roundtrips() {
+    let out = compile_and_run(
+        "<?php $a = [9223372036854775806]; echo $a[0], \"|\"; var_dump($a[0]);",
+    );
+    assert_eq!(out, "9223372036854775806|int(9223372036854775806)\n");
+}
+
+/// Verifies a nullable-int function returning the sentinel-valued integer var_dumps as
+/// int(...), not NULL — the ?int return channel must distinguish the value from null.
+#[ignore = "TODO(null-sentinel): misread as null under NullRepr::Sentinel - un-ignore in Phase 2"]
+#[test]
+fn test_int_at_null_sentinel_nullable_return_is_not_null() {
+    let out = compile_and_run(
+        "<?php function f(): ?int { return 9223372036854775806; } var_dump(f());",
+    );
+    assert_eq!(out, "int(9223372036854775806)\n");
+}
+
+/// Verifies is_null() rejects the sentinel-valued integer: a real int is never null.
+#[ignore = "TODO(null-sentinel): misread as null under NullRepr::Sentinel - un-ignore in Phase 2"]
+#[test]
+fn test_int_at_null_sentinel_is_not_null() {
+    let out = compile_and_run("<?php $x = 9223372036854775806; var_dump(is_null($x));");
+    assert_eq!(out, "bool(false)\n");
+}
+
+/// Verifies ?? does not treat the sentinel-valued integer as null: the left operand wins.
+#[ignore = "TODO(null-sentinel): misread as null under NullRepr::Sentinel - un-ignore in Phase 2"]
+#[test]
+fn test_int_at_null_sentinel_null_coalesce_keeps_value() {
+    let out = compile_and_run("<?php $x = 9223372036854775806; echo $x ?? 0;");
+    assert_eq!(out, "9223372036854775806");
+}
+
+/// Verifies isset() reports true for an array element holding the sentinel-valued integer.
+/// Uses a ternary echo because var_dump(isset(...)) has a separate, unrelated formatting
+/// quirk (prints int(1) instead of bool(true)).
+#[test]
+fn test_int_at_null_sentinel_isset_is_true() {
+    let out = compile_and_run(
+        "<?php $a = [9223372036854775806]; echo isset($a[0]) ? \"set\" : \"unset\";",
+    );
+    assert_eq!(out, "set");
+}

--- a/tests/codegen/null_sentinel/tagged.rs
+++ b/tests/codegen/null_sentinel/tagged.rs
@@ -227,6 +227,11 @@ fn test_tagged_unary_minus_and_abs_narrow_null() {
 /// the same fixture still misreads PHP_INT_MAX-1 as null (guards the default until Phase 4).
 #[test]
 fn test_sentinel_default_still_suppresses_collision_value() {
+    if default_null_repr() == elephc::codegen::NullRepr::Tagged {
+        // The whole suite is forced to the tagged representation; the legacy default
+        // behavior under test does not apply in this configuration.
+        return;
+    }
     let out = compile_and_run("<?php echo 9223372036854775806;");
     assert_eq!(out, "");
 }

--- a/tests/codegen/null_sentinel/tagged.rs
+++ b/tests/codegen/null_sentinel/tagged.rs
@@ -239,7 +239,10 @@ fn test_tagged_plain_int_emits_no_sentinel_check() {
         false,
         elephc::codegen::NullRepr::Tagged,
     );
-    let main_start = user_asm.find("_main:").expect("user asm contains _main");
+    let main_start = user_asm
+        .find("_main:")
+        .or_else(|| user_asm.find("\nmain:").map(|i| i + 1))
+        .expect("user asm contains the main label");
     let main_body = &user_asm[main_start..];
     let main_end = main_body.find("ret").map(|i| i + main_start).unwrap_or(user_asm.len());
     let main_section = &user_asm[main_start..main_end];
@@ -265,7 +268,10 @@ fn test_sentinel_plain_int_still_emits_sentinel_check() {
         false,
         elephc::codegen::NullRepr::Sentinel,
     );
-    let main_start = user_asm.find("_main:").expect("user asm contains _main");
+    let main_start = user_asm
+        .find("_main:")
+        .or_else(|| user_asm.find("\nmain:").map(|i| i + 1))
+        .expect("user asm contains the main label");
     let main_body = &user_asm[main_start..];
     let main_end = main_body.find("ret").map(|i| i + main_start).unwrap_or(user_asm.len());
     let main_section = &user_asm[main_start..main_end];

--- a/tests/codegen/null_sentinel/tagged.rs
+++ b/tests/codegen/null_sentinel/tagged.rs
@@ -185,6 +185,44 @@ fn test_tagged_empty_on_array_reads() {
     );
 }
 
+
+/// array_pop on an empty int array yields a real tagged null (NULL, is_null true, ?? falls
+/// back) instead of the sentinel integer.
+#[test]
+fn test_tagged_array_pop_empty_is_null() {
+    let out = compile_and_run_tagged(
+        "<?php $e = [1]; array_pop($e); var_dump(array_pop($e)); var_dump(is_null(array_pop($e))); echo array_pop($e) ?? -5;",
+    );
+    assert_eq!(out, "NULL\nbool(true)\n-5");
+}
+
+/// array_shift on an empty int array yields a real tagged null.
+#[test]
+fn test_tagged_array_shift_empty_is_null() {
+    let out = compile_and_run_tagged(
+        "<?php $s = [2]; array_shift($s); var_dump(array_shift($s));",
+    );
+    assert_eq!(out, "NULL\n");
+}
+
+/// array_pop and array_shift still return real values from non-empty int arrays.
+#[test]
+fn test_tagged_array_pop_shift_values_roundtrip() {
+    let out = compile_and_run_tagged(
+        "<?php $a = [10, 20, 30]; echo array_pop($a), \"|\", array_shift($a), \"|\"; var_dump(array_pop($a));",
+    );
+    assert_eq!(out, "30|10|int(20)\n");
+}
+
+/// Unary minus and abs() coerce a null array read to zero (PHP -null == 0, abs(null) == 0).
+#[test]
+fn test_tagged_unary_minus_and_abs_narrow_null() {
+    let out = compile_and_run_tagged(
+        "<?php $a = [3]; echo -$a[9], \"|\", abs($a[9]), \"|\", -$a[0], \"|\", abs(-$a[0]);",
+    );
+    assert_eq!(out, "0|0|-3|3");
+}
+
 /// The legacy in-band behavior is preserved under the default sentinel representation:
 /// the same fixture still misreads PHP_INT_MAX-1 as null (guards the default until Phase 4).
 #[test]

--- a/tests/codegen/null_sentinel/tagged.rs
+++ b/tests/codegen/null_sentinel/tagged.rs
@@ -1,0 +1,194 @@
+//! Purpose:
+//! End-to-end coverage of the tagged null representation (`NullRepr::Tagged`): the §0
+//! collision repros plus the tag-aware consumer surface (echo, var_dump, is_null, ??, ??=,
+//! isset, strict comparison, arithmetic, string coercion) over null-capable int reads.
+//!
+//! Called from:
+//! - `cargo test` through Rust's test harness.
+//!
+//! Key details:
+//! - Every fixture is compiled with `compile_and_run_tagged` (forces `NullRepr::Tagged`);
+//!   expected outputs are PHP 8.4 cross-checked. The legacy sentinel default is covered by
+//!   the rest of the suite and must keep passing unchanged.
+
+use super::*;
+
+/// The integer PHP_INT_MAX-1 (== the legacy null sentinel bit pattern) must echo as itself
+/// under the tagged representation.
+#[test]
+fn test_tagged_int_at_sentinel_echoes_as_integer() {
+    let out = compile_and_run_tagged("<?php echo 9223372036854775806;");
+    assert_eq!(out, "9223372036854775806");
+}
+
+/// The sentinel-valued integer survives a variable round-trip through echo and var_dump.
+#[test]
+fn test_tagged_int_at_sentinel_var_roundtrips() {
+    let out =
+        compile_and_run_tagged("<?php $x = 9223372036854775806; echo $x, \"|\"; var_dump($x);");
+    assert_eq!(out, "9223372036854775806|int(9223372036854775806)\n");
+}
+
+/// The sentinel-valued integer read back from an array prints and var_dumps as int(...).
+#[test]
+fn test_tagged_int_at_sentinel_in_array_roundtrips() {
+    let out = compile_and_run_tagged(
+        "<?php $a = [9223372036854775806]; echo $a[0], \"|\"; var_dump($a[0]);",
+    );
+    assert_eq!(out, "9223372036854775806|int(9223372036854775806)\n");
+}
+
+/// A nullable-int function returning the sentinel-valued integer var_dumps as int(...).
+#[test]
+fn test_tagged_int_at_sentinel_nullable_return_is_not_null() {
+    let out = compile_and_run_tagged(
+        "<?php function f(): ?int { return 9223372036854775806; } var_dump(f());",
+    );
+    assert_eq!(out, "int(9223372036854775806)\n");
+}
+
+/// is_null() rejects the sentinel-valued integer: a real int is never null.
+#[test]
+fn test_tagged_int_at_sentinel_is_not_null() {
+    let out = compile_and_run_tagged("<?php $x = 9223372036854775806; var_dump(is_null($x));");
+    assert_eq!(out, "bool(false)\n");
+}
+
+/// ?? keeps the sentinel-valued integer instead of falling back to the default.
+#[test]
+fn test_tagged_int_at_sentinel_null_coalesce_keeps_value() {
+    let out = compile_and_run_tagged("<?php $x = 9223372036854775806; echo $x ?? 0;");
+    assert_eq!(out, "9223372036854775806");
+}
+
+/// isset() reports true for an array element holding the sentinel-valued integer.
+#[test]
+fn test_tagged_int_at_sentinel_isset_is_true() {
+    let out = compile_and_run_tagged(
+        "<?php $a = [9223372036854775806]; echo isset($a[0]) ? \"set\" : \"unset\";",
+    );
+    assert_eq!(out, "set");
+}
+
+/// An out-of-bounds int-array read var_dumps as NULL, not as the sentinel integer.
+#[test]
+fn test_tagged_array_miss_var_dumps_null() {
+    let out = compile_and_run_tagged("<?php $a = [1, 2]; var_dump($a[5]);");
+    assert_eq!(out, "NULL\n");
+}
+
+/// ?? falls back to the default for an out-of-bounds int-array read.
+#[test]
+fn test_tagged_array_miss_null_coalesce_falls_back() {
+    let out = compile_and_run_tagged("<?php $a = [1, 2]; echo $a[5] ?? -1;");
+    assert_eq!(out, "-1");
+}
+
+/// A dynamic-index miss behaves like a static one (read through a variable index).
+#[test]
+fn test_tagged_array_miss_dynamic_index_is_null() {
+    let out = compile_and_run_tagged("<?php $a = [1, 2]; $i = 9; var_dump($a[$i]);");
+    assert_eq!(out, "NULL\n");
+}
+
+/// An associative-array miss on an int-valued map yields null for var_dump and ??.
+#[test]
+fn test_tagged_assoc_miss_is_null() {
+    let out = compile_and_run_tagged(
+        "<?php $m = [\"x\" => 1]; var_dump($m[\"zz\"]); echo $m[\"zz\"] ?? 9;",
+    );
+    assert_eq!(
+        out,
+        "NULL\n9"
+    );
+}
+
+/// Strict comparison sees an array miss as identical to null and a hit as not null.
+#[test]
+fn test_tagged_array_miss_strict_equals_null() {
+    let out = compile_and_run_tagged(
+        "<?php $a = [1]; var_dump($a[5] === null); var_dump($a[0] === null); var_dump($a[5] !== null);",
+    );
+    assert_eq!(
+        out,
+        "bool(true)\nbool(false)\nbool(false)\n"
+    );
+}
+
+/// Arithmetic coerces a null array read to zero on either operand side (PHP null + 1 == 1).
+#[test]
+fn test_tagged_array_miss_arithmetic_coerces_to_zero() {
+    let out = compile_and_run_tagged(
+        "<?php $a = [10]; echo $a[5] + 1, \"|\", 1 + $a[5], \"|\", $a[5] * 3;",
+    );
+    assert_eq!(
+        out,
+        "1|1|0"
+    );
+}
+
+/// String contexts render a null array read as an empty string, not the sentinel digits.
+#[test]
+fn test_tagged_array_miss_string_contexts_are_empty() {
+    let out = compile_and_run_tagged(
+        "<?php $a = [10]; echo $a[5] . \"end\", \"|\", \"x{$a[5]}y\";",
+    );
+    assert_eq!(
+        out,
+        "end|xy"
+    );
+}
+
+/// Truthiness of a null array read is false; an in-bounds non-zero read is truthy.
+#[test]
+fn test_tagged_array_miss_truthiness() {
+    let out = compile_and_run_tagged(
+        "<?php $a = [10]; echo $a[5] ? \"t\" : \"f\"; echo $a[0] ? \"T\" : \"F\";",
+    );
+    assert_eq!(out, "fT");
+}
+
+/// ??= stores the fallback when the current value is a null array read.
+#[test]
+fn test_tagged_null_coalesce_assign_on_null_local() {
+    let out = compile_and_run_tagged("<?php $w = null; $w ??= 3; echo $w;");
+    assert_eq!(out, "3");
+}
+
+/// In-bounds reads, sums, and casts keep exact int semantics across the full range.
+#[test]
+fn test_tagged_array_reads_exact_int_semantics() {
+    let out = compile_and_run_tagged(
+        "<?php $a = [10, 20, 30]; $s = 0; for ($i = 0; $i < 3; $i++) { $s = $s + $a[$i]; } echo $s, \"|\", intdiv($a[1], $a[0]), \"|\", (int)$a[1];",
+    );
+    assert_eq!(out, "60|2|20");
+}
+
+/// gettype() distinguishes a null miss from an integer hit at runtime.
+#[test]
+fn test_tagged_gettype_dispatches_on_runtime_tag() {
+    let out = compile_and_run_tagged(
+        "<?php $a = [10]; echo gettype($a[0]), \"|\", gettype($a[5]);",
+    );
+    assert_eq!(out, "integer|NULL");
+}
+
+/// empty() treats a null miss and a zero hit as empty, and a non-zero hit as non-empty.
+#[test]
+fn test_tagged_empty_on_array_reads() {
+    let out = compile_and_run_tagged(
+        "<?php $a = [0, 7]; var_dump(empty($a[5])); var_dump(empty($a[0])); var_dump(empty($a[1]));",
+    );
+    assert_eq!(
+        out,
+        "bool(true)\nbool(true)\nbool(false)\n"
+    );
+}
+
+/// The legacy in-band behavior is preserved under the default sentinel representation:
+/// the same fixture still misreads PHP_INT_MAX-1 as null (guards the default until Phase 4).
+#[test]
+fn test_sentinel_default_still_suppresses_collision_value() {
+    let out = compile_and_run("<?php echo 9223372036854775806;");
+    assert_eq!(out, "");
+}

--- a/tests/codegen/null_sentinel/tagged.rs
+++ b/tests/codegen/null_sentinel/tagged.rs
@@ -283,15 +283,10 @@ fn test_sentinel_plain_int_still_emits_sentinel_check() {
     );
 }
 
-/// The legacy in-band behavior is preserved under the default sentinel representation:
-/// the same fixture still misreads PHP_INT_MAX-1 as null (guards the default until Phase 4).
+/// The legacy in-band behavior is preserved under the explicit sentinel opt-out:
+/// the same fixture still misreads PHP_INT_MAX-1 as null when --null-repr=sentinel.
 #[test]
-fn test_sentinel_default_still_suppresses_collision_value() {
-    if default_null_repr() == elephc::codegen::NullRepr::Tagged {
-        // The whole suite is forced to the tagged representation; the legacy default
-        // behavior under test does not apply in this configuration.
-        return;
-    }
-    let out = compile_and_run("<?php echo 9223372036854775806;");
+fn test_sentinel_optout_still_suppresses_collision_value() {
+    let out = compile_and_run_sentinel("<?php echo 9223372036854775806;");
     assert_eq!(out, "");
 }

--- a/tests/codegen/null_sentinel/tagged.rs
+++ b/tests/codegen/null_sentinel/tagged.rs
@@ -223,6 +223,60 @@ fn test_tagged_unary_minus_and_abs_narrow_null() {
     assert_eq!(out, "0|0|-3|3");
 }
 
+
+/// Phase 3 narrowing proof: a plain non-nullable int emits no in-band sentinel material
+/// under the tagged representation — neither the 0x7fff_ffff_ffff_fffe immediate nor its
+/// decimal form appears anywhere in the user assembly for echo + var_dump of an int local.
+#[test]
+fn test_tagged_plain_int_emits_no_sentinel_check() {
+    let dir = make_cli_test_dir("elephc_tagged_plain_int_asm");
+    let (user_asm, _runtime_asm, _libs) = compile_source_to_asm_with_defines_repr(
+        "<?php $x = 5; echo $x; var_dump($x);",
+        &dir,
+        &std::collections::HashSet::new(),
+        8_388_608,
+        false,
+        false,
+        elephc::codegen::NullRepr::Tagged,
+    );
+    let main_start = user_asm.find("_main:").expect("user asm contains _main");
+    let main_body = &user_asm[main_start..];
+    let main_end = main_body.find("ret").map(|i| i + main_start).unwrap_or(user_asm.len());
+    let main_section = &user_asm[main_start..main_end];
+    let lower = main_section.to_lowercase();
+    assert!(
+        !lower.contains("0xfffe") && !main_section.contains("9223372036854775806"),
+        "plain-int echo/var_dump must not materialize the null sentinel under Tagged:\n{}",
+        main_section
+    );
+}
+
+/// Control for the narrowing proof: the same program under the sentinel representation
+/// does materialize the in-band sentinel for its echo/var_dump null checks.
+#[test]
+fn test_sentinel_plain_int_still_emits_sentinel_check() {
+    let dir = make_cli_test_dir("elephc_sentinel_plain_int_asm");
+    let (user_asm, _runtime_asm, _libs) = compile_source_to_asm_with_defines_repr(
+        "<?php $x = 5; echo $x; var_dump($x);",
+        &dir,
+        &std::collections::HashSet::new(),
+        8_388_608,
+        false,
+        false,
+        elephc::codegen::NullRepr::Sentinel,
+    );
+    let main_start = user_asm.find("_main:").expect("user asm contains _main");
+    let main_body = &user_asm[main_start..];
+    let main_end = main_body.find("ret").map(|i| i + main_start).unwrap_or(user_asm.len());
+    let main_section = &user_asm[main_start..main_end];
+    let lower = main_section.to_lowercase();
+    assert!(
+        lower.contains("0xfffe") || main_section.contains("9223372036854775806"),
+        "sentinel-mode echo/var_dump should still materialize the null sentinel:\n{}",
+        main_section
+    );
+}
+
 /// The legacy in-band behavior is preserved under the default sentinel representation:
 /// the same fixture still misreads PHP_INT_MAX-1 as null (guards the default until Phase 4).
 #[test]

--- a/tests/codegen/support/compiler.rs
+++ b/tests/codegen/support/compiler.rs
@@ -76,6 +76,7 @@ pub(crate) fn compile_source_to_asm_with_defines_repr(
     heap_debug: bool,
     null_repr: elephc::codegen::NullRepr,
 ) -> (String, String, Vec<String>) {
+    elephc::codegen::set_null_repr(null_repr);
     let tokens = elephc::lexer::tokenize(source).expect("tokenize failed");
     let ast = elephc::parser::parse(&tokens).expect("parse failed");
     let synthetic_main = dir.join("test.php");

--- a/tests/codegen/support/compiler.rs
+++ b/tests/codegen/support/compiler.rs
@@ -56,12 +56,13 @@ pub(crate) fn compile_source_to_asm_with_defines(
     )
 }
 
-/// Returns the null representation selected for this test process: `ELEPHC_NULL_REPR=tagged`
-/// forces the tagged scalar representation, anything else keeps the sentinel default.
+/// Returns the null representation selected for this test process: `ELEPHC_NULL_REPR` can
+/// force either mode; without it the compiler default (tagged) applies.
 pub(crate) fn default_null_repr() -> elephc::codegen::NullRepr {
     match std::env::var("ELEPHC_NULL_REPR").as_deref() {
         Ok("tagged") => elephc::codegen::NullRepr::Tagged,
-        _ => elephc::codegen::NullRepr::Sentinel,
+        Ok("sentinel") => elephc::codegen::NullRepr::Sentinel,
+        _ => elephc::codegen::NullRepr::default(),
     }
 }
 
@@ -399,9 +400,20 @@ pub(crate) fn compile_and_run(source: &str) -> String {
     compile_and_run_with_heap_size(source, 8_388_608)
 }
 
+/// Compiles and runs a PHP source with the legacy sentinel null representation forced on,
+/// regardless of `ELEPHC_NULL_REPR`. Used by the sentinel opt-out guard tests.
+pub(crate) fn compile_and_run_sentinel(source: &str) -> String {
+    compile_and_run_with_repr(source, elephc::codegen::NullRepr::Sentinel)
+}
+
 /// Compiles and runs a PHP source with the tagged null representation forced on,
 /// regardless of `ELEPHC_NULL_REPR`. Used by null-sentinel surface tests.
 pub(crate) fn compile_and_run_tagged(source: &str) -> String {
+    compile_and_run_with_repr(source, elephc::codegen::NullRepr::Tagged)
+}
+
+/// Compiles and runs a PHP source with an explicit null representation.
+fn compile_and_run_with_repr(source: &str, null_repr: elephc::codegen::NullRepr) -> String {
     let id = TEST_ID.fetch_add(1, Ordering::SeqCst);
     let tid = std::thread::current().id();
     let pid = std::process::id();
@@ -415,7 +427,7 @@ pub(crate) fn compile_and_run_tagged(source: &str) -> String {
         8_388_608,
         false,
         false,
-        elephc::codegen::NullRepr::Tagged,
+        null_repr,
     );
     let runtime_obj = runtime_obj_for_asm(&runtime_asm);
 

--- a/tests/codegen/support/compiler.rs
+++ b/tests/codegen/support/compiler.rs
@@ -36,6 +36,7 @@ pub(crate) fn compile_source_to_asm_with_options(
 // type-checks, and generates ARM64/x86_64 assembly for the current target.
 // Returns user assembly, runtime assembly, and library names required for linking.
 /// Provides the Compile source to asm with defines helper used by the compiler module.
+/// Uses the environment-selected null representation (`ELEPHC_NULL_REPR`).
 pub(crate) fn compile_source_to_asm_with_defines(
     source: &str,
     dir: &Path,
@@ -43,6 +44,37 @@ pub(crate) fn compile_source_to_asm_with_defines(
     heap_size: usize,
     gc_stats: bool,
     heap_debug: bool,
+) -> (String, String, Vec<String>) {
+    compile_source_to_asm_with_defines_repr(
+        source,
+        dir,
+        defines,
+        heap_size,
+        gc_stats,
+        heap_debug,
+        default_null_repr(),
+    )
+}
+
+/// Returns the null representation selected for this test process: `ELEPHC_NULL_REPR=tagged`
+/// forces the tagged scalar representation, anything else keeps the sentinel default.
+pub(crate) fn default_null_repr() -> elephc::codegen::NullRepr {
+    match std::env::var("ELEPHC_NULL_REPR").as_deref() {
+        Ok("tagged") => elephc::codegen::NullRepr::Tagged,
+        _ => elephc::codegen::NullRepr::Sentinel,
+    }
+}
+
+/// Full compile-to-assembly pipeline with an explicit null representation.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn compile_source_to_asm_with_defines_repr(
+    source: &str,
+    dir: &Path,
+    defines: &HashSet<String>,
+    heap_size: usize,
+    gc_stats: bool,
+    heap_debug: bool,
+    null_repr: elephc::codegen::NullRepr,
 ) -> (String, String, Vec<String>) {
     let tokens = elephc::lexer::tokenize(source).expect("tokenize failed");
     let ast = elephc::parser::parse(&tokens).expect("parse failed");
@@ -85,6 +117,7 @@ pub(crate) fn compile_source_to_asm_with_defines(
         heap_debug,
         target(),
         requires_elephc_tls,
+        null_repr,
     );
     let runtime_features =
         elephc::codegen::runtime_features_for_program_and_classes(&optimized, &check_result.classes);
@@ -363,4 +396,54 @@ pub(crate) fn compile_and_run_with_heap_size(source: &str, heap_size: usize) -> 
 /// Provides the Compile and run helper used by the compiler module.
 pub(crate) fn compile_and_run(source: &str) -> String {
     compile_and_run_with_heap_size(source, 8_388_608)
+}
+
+/// Compiles and runs a PHP source with the tagged null representation forced on,
+/// regardless of `ELEPHC_NULL_REPR`. Used by null-sentinel surface tests.
+pub(crate) fn compile_and_run_tagged(source: &str) -> String {
+    let id = TEST_ID.fetch_add(1, Ordering::SeqCst);
+    let tid = std::thread::current().id();
+    let pid = std::process::id();
+    let dir = std::env::temp_dir().join(format!("elephc_test_tagged_{}_{:?}_{}", pid, tid, id));
+    fs::create_dir_all(&dir).unwrap();
+
+    let (user_asm, runtime_asm, required_libraries) = compile_source_to_asm_with_defines_repr(
+        source,
+        &dir,
+        &HashSet::new(),
+        8_388_608,
+        false,
+        false,
+        elephc::codegen::NullRepr::Tagged,
+    );
+    let runtime_obj = runtime_obj_for_asm(&runtime_asm);
+
+    let elephc_out = assemble_and_run(
+        &user_asm,
+        &runtime_obj,
+        &dir,
+        &required_libraries,
+        &default_link_paths(),
+        &[],
+    );
+
+    // PHP cross-check (opt-in via ELEPHC_PHP_CHECK=1)
+    if std::env::var("ELEPHC_PHP_CHECK").is_ok() {
+        let php_path = dir.join("test.php");
+        fs::write(&php_path, source).unwrap();
+        if let Ok(php_output) = Command::new("php").arg(&php_path).output() {
+            if php_output.status.success() {
+                let php_out = String::from_utf8_lossy(&php_output.stdout);
+                if elephc_out != php_out.as_ref() {
+                    eprintln!(
+                        "PHP compat note: output differs for tagged test.\n  elephc: {:?}\n  php:    {:?}",
+                        elephc_out, php_out
+                    );
+                }
+            }
+        }
+    }
+
+    let _ = fs::remove_dir_all(&dir);
+    elephc_out
 }

--- a/tests/codegen/support/projects.rs
+++ b/tests/codegen/support/projects.rs
@@ -228,6 +228,7 @@ pub(crate) fn compile_and_run_files_expect_failure(
         false,
         target(),
         requires_elephc_tls,
+        default_null_repr(),
     );
     let required_libraries = required_libraries_for_codegen(&optimized, &check_result);
 
@@ -312,6 +313,7 @@ pub(crate) fn compile_and_run_files_with_defines(
         false,
         target(),
         requires_elephc_tls,
+        default_null_repr(),
     );
     let required_libraries = required_libraries_for_codegen(&optimized, &check_result);
     // user assembly is already platform-correct (emitters handle platform at emit time)
@@ -429,6 +431,7 @@ pub(crate) fn compile_and_run_with_stdin(source: &str, stdin_data: &str) -> Stri
         false,
         target(),
         requires_elephc_tls,
+        default_null_repr(),
     );
     let required_libraries = required_libraries_for_codegen(&optimized, &check_result);
     // user assembly is already platform-correct (emitters handle platform at emit time)
@@ -541,6 +544,7 @@ pub(crate) fn compile_and_run_in_dir(source: &str) -> (String, std::path::PathBu
         false,
         target(),
         requires_elephc_tls,
+        default_null_repr(),
     );
     let required_libraries = required_libraries_for_codegen(&optimized, &check_result);
     // user assembly is already platform-correct (emitters handle platform at emit time)


### PR DESCRIPTION
- **test(null-sentinel): repros and benches for the PHP_INT_MAX-1 collision**
- **refactor(codegen): unify NULL_SENTINEL into one canonical constant**
- **docs(types): document the null-sentinel integer collision**
- **feat(codegen): tagged null representation behind NullRepr flag**
- **feat(codegen): tagged nulls for array_pop/array_shift, negate, abs**
- **fix(codegen): align inference and slots with tagged scalar values**
- **feat(codegen): tagged pop/shift inference + plain-int narrowing proof**
- **test(null-sentinel): platform-aware main label in asm narrowing proofs**
- **docs(internals): document the tagged null representation + roadmap**
- **feat(codegen)!: default to the tagged null representation**
- **test(streams): ephemeral ports for the http/https test servers**
