### PR TITLE
feat/linear scan register allocator

### DIFF
--- a/.plans/eir-06-linear-scan-register-allocator.md
+++ b/.plans/eir-06-linear-scan-register-allocator.md
@@ -1,495 +1,191 @@
 # Phase 06 — Linear-Scan Register Allocator
 
-> **For agentic workers:** Replace the "every SSA value gets a stack slot" placement from Phase 04 with a real register allocator. This phase produces the first significant performance gain — expect 15–30% on compute benchmarks.
+> **For agentic workers:** Replace the "every SSA value gets a stack slot"
+> placement from Phase 04 (the current production EIR backend) with a real
+> linear-scan register allocator. This is the first significant performance gain
+> of the EIR series.
 
-**Goal:** Implement linear-scan register allocation (Poletto & Sarkar, 1999) over EIR functions, producing per-instruction register assignments. The IR backend reads the allocation result and emits ASM that places values in registers when possible and spills only when register pressure demands.
+**Status of the surrounding series:** Phases 1–5 are done. The EIR backend is the
+**default**; `--ast-backend` is deprecated (removal in v0.26.0). The Phase 04
+placement — every non-void SSA value gets a fixed stack slot, see
+`src/codegen_ir/value_placement.rs` ("Phase 06 replaces this") — is the live
+baseline this phase replaces. `src/ir_passes/` does not exist yet.
 
-**Architecture:** Three new modules under `src/ir_passes/`: liveness analysis, interval construction, allocator core. Output is an `Allocation` table keyed by `ValueId` indicating *register*, *stack slot*, or both (for spilled values). The `codegen_ir` backend reads `Allocation` and emits accordingly.
+**Goal:** Implement linear-scan register allocation (Poletto & Sarkar, 1999) over
+EIR functions, producing per-`ValueId` register/stack assignments. Scope is the
+**full** algorithm: liveness + live intervals + active list with furthest-use
+spill selection, **plus interval splitting and explicit spill/reload code**,
+separate int/float register pools, and callee-saved usage (with save/restore)
+for values that live across calls.
 
-**Tech Stack:** Rust. Existing IR module. No new dependencies.
+**Architecture:** New IR-level pass under `src/ir_passes/` (consistent with the
+EIR overview: read-only analyses + sidecar tables, invoked from `pipeline.rs`
+after lowering, before codegen; the later optimization phases 7–9 live here too).
+Output is an `Allocation` table keyed by `ValueId`. The `codegen_ir` backend
+reads `Allocation` and emits accordingly.
+
+**Tech stack:** Rust, existing IR + ABI modules, no new dependencies.
+
+## Rollout
+
+The allocator is the **default**. A flag `--regalloc=stack` (style matches the
+existing `--null-repr=sentinel|tagged`; default `--regalloc=linear`) forces the
+Phase 04 spill-everything path as a fallback. This enables:
+
+- **Differential testing**: the same `.php` must produce identical stdout under
+  `--regalloc=linear` and `--regalloc=stack`. Primary safety net.
+- **Instant rollback** if an allocation bug surfaces.
+
+The flag and the legacy `stack` path are removed in a later cleanup once the
+allocator is proven stable (fold into Phase 09 cleanup).
+
+---
+
+## Integration point: chokepoints only
+
+The EIR backend centralizes operand materialization. Integration touches **only**
+these helpers; the `lower_inst/*` emitters are **not** modified:
+
+- `load_value_to_reg`, `load_value_to_result`, `load_string_value_to_regs`
+- `store_result_value`
+- `value_offset`
+
+Emitters keep computing in the result/scratch registers. What changes:
+
+- **operand load**: if the value is in a register, emit a reg→reg `mov`/`fmov`
+  (or nothing) instead of a memory load.
+- **result store**: move the result from the result reg into the value's
+  assigned register (or store to its spill slot) instead of always storing to a
+  fixed slot.
+
+This keeps intra-instruction codegen identical while eliminating stack
+round-trips for register-resident values.
+
+## What is register-allocated in the first cut
+
+Only single-word values: `I64`, `F64`, `Heap(ptr)`.
+
+- `Str` / `TaggedScalar` (16-byte ptr+len pairs) and `IterStart` (64-byte
+  iterator state) stay on stack slots. Avoids register-pair complexity; still
+  satisfies the roadmap. Extendable later.
+
+## Register pools, callee-saved, target differences
+
+- **Reserved scratch registers (not allocatable)**: `x9`/`x10`/`x11` (AArch64),
+  `r11`/`r10`/`rcx` (x86_64). Emitters that grab scratch keep working unchanged.
+- **Cross-call values prefer callee-saved**: `x19`–`x28` / `rbx`,`r12`–`r15`.
+  Track which are actually used; emit save/restore in prologue/epilogue (extend
+  `frame.rs`). If none free, spill around the call.
+- **Target-critical (supported-target policy)**: SysV x86_64 has **no
+  callee-saved XMM**, whereas AArch64 has `d8`–`d15` callee-saved (low 64 bits).
+  So **float values live across a call on x86_64 must spill**; on AArch64 they
+  may use callee-saved float regs. Tested explicitly on both.
+
+## Correctness-critical constraints
+
+- **Ownership / GC**: cleanup paths that release `Owned` heap values must find
+  the value wherever it lives. Release code consults `Allocation`, never assumes
+  the stack slot. Highest-risk interaction → tests in `tests/codegen/runtime_gc/`.
+- **Exceptions**: values live into an exception handler (`try`/catch) or across a
+  point that can throw must reside on the stack or in callee-saved regs (a throw
+  unwinds caller-saved state). First cut: **force-spill** values live within /
+  across a try region.
+- **Generators**: across a `GeneratorSuspend` the state lives in the generator
+  frame → **force-spill** values live across a suspend.
 
 ---
 
 ## File Structure
 
-- Create: `src/ir_passes/mod.rs` — module entry, pass registry
-- Create: `src/ir_passes/liveness.rs` — backward dataflow, per-block live-in/live-out, per-instruction live ranges
-- Create: `src/ir_passes/intervals.rs` — `LiveInterval { value, start, end, type }`, interval list construction
-- Create: `src/ir_passes/regalloc.rs` — linear-scan algorithm with separate int and float register pools
-- Create: `src/ir_passes/allocation.rs` — `Allocation` table consumed by the backend
+- Create: `src/ir_passes/mod.rs` — module entry, pass exports
+- Create: `src/ir_passes/liveness.rs` — backward dataflow, per-block
+  live-in/live-out, per-instruction live ranges
+- Create: `src/ir_passes/intervals.rs` — `LiveInterval { value, ir_type, start, end }`,
+  interval construction over linear program order
+- Create: `src/ir_passes/regalloc.rs` — linear-scan core: active list, expire,
+  furthest-use spill, separate int/float pools, callee-saved tracking
+- Create: `src/ir_passes/allocation.rs` — `Allocation` table consumed by backend
+- Create: `src/ir_passes/resolve.rs` — block-param parallel moves + cross-edge
+  location reconciliation, critical-edge handling
 - Create: `src/ir_passes/tests/` — unit tests on hand-built EIR
 - Modify: `src/lib.rs` — add `pub mod ir_passes;`
-- Modify: `src/codegen_ir/value_placement.rs` — consume `Allocation` if present, fall back to old behavior if not
-- Modify: `src/codegen_ir/lower_inst/*` — when emitting, ask the placement: "where is value X?" instead of always loading from stack
-- Modify: `src/codegen_ir/lower_term.rs` — block-parameter parallel move uses the allocator's per-value answer
-- Modify: `src/pipeline.rs` — invoke the pass on each function after lowering, before codegen
+- Modify: `src/cli.rs` — `--regalloc=linear|stack` flag (default linear)
+- Modify: `src/pipeline.rs` — run the pass per function after lowering, before
+  codegen; thread the chosen mode
+- Modify: `src/codegen_ir/value_placement.rs` / `frame.rs` — build `Allocation`,
+  or fall back to spill-everything under `stack`
+- Modify: `src/codegen_ir/context.rs` chokepoints — `load_value_to_reg`,
+  `load_value_to_result`, `load_string_value_to_regs`, `store_result_value`,
+  `value_offset` become allocation-aware
+- Modify: `src/codegen_ir/lower_term.rs` — block-parameter moves consult `resolve`
 
 ---
 
-## Task 1: Implement liveness analysis
-
-**Files:**
-- Create: `src/ir_passes/mod.rs`
-- Create: `src/ir_passes/liveness.rs`
-- Test: `src/ir_passes/tests/liveness_test.rs`
-
-- [ ] **Step 1: Module scaffold**
-
-```rust
-// src/ir_passes/mod.rs
-//! Purpose:
-//! IR-level analyses and transformations. Currently holds liveness, intervals,
-//! and the linear-scan register allocator.
-//!
-//! Called from:
-//! - `crate::pipeline::compile()` when `--ir-backend` is in use.
-//!
-//! Key details:
-//! - Passes are read-only or produce sidecar tables (e.g., `Allocation`).
-//!   They do not mutate `Function` directly.
-
-mod allocation;
-mod intervals;
-mod liveness;
-mod regalloc;
-
-#[cfg(test)]
-mod tests;
-
-pub use allocation::{Allocation, Placement};
-pub use intervals::{IntervalIndex, LiveInterval};
-pub use liveness::{LivenessInfo, compute_liveness};
-pub use regalloc::allocate_registers;
-```
-
-- [ ] **Step 2: Failing test**
-
-```rust
-// src/ir_passes/tests/liveness_test.rs
-#[test]
-fn liveness_basic_sequence() {
-    // Build:
-    //   v0 = const_i64 1
-    //   v1 = const_i64 2
-    //   v2 = iadd v0, v1
-    //   return v2
-    let func = build_basic_add_function();
-    let liveness = compute_liveness(&func);
-    let block0 = func.blocks[0].id;
-    let live_out = liveness.live_out_of(block0);
-    assert!(live_out.is_empty(), "no values escape an entry-only function");
-
-    let live_after_v0 = liveness.live_after_instruction_in_block(block0, 0);
-    assert!(live_after_v0.contains(&v0_id()), "v0 alive after its def, until v2");
-}
-```
-
-- [ ] **Step 3: Implement backward dataflow**
-
-```rust
-// src/ir_passes/liveness.rs
-//! Purpose:
-//! Backward dataflow per-block liveness analysis on EIR functions. Computes
-//! live-in / live-out / per-instruction live ranges.
-//!
-//! Called from:
-//! - `crate::ir_passes::intervals::build_intervals`
-//!
-//! Key details:
-//! - SSA-lite with block params: a block param is "defined" at block entry;
-//!   block arguments at a branch are "uses" at the terminator point.
-//! - Iterative until fixed point; CFG is small so worklist is plenty.
-
-use std::collections::{HashMap, HashSet, VecDeque};
-
-use crate::ir::{BlockId, Function, Terminator, ValueId};
-
-pub struct LivenessInfo {
-    pub live_in: HashMap<BlockId, HashSet<ValueId>>,
-    pub live_out: HashMap<BlockId, HashSet<ValueId>>,
-}
-
-impl LivenessInfo {
-    pub fn live_out_of(&self, block: BlockId) -> &HashSet<ValueId> {
-        self.live_out.get(&block).expect("missing block in liveness")
-    }
-
-    pub fn live_after_instruction_in_block(
-        &self,
-        block: BlockId,
-        inst_index_in_block: u32,
-    ) -> HashSet<ValueId> {
-        // Per-instruction liveness is computed on demand from block live-out
-        // by replaying the block backward up to the requested instruction.
-        // Implementation detail in `liveness.rs`.
-        unimplemented!()
-    }
-}
-
-pub fn compute_liveness(func: &Function) -> LivenessInfo {
-    // Initialize live_in[B] = uses(B) - defs_before_use(B); live_out[B] = empty
-    // Loop until no changes:
-    //   live_out[B] = union of live_in over successors (with branch args
-    //                 substituted for block-param defs)
-    //   live_in[B] = uses(B) U (live_out[B] - defs(B))
-    let mut info = LivenessInfo {
-        live_in: HashMap::new(),
-        live_out: HashMap::new(),
-    };
-    for b in &func.blocks {
-        info.live_in.insert(b.id, HashSet::new());
-        info.live_out.insert(b.id, HashSet::new());
-    }
-
-    let succs = compute_successors(func);
-
-    let mut worklist: VecDeque<BlockId> = func.blocks.iter().map(|b| b.id).collect();
-    while let Some(b) = worklist.pop_front() {
-        let block = &func.blocks[b.as_raw() as usize];
-        let mut new_live_out = HashSet::new();
-        for s in succs.get(&b).into_iter().flatten() {
-            let s_live_in = info.live_in.get(s).unwrap().clone();
-            new_live_out.extend(s_live_in);
-        }
-        // Subtract: block-param "defs" at successor s correspond to branch
-        // args at this block's terminator. Replace them.
-        new_live_out = substitute_branch_args(func, b, new_live_out);
-
-        let mut new_live_in = uses_of_block(func, b);
-        for v in &new_live_out {
-            if !defs_of_block(func, b).contains(v) {
-                new_live_in.insert(*v);
-            }
-        }
-
-        let changed = info.live_in.get(&b) != Some(&new_live_in)
-            || info.live_out.get(&b) != Some(&new_live_out);
-        info.live_in.insert(b, new_live_in);
-        info.live_out.insert(b, new_live_out);
-        if changed {
-            for &pred in &predecessors_of(func, b, &succs) {
-                worklist.push_back(pred);
-            }
-        }
-    }
-    info
-}
-
-// Helper signatures only — full implementation goes here.
-fn compute_successors(_f: &Function) -> HashMap<BlockId, Vec<BlockId>> { unimplemented!() }
-fn substitute_branch_args(_f: &Function, _b: BlockId, set: HashSet<ValueId>) -> HashSet<ValueId> { set }
-fn uses_of_block(_f: &Function, _b: BlockId) -> HashSet<ValueId> { unimplemented!() }
-fn defs_of_block(_f: &Function, _b: BlockId) -> HashSet<ValueId> { unimplemented!() }
-fn predecessors_of(_f: &Function, _b: BlockId, _succs: &HashMap<BlockId, Vec<BlockId>>) -> Vec<BlockId> { unimplemented!() }
-```
-
-- [ ] **Step 4: Implement helpers and run tests**
-
-Fill in the helpers and run `cargo test --lib ir_passes::tests::liveness_test`. Expect pass.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add src/ir_passes/mod.rs src/ir_passes/liveness.rs src/ir_passes/tests/liveness_test.rs src/lib.rs
-git commit -m "feat(ir_passes): implement liveness analysis"
-```
-
----
-
-## Task 2: Build live intervals
-
-**Files:**
-- Create: `src/ir_passes/intervals.rs`
-- Test: `src/ir_passes/tests/intervals_test.rs`
-
-- [ ] **Step 1: Failing test**
-
-```rust
-#[test]
-fn intervals_for_simple_add() {
-    let func = build_basic_add_function();
-    let intervals = build_intervals(&func, &compute_liveness(&func));
-    assert_eq!(intervals.len(), 3);  // v0, v1, v2
-    let v0 = find_interval_for(&intervals, ValueId::from_raw(0));
-    let v2 = find_interval_for(&intervals, ValueId::from_raw(2));
-    assert!(v0.end <= v2.start, "v0 dies before v2 is defined? no — at iadd v0 is used");
-}
-```
-
-- [ ] **Step 2: Implement**
-
-```rust
-// src/ir_passes/intervals.rs
-//! Purpose:
-//! Builds linear program-order live intervals from per-block liveness.
-//!
-//! Called from:
-//! - `crate::ir_passes::regalloc::allocate_registers`
-//!
-//! Key details:
-//! - Program order is the topological order used by the backend for block
-//!   emission; intervals refer to this order, not the SSA def position.
-
-use crate::ir::{Function, IrType, ValueId};
-use crate::ir_passes::liveness::LivenessInfo;
-
-#[derive(Debug, Clone)]
-pub struct LiveInterval {
-    pub value: ValueId,
-    pub ir_type: IrType,
-    pub start: u32,   // program-order index of the first use OR def
-    pub end: u32,     // program-order index of the last use
-}
-
-pub type IntervalIndex = u32;
-
-pub fn build_intervals(func: &Function, liveness: &LivenessInfo) -> Vec<LiveInterval> {
-    // Walk blocks in program order. For each value, track the
-    // [first_def_pos, last_use_pos] across all blocks where the value is
-    // live. Block-param defs are at the block's first program position;
-    // branch-arg uses are at the terminator's program position.
-    unimplemented!()
-}
-```
-
-- [ ] **Step 3 / 4: Test, pass, commit**
-
----
-
-## Task 3: Implement linear scan
-
-**Files:**
-- Create: `src/ir_passes/regalloc.rs`
-- Create: `src/ir_passes/allocation.rs`
-- Test: `src/ir_passes/tests/regalloc_test.rs`
-
-- [ ] **Step 1: Define `Allocation`**
-
-```rust
-// src/ir_passes/allocation.rs
-//! Purpose:
-//! The output of register allocation: per-ValueId placement and per-function
-//! spill slot table.
-//!
-//! Called from:
-//! - `crate::codegen_ir::lower_inst::*` to find each operand's location.
-//!
-//! Key details:
-//! - `Placement::Register(name)` means the value lives in that register
-//!   between its def and use range.
-//! - `Placement::Spilled(offset)` means the value lives at the named stack
-//!   offset and must be loaded into a register for each use.
-
-use std::collections::HashMap;
-
-use crate::ir::ValueId;
-
-#[derive(Debug, Clone)]
-pub enum Placement {
-    Register(&'static str),
-    Spilled { offset: i32 },
-    SpilledAndReloaded { offset: i32, reload_to: &'static str },
-}
-
-pub struct Allocation {
-    pub placement: HashMap<ValueId, Placement>,
-    pub spill_slot_bytes: usize,
-    pub callee_saved_used: Vec<&'static str>,
-}
-```
-
-- [ ] **Step 2: Linear-scan core**
-
-```rust
-// src/ir_passes/regalloc.rs
-//! Purpose:
-//! Poletto-Sarkar linear-scan register allocator with separate int and float
-//! register pools, callee-saved register preservation, and spill heuristics.
-//!
-//! Called from:
-//! - `crate::pipeline::compile()` after AST → IR lowering
-//!
-//! Key details:
-//! - Pools per architecture come from `crate::codegen::abi::registers`.
-//!   Reserve scratch registers used by lowering (`x9..x11`) — those stay
-//!   excluded from the allocator pool.
-//! - Spill heuristic: spill the interval with the largest end position.
-
-use std::collections::BTreeSet;
-
-use crate::codegen::abi::registers;
-use crate::codegen::platform::{Arch, Target};
-use crate::ir::{Function, IrType};
-use crate::ir_passes::allocation::{Allocation, Placement};
-use crate::ir_passes::intervals::{build_intervals, LiveInterval};
-use crate::ir_passes::liveness::compute_liveness;
-
-pub fn allocate_registers(func: &Function, target: Target) -> Allocation {
-    let liveness = compute_liveness(func);
-    let mut intervals = build_intervals(func, &liveness);
-    intervals.sort_by_key(|iv| iv.start);
-
-    let int_pool = int_register_pool(target);
-    let float_pool = float_register_pool(target);
-    let mut int_free: BTreeSet<&'static str> = int_pool.iter().copied().collect();
-    let mut float_free: BTreeSet<&'static str> = float_pool.iter().copied().collect();
-    let mut active: Vec<(LiveInterval, Placement)> = Vec::new();
-    let mut alloc = Allocation {
-        placement: Default::default(),
-        spill_slot_bytes: 0,
-        callee_saved_used: Vec::new(),
-    };
-
-    for iv in intervals {
-        expire_old_intervals(&mut active, iv.start, &mut int_free, &mut float_free);
-        let pool = if iv.ir_type.is_float() { &mut float_free } else { &mut int_free };
-        if let Some(reg) = pool.iter().next().copied() {
-            pool.remove(reg);
-            let placement = Placement::Register(reg);
-            alloc.placement.insert(iv.value, placement.clone());
-            active.push((iv, placement));
-            mark_callee_saved_if_needed(&mut alloc, reg, target);
-        } else {
-            // Spill heuristic: spill the active interval with the largest
-            // end position.
-            spill_at_interval(&mut active, &mut alloc, &iv);
-        }
-    }
-    alloc
-}
-
-fn expire_old_intervals(/* ... */) { unimplemented!() }
-fn spill_at_interval(/* ... */) { unimplemented!() }
-fn int_register_pool(target: Target) -> Vec<&'static str> {
-    match target.arch {
-        Arch::AArch64 => vec!["x19","x20","x21","x22","x23","x24","x25","x26","x27","x28", "x12","x13","x14","x15"],
-        Arch::X86_64 => vec!["rbx","r12","r13","r14","r15"],
-    }
-    // Note: x0-x7 / rdi-r9 are reserved for argument passing during calls;
-    // the allocator may use them outside live ranges crossing a call.
-    // Refinement deferred to a follow-up commit if pressure benchmarks justify.
-}
-fn float_register_pool(target: Target) -> Vec<&'static str> {
-    match target.arch {
-        Arch::AArch64 => vec!["d8","d9","d10","d11","d12","d13","d14","d15"],
-        Arch::X86_64 => vec![/* XMM scratch set, deferred */],
-    }
-}
-fn mark_callee_saved_if_needed(_alloc: &mut Allocation, _reg: &'static str, _target: Target) {}
-```
-
-- [ ] **Step 3: Tests**
-
-Hand-build several EIR functions:
-1. A two-add function where everything fits in two registers.
-2. A function that requires spilling (10+ live values simultaneously).
-3. A function with mixed int and float values.
-4. A function with a call mid-live-range (must reserve callee-saved registers across calls).
-
-Verify the produced `Allocation` matches expected placements.
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add src/ir_passes/regalloc.rs src/ir_passes/allocation.rs src/ir_passes/tests/regalloc_test.rs
-git commit -m "feat(ir_passes): implement linear-scan register allocator"
-```
-
----
-
-## Task 4: Wire allocator into the backend
-
-**Files:**
-- Modify: `src/pipeline.rs`
-- Modify: `src/codegen_ir/value_placement.rs`
-- Modify: `src/codegen_ir/lower_inst/*` (read placement instead of always stack)
-- Modify: `src/codegen_ir/lower_term.rs` (parallel move with placement awareness)
-
-- [ ] **Step 1: Invoke allocator after lowering**
-
-In `src/pipeline.rs`:
-
-```rust
-let ir_module = ir_lower::lower_program(/* ... */);
-let allocations: HashMap<&Function, Allocation> = ir_module
-    .functions.iter().chain(ir_module.class_methods.iter())
-    .map(|f| (f, ir_passes::allocate_registers(f, target)))
-    .collect();
-let user_asm = codegen_ir::generate_user_asm_from_ir_with_alloc(&ir_module, &allocations, ...);
-```
-
-- [ ] **Step 2: Backend reads `Allocation`**
-
-Rewrite the helper that produces the "where is this value?" answer for the lowering code. If `Allocation` says register, the lowering emits `mov`/`fmov` from that register where the AST emitter would `ldr`. If `Allocation` says spilled, fall back to the Phase 04 stack-slot behavior for that value.
-
-- [ ] **Step 3: Parallel-move scheduling at terminators**
-
-Block-parameter moves are now register-to-register where possible. The parallel-move scheduler must handle cycles (`a -> b, b -> a`) with one scratch register. Implementation: standard "topological sort, break cycles by saving to scratch" pattern.
-
-- [ ] **Step 4: Run full test suite**
-
-Run:
-```bash
-cargo test
-cargo test -- --include-ignored
-./scripts/test-linux-x86_64.sh
-./scripts/test-linux-arm64.sh
-```
-
-Expected: all green. Behavior is unchanged; only the assembly is leaner.
-
-- [ ] **Step 5: Benchmark gate**
-
-Run the benchmark suite:
-```bash
-./scripts/run-benchmarks.sh --backend ir --baseline phase4
-```
-
-Expected: **at least 15% improvement on compute-heavy benchmarks** (fibonacci, mandelbrot, tight numeric loops). If less, diagnose:
-- Are spills happening when they shouldn't? Print the `Allocation` and inspect.
-- Is the parallel-move scheduler creating redundant `mov`s? Check with `--emit-asm` on a known hot function.
-- Is the int pool too small? Try `x12-x15` additions.
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add src/pipeline.rs src/codegen_ir/
-git commit -m "feat(codegen_ir): consume linear-scan allocation for value placement"
-```
-
----
-
-## Task 5: Refinements (only if benchmarks below target)
-
-**Files:** as needed
-
-If Phase 06 benchmarks are below the ≥15% target, consider these refinements in order:
-
-- [ ] **Refinement A: Reuse caller-saved registers when live ranges don't cross a call**
-
-The default-conservative pool excludes `x0..x7`. Many SSA values never cross a call. Annotate intervals with "crosses call" flag, allow caller-saved regs for non-crossing intervals.
-
-- [ ] **Refinement B: Coalesce moves**
-
-When an SSA value is the target of a single `Mov` op (from Phase 03 ownership ops) and the source's interval doesn't conflict, assign them the same register. Eliminates the `Mov` at lowering.
-
-- [ ] **Refinement C: Better spill heuristic**
-
-Replace "spill the interval with largest end" with "spill the interval with the lowest use frequency in the upcoming live range". Cheap to compute, often better.
-
-Each refinement is its own task with its own benchmark check. Don't bundle them — that makes it hard to attribute the gain.
-
-Commit per refinement:
-```bash
-git commit -m "perf(ir_passes): use caller-saved regs for non-call-crossing intervals"
-```
+## Staging (independently landable tasks)
+
+Each task ends green on `cargo test`, `cargo test -- --include-ignored`, and the
+Docker Linux scripts where target-sensitive. TDD: failing unit test first.
+
+### Task 1 — Liveness analysis
+Backward dataflow to fixpoint over `ValueId`: per-block `live_in`/`live_out`.
+Block params are defs at block entry; instruction/terminator operands (incl.
+branch args) are uses. Unit tests on hand-built functions (straight-line, loop,
+diamond). Files: `mod.rs`, `liveness.rs`, `tests/liveness_test.rs`, `lib.rs`.
+
+### Task 2 — Live intervals
+Linearize blocks in reverse postorder; number positions. Build
+`[def, last_use]` per value, extended across loop back-edges. Unit tests on
+overlapping and disjoint ranges. Files: `intervals.rs`, `tests/intervals_test.rs`.
+
+### Task 3 — `Allocation` + register-aware chokepoints in "all-spilled" mode
+Define `Allocation` and make the backend consume it, but produce all-stack
+placements so output is byte-for-behavior identical to Phase 04. Proves the
+integration at zero risk. Differential test harness wired here. Files:
+`allocation.rs`, `codegen_ir/context.rs`, `frame.rs`, `cli.rs`, `pipeline.rs`.
+
+### Task 4 — Linear-scan core (assignment, no splitting yet)
+Active list sorted by end; expire; assign from matching pool; furthest-use spill
+to a slot (whole-interval spill). Separate int/float pools from
+`codegen/abi/registers`. Pre-coloring/fixed intervals for ABI constraints
+(incoming params, `Call` results in x0/d0, `Call` operands → arg regs, `Return`
+value). Unit tests: fits-in-regs, forced spill (10+ live), mixed int/float.
+Files: `regalloc.rs`, `tests/regalloc_test.rs`.
+
+### Task 5 — Callee-saved usage + prologue/epilogue save/restore
+Cross-call intervals prefer callee-saved; track used set; emit save/restore.
+Handle the x86_64-no-callee-XMM float rule (force float spill across calls).
+Tests on call-heavy functions, both targets via Docker. Files: `regalloc.rs`,
+`codegen_ir/frame.rs`.
+
+### Task 6 — Interval splitting + explicit spill/reload
+Split a spilled interval at the conflict point: part in reg, part in slot, with
+reload/store at the boundary. Furthest-use spill candidate. Files: `regalloc.rs`,
+`intervals.rs`, chokepoint reload paths.
+
+### Task 7 — Block-param resolution
+Parallel moves at edges (cycle-breaking via one scratch reg), cross-edge location
+reconciliation, critical-edge splitting. Files: `resolve.rs`,
+`codegen_ir/lower_term.rs`.
+
+### Task 8 — Correctness constraints: GC, exceptions, generators
+Release paths consult `Allocation`. Force-spill values live within/across try
+regions and across `GeneratorSuspend`. Files: `regalloc.rs`, ownership/cleanup
+emitters. Tests in `tests/codegen/runtime_gc/`.
+
+### Task 9 — Default switch + differential CI
+Default `--regalloc=linear`. Differential test: full `codegen_tests` suite
+produces identical stdout under `linear` and `stack`. Stress: high pressure,
+calls, loops, float-heavy on x86_64.
 
 ---
 
 ## Exit criteria
 
-- Linear-scan allocator integrated and producing valid placements
-- Full test suite green on both backends; IR backend now demonstrates ≥15% speedup on compute benchmarks vs Phase 04 baseline
-- Allocator handles all edge cases tested: spilling, float pool, callee-saved across calls, parallel moves at terminators
-- Documentation: `docs/internals/the-ir.md` gains a "Register allocation" section
-- Zero compiler warnings
+- Linear-scan allocator integrated, default on, producing valid placements.
+- Full suite green under both `--regalloc=linear` and `--regalloc=stack`, on all
+  three targets (Docker Linux x86_64 / ARM64 + local macOS ARM64).
+- Edge cases tested: spilling, interval splitting, float pool, callee-saved
+  across calls (incl. x86_64 float-spill rule), block-param parallel moves,
+  GC/exception/generator force-spill.
+- `docs/internals/the-ir.md` gains a "Register allocation" section.
+- `cargo build` clean, zero warnings.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ elephc --emit-asm --source-map hello.php
 # Run the front-end checks without writing assembly or a binary
 elephc --check hello.php
 
+# Fall back to stack-only value placement (default is linear-scan registers)
+elephc --regalloc=stack hot.php
+
 # Link extra native libraries or frameworks for FFI
 elephc app.php -l sqlite3 -L /opt/homebrew/lib --framework Cocoa
 
@@ -303,7 +306,7 @@ User-defined constants are also supported via `const NAME = value;` and `define(
 ## How it works
 
 ```
-PHP source → Lexer → Parser (AST) → Magic constants (per-file) → Conditional (ifdef/--define) → Autoload registry build (Composer + SPL rules) → Resolver (include declaration discovery, include/require inlining, per-file constants, once guards, function variant marks) → NameResolver (namespaces/use/FQNs) → Autoload run (class-triggered file insertion) → Optimizer (constant folding) → Type Checker → Optimizer (constant propagation) → Optimizer (control-flow pruning) → Optimizer (control-flow normalization) → Optimizer (dead-code elimination) → EIR lowering + validation → EIR codegen → runtime cache → as + ld → native executable
+PHP source → Lexer → Parser (AST) → Magic constants (per-file) → Conditional (ifdef/--define) → Autoload registry build (Composer + SPL rules) → Resolver (include declaration discovery, include/require inlining, per-file constants, once guards, function variant marks) → NameResolver (namespaces/use/FQNs) → Autoload run (class-triggered file insertion) → Optimizer (constant folding) → Type Checker → Optimizer (constant propagation) → Optimizer (control-flow pruning) → Optimizer (control-flow normalization) → Optimizer (dead-code elimination) → EIR lowering + validation → register allocation → EIR codegen → runtime cache → as + ld → native executable
 ```
 
 The compiler emits human-readable assembly for the selected target. You can inspect the `.s` file to see exactly what your PHP becomes:
@@ -327,6 +330,8 @@ elephc already performs a small but useful AST-level optimization pipeline befor
 - **Local effect summaries for purity / may-throw reasoning**: tracks known pure and non-throwing builtins, user functions, static methods, private `$this` methods, closures, first-class callables, and merged callable aliases through `if` / `switch` / `try` control flow so the optimizer can simplify `try` regions and prune dead handlers more precisely.
 
 The optimizer is intentionally conservative. It does not yet do full function-level CFG fixed-point propagation, aggressive whole-program optimization, or assembly-level peephole rewriting, but it does compute lightweight effect summaries and local CFG-lite reachability for known call targets and structured control flow so AST rewrites can stay more precise without becoming risky.
+
+At the EIR level, the backend runs a **linear-scan register allocator** (Poletto-Sarkar) with liveness analysis, live intervals, and separate integer/float register pools. Hot scalar values live in callee-saved registers across calls instead of being spilled to the stack on every use, which speeds up compute-heavy code substantially. Use `--regalloc=stack` to fall back to the original spill-everything placement.
 
 ### Type system
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -693,7 +693,7 @@ imposed. See `docs/internals/the-ir.md`.
 - [x] EIR → ASM backend producing semantically equivalent output to the legacy backend (no optimizations yet)
 - [x] Default backend switch from AST to EIR, with `--ast-backend` retained as an explicit fallback
 - [x] CI default-EIR gate, frozen fallback smoke coverage, and IR-only benchmark job for parity and regression tracking
-- [ ] Linear-scan register allocator (Poletto-Sarkar) with liveness analysis, live intervals, allocation table, separate int / float pools, and callee-saved preservation across calls
+- [x] Linear-scan register allocator (Poletto-Sarkar) with liveness analysis, live intervals, allocation table, separate int / float pools, and callee-saved preservation across calls
 - [ ] Register-pressure mitigations: caller-saved reuse for non-call-crossing intervals; better spill heuristic
 
 Expected outcome: EIR is the default and only active implementation backend in

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -124,6 +124,13 @@ PHP source (.php)
        │
        ▼
 ┌─────────────┐
+│ Reg. Alloc  │  src/ir_passes/
+│             │  Linear-scan register allocation (liveness, intervals, pools)
+│             │  over EIR functions before codegen.
+└──────┬──────┘
+       │
+       ▼
+┌─────────────┐
 │ EIR Codegen │  src/codegen_ir/ + shared src/codegen/abi/
 │             │  Emits target assembly text from EIR. The legacy AST backend
 │             │  remains in src/codegen/ behind --ast-backend.
@@ -174,6 +181,7 @@ src/
 ├── optimize/                  Constant folding, constant propagation, control-flow pruning, normalization, dead-code elimination
 ├── ir/                        EIR types, builder, validator, printer, effects, and tests
 ├── ir_lower/                  Active checked-AST to EIR lowering
+├── ir_passes/                 EIR analyses and linear-scan register allocation
 ├── codegen_ir/                Active EIR to target assembly backend
 ├── runtime_cache.rs           Cached shared runtime object preparation
 ├── source_map.rs              Assembly comment markers → JSON sidecar map

--- a/docs/internals/memory-model.md
+++ b/docs/internals/memory-model.md
@@ -75,6 +75,8 @@ Each function has a stack frame. The [code generator](the-codegen.md) calculates
 - Strings take **two slots** (16 bytes): pointer at `[x29, #-offset]`, length at `[x29, #-(offset-8)]`
 - The total frame size is always 16-byte aligned (ARM64 ABI requirement)
 
+On the EIR backend the frame also reserves one save slot per callee-saved register that the linear-scan register allocator uses, and short-lived scalar SSA temporaries may live in registers instead of a stack slot. PHP local variables themselves are still slot-backed as shown above. See [The IR](the-ir.md) for the register allocation pass.
+
 ### Variable allocation
 
 Variables are allocated stack slots when the [code generator](the-codegen.md) scans the function body (`collect_local_vars`). The allocation is determined at compile time — there's no dynamic stack growth.

--- a/docs/internals/the-codegen.md
+++ b/docs/internals/the-codegen.md
@@ -94,7 +94,7 @@ This means normal CLI builds no longer concatenate the runtime text into every o
 
 The source-map file is intentionally simple. Today it stores a list of `(asm_line, php_line, php_col)` entries so tools and humans can correlate generated assembly back to the original PHP statements without needing full DWARF debug info.
 
-The AST optimizer intentionally still runs before backend selection. By the time the default EIR backend runs, constant expressions and some dead control-flow have already been removed, and EIR adds the function-wide value and control-flow shape needed for later register allocation and IR optimizations. The legacy AST backend sees the same optimized AST when `--ast-backend` is selected.
+The AST optimizer intentionally still runs before backend selection. By the time the default EIR backend runs, constant expressions and some dead control-flow have already been removed, and EIR adds the function-wide value and control-flow shape that the linear-scan register allocator (`src/ir_passes/`, see [The IR](the-ir.md)) and future IR optimizations rely on. The legacy AST backend sees the same optimized AST when `--ast-backend` is selected.
 
 ## Emit modes: executable vs cdylib
 

--- a/docs/internals/the-ir.md
+++ b/docs/internals/the-ir.md
@@ -1106,9 +1106,11 @@ Only callee-saved registers are allocated, so values survive calls without
 spilling and never collide with the scratch or result registers the emitters
 use. The prologue saves and the epilogue restores exactly the callee-saved
 registers the allocator used. On aarch64 the pools are `x21`–`x28` and
-`d8`–`d14`; on x86_64 they are `rbx`, `r14`, `r15`. SysV x86_64 has no
-callee-saved XMM registers, so float values are never register-allocated there
-and stay in stack slots.
+`d8`–`d14`. On x86_64 only `rbx` is allocated: `r14` and `r15` are used as
+scratch by hand-written runtime routines and shared heap-marker codegen without
+ABI-compliant save/restore, so they are not safe to hold values across calls.
+SysV x86_64 also has no callee-saved XMM registers, so float values are never
+register-allocated there and stay in stack slots.
 
 The first cut register-allocates only single-word `NonHeap` scalars (`I64`,
 `F64`) that are neither block parameters nor branch arguments, keeping the

--- a/docs/internals/the-ir.md
+++ b/docs/internals/the-ir.md
@@ -1078,6 +1078,43 @@ Then it materializes:
 - source-map comments
 - instruction comments at the repository-required column
 
+## Register Allocation
+
+The `src/ir_passes/` module runs a linear-scan register allocator
+(Poletto-Sarkar) over each function before backend lowering. It is the default;
+`--regalloc=stack` (or `ELEPHC_REGALLOC=stack`) selects the original
+spill-everything path, which keeps every SSA value in a stack slot.
+
+The pass has four stages:
+
+1. **Liveness** (`liveness.rs`): backward dataflow to a fixed point producing
+   per-block live-in/live-out value sets. Block parameters are definitions at
+   block entry; branch arguments are uses at the predecessor's terminator.
+2. **Intervals** (`intervals.rs`): blocks are numbered in reverse postorder and
+   each value gets one contiguous `[start, end]` live interval. A value live
+   across edges or a loop back-edge spans the intervening positions.
+3. **Scan** (`regalloc.rs`): intervals are walked in start order against an
+   active set; a free register from the matching pool is assigned, otherwise the
+   interval with the furthest end point is spilled. Integer and float values
+   draw from separate pools.
+4. **Frame integration** (`codegen_ir/frame.rs`): the allocation is stored in
+   the frame layout, each used callee-saved register gets a save slot, and the
+   value-access chokepoints (`load_value_to_result`, `load_value_to_reg`,
+   `store_result_value`) read and write registers instead of slots.
+
+Only callee-saved registers are allocated, so values survive calls without
+spilling and never collide with the scratch or result registers the emitters
+use. The prologue saves and the epilogue restores exactly the callee-saved
+registers the allocator used. On aarch64 the pools are `x21`–`x28` and
+`d8`–`d14`; on x86_64 they are `rbx`, `r14`, `r15`. SysV x86_64 has no
+callee-saved XMM registers, so float values are never register-allocated there
+and stay in stack slots.
+
+The first cut register-allocates only single-word `NonHeap` scalars (`I64`,
+`F64`) that are neither block parameters nor branch arguments, keeping the
+slot-based block-parameter moves and the ownership/GC cleanup paths unchanged.
+Generators and functions containing exception handlers fall back to all-spilled.
+
 ## Phase 02 Implementation Contract
 
 The `src/ir/` module should implement at least:

--- a/docs/internals/the-optimizer.md
+++ b/docs/internals/the-optimizer.md
@@ -417,7 +417,11 @@ The current optimizer is still intentionally local. It does not yet implement:
 - broader control-flow normalization beyond the current local AST shell rewrites
 - backend-specific peephole cleanup
 - runtime dead stripping
-- register allocation
 - elimination of the `adrp/add/stur` instruction triple at the FCC assignment site when the wrapper is stubbed (the stub address still gets loaded and stored even though both are dead)
 
 Those remain roadmap items for later optimization work.
+
+Note that **register allocation** is no longer on this list: the EIR backend now
+runs a linear-scan register allocator (`src/ir_passes/`), described in
+[The IR](the-ir.md). It is a backend pass over EIR rather than an AST-level
+optimization, so it lives outside `src/optimize/`.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,7 +15,7 @@ pub(crate) use crate::codegen::Emit;
 use crate::codegen::platform::Target;
 
 /// Usage string printed to stderr when command-line arguments are invalid or missing.
-pub(crate) const USAGE: &str = "Usage: elephc [--target TARGET] [--heap-size=BYTES] [--gc-stats] [--heap-debug] [--emit-ir] [--ir-backend] [--ast-backend] [--emit-asm] [--emit KIND] [--check] [--null-repr=sentinel|tagged] [--timings] [--source-map] [--define SYMBOL] [--link LIB|-lLIB] [--link-path DIR|-LDIR] [--framework NAME] <source.php>";
+pub(crate) const USAGE: &str = "Usage: elephc [--target TARGET] [--heap-size=BYTES] [--gc-stats] [--heap-debug] [--emit-ir] [--ir-backend] [--ast-backend] [--emit-asm] [--emit KIND] [--check] [--null-repr=sentinel|tagged] [--regalloc=linear|stack] [--timings] [--source-map] [--define SYMBOL] [--link LIB|-lLIB] [--link-path DIR|-LDIR] [--framework NAME] <source.php>";
 
 /// Backend selected for assembly generation after frontend and optimization passes.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -39,6 +39,7 @@ pub(crate) struct CliConfig {
     pub(crate) check_only: bool,
     pub(crate) emit_timings: bool,
     pub(crate) emit_source_map: bool,
+    pub(crate) regalloc_linear: bool,
     pub(crate) target: Target,
     pub(crate) extra_link_libs: Vec<String>,
     pub(crate) extra_link_paths: Vec<String>,
@@ -75,6 +76,13 @@ pub(crate) fn parse_args(args: &[String]) -> CliConfig {
         Ok("tagged") => crate::codegen::NullRepr::Tagged,
         Ok("sentinel") => crate::codegen::NullRepr::Sentinel,
         _ => crate::codegen::NullRepr::default(),
+    };
+    // The register allocator is on by default; an env override lets the test
+    // harness compile the whole suite under the stack fallback for comparison.
+    let mut regalloc_linear = match std::env::var("ELEPHC_REGALLOC").as_deref() {
+        Ok("stack") => false,
+        Ok("linear") => true,
+        _ => true,
     };
 
     let mut i = 1;
@@ -114,6 +122,8 @@ pub(crate) fn parse_args(args: &[String]) -> CliConfig {
             emit_source_map = true;
         } else if let Some(value) = arg.strip_prefix("--null-repr=") {
             null_repr = parse_null_repr(value);
+        } else if let Some(value) = arg.strip_prefix("--regalloc=") {
+            regalloc_linear = parse_regalloc(value);
         } else if arg == "--define" {
             i += 1;
             let symbol = required_value(args, i, "Missing symbol after --define");
@@ -188,6 +198,7 @@ pub(crate) fn parse_args(args: &[String]) -> CliConfig {
         check_only,
         emit_timings,
         emit_source_map,
+        regalloc_linear,
         target,
         extra_link_libs,
         extra_link_paths,
@@ -240,6 +251,15 @@ fn parse_null_repr(value: &str) -> crate::codegen::NullRepr {
         "sentinel" => crate::codegen::NullRepr::Sentinel,
         "tagged" => crate::codegen::NullRepr::Tagged,
         other => fail(&format!("Unknown null representation: {}", other)),
+    }
+}
+
+/// Parse a `--regalloc=` value into the linear-scan toggle, or fail.
+fn parse_regalloc(value: &str) -> bool {
+    match value {
+        "linear" => true,
+        "stack" => false,
+        other => fail(&format!("Unknown register allocator: {}", other)),
     }
 }
 

--- a/src/codegen/abi/frame.rs
+++ b/src/codegen/abi/frame.rs
@@ -218,6 +218,37 @@ pub fn load_at_offset_scratch(emitter: &mut Emitter, reg: &str, offset: usize, s
     }
 }
 
+/// Emits a register-to-register move, choosing the move form by the register
+/// classes of both operands. Handles same-class moves and moves between a
+/// general-purpose and a floating-point register (a raw 64-bit bit copy, used
+/// when a float value's payload must reach an integer register). Emits nothing
+/// when source and destination are identical.
+pub fn emit_reg_move(emitter: &mut Emitter, dst: &str, src: &str) {
+    if dst == src {
+        return;
+    }
+    let dst_float = is_float_register(dst);
+    let src_float = is_float_register(src);
+    match emitter.target.arch {
+        Arch::AArch64 => {
+            if dst_float || src_float {
+                emitter.instruction(&format!("fmov {}, {}", dst, src));         // move between FP and/or GP registers
+            } else {
+                emitter.instruction(&format!("mov {}, {}", dst, src));          // move integer/pointer register
+            }
+        }
+        Arch::X86_64 => {
+            if dst_float && src_float {
+                emitter.instruction(&format!("movsd {}, {}", dst, src));        // move scalar double between XMM registers
+            } else if dst_float || src_float {
+                emitter.instruction(&format!("movq {}, {}", dst, src));         // move 64-bit payload between GP and XMM
+            } else {
+                emitter.instruction(&format!("mov {}, {}", dst, src));          // move integer/pointer register
+            }
+        }
+    }
+}
+
 /// Loads a value from an arbitrary address in memory into `reg`.
 /// `addr_reg` holds the base address; `byte_offset` is added (AArch64 scaled immediate, x86_64 additive).
 /// On x86_64, float registers use movsd; integers use mov.

--- a/src/codegen/abi/mod.rs
+++ b/src/codegen/abi/mod.rs
@@ -31,7 +31,7 @@ pub use calls::{
 pub use frame::{
     emit_cleanup_callback_epilogue, emit_cleanup_callback_prologue, emit_frame_prologue,
     emit_frame_restore, emit_frame_slot_address, emit_load_from_address,
-    emit_preserve_return_value, emit_restore_return_value, emit_return,
+    emit_preserve_return_value, emit_reg_move, emit_restore_return_value, emit_return,
     emit_store_to_address, emit_store_zero_to_address, emit_store_zero_to_local_slot, load_at_offset,
     load_at_offset_scratch, load_from_caller_stack, store_at_offset, store_at_offset_scratch,
 };

--- a/src/codegen_ir/block_emit.rs
+++ b/src/codegen_ir/block_emit.rs
@@ -55,16 +55,17 @@ pub(super) fn emit_module(
     heap_debug: bool,
     requires_elephc_tls: bool,
     emit: Emit,
+    regalloc_linear: bool,
 ) -> Result<()> {
     function_variants::emit_dispatchers(module, emitter, data);
     for function in module.functions.iter().filter(|function| !is_main(function)) {
-        emit_user_function(module, function, emitter, data)?;
+        emit_user_function(module, function, emitter, data, regalloc_linear)?;
     }
     for method in &module.class_methods {
-        emit_class_method(module, method, emitter, data)?;
+        emit_class_method(module, method, emitter, data, regalloc_linear)?;
     }
     for closure in &module.closures {
-        emit_user_function(module, closure, emitter, data)?;
+        emit_user_function(module, closure, emitter, data, regalloc_linear)?;
     }
     emit_eir_fiber_wrappers(module, emitter);
     if matches!(emit, Emit::Cdylib) {
@@ -83,6 +84,7 @@ pub(super) fn emit_module(
         gc_stats,
         heap_debug,
         requires_elephc_tls,
+        regalloc_linear,
     )
 }
 
@@ -140,12 +142,13 @@ fn emit_user_function(
     function: &Function,
     emitter: &mut Emitter,
     data: &mut DataSection,
+    regalloc_linear: bool,
 ) -> Result<()> {
     if function.flags.is_generator {
         let entry_label = user_function_entry_symbol(function);
         return emit_generator_function(module, function, &entry_label, emitter, data);
     }
-    let layout = frame::layout_for_function(function);
+    let layout = frame::layout_for_function(function, emitter.target, regalloc_linear);
     let epilogue_label = user_function_epilogue_symbol(function);
     let mut ctx = FunctionContext::new(
         module,
@@ -192,12 +195,13 @@ fn emit_class_method(
     function: &Function,
     emitter: &mut Emitter,
     data: &mut DataSection,
+    regalloc_linear: bool,
 ) -> Result<()> {
     let entry_label = class_method_entry_symbol(function)?;
     if function.flags.is_generator {
         return emit_generator_function(module, function, &entry_label, emitter, data);
     }
-    let layout = frame::layout_for_function(function);
+    let layout = frame::layout_for_function(function, emitter.target, regalloc_linear);
     let epilogue_label = format!("{}_epilogue", entry_label);
     let mut ctx = FunctionContext::new(
         module,
@@ -321,8 +325,9 @@ fn emit_main_function(
     gc_stats: bool,
     heap_debug: bool,
     requires_elephc_tls: bool,
+    regalloc_linear: bool,
 ) -> Result<()> {
-    let layout = frame::layout_for_function(function);
+    let layout = frame::layout_for_function(function, emitter.target, regalloc_linear);
     let mut ctx = FunctionContext::new(
         module,
         function,

--- a/src/codegen_ir/context.rs
+++ b/src/codegen_ir/context.rs
@@ -17,6 +17,7 @@ use crate::codegen::data_section::DataSection;
 use crate::codegen::emit::Emitter;
 use crate::codegen::platform::Arch;
 use crate::ir::{BlockId, DataId, Function, LocalSlotId, Module, Op, Ownership, ValueDef, ValueId};
+use crate::ir_passes::Allocation;
 use crate::types::PhpType;
 
 use super::frame::FrameLayout;
@@ -30,6 +31,8 @@ pub(super) struct FunctionContext<'a> {
     pub(super) emitter: &'a mut Emitter,
     pub(super) data: &'a mut DataSection,
     pub(super) placement: ValuePlacement,
+    pub(super) allocation: Allocation,
+    pub(super) callee_saved_offsets: Vec<(&'static str, usize)>,
     local_offsets: HashMap<LocalSlotId, usize>,
     promoted_ref_cells: HashSet<LocalSlotId>,
     try_handler_offsets: HashMap<i64, usize>,
@@ -62,6 +65,8 @@ impl<'a> FunctionContext<'a> {
             emitter,
             data,
             placement: layout.value_placement,
+            allocation: layout.allocation,
+            callee_saved_offsets: layout.callee_saved_offsets,
             local_offsets: layout.local_offsets,
             promoted_ref_cells: HashSet::new(),
             try_handler_offsets: layout.try_handler_offsets,
@@ -208,18 +213,37 @@ impl<'a> FunctionContext<'a> {
     }
 
     /// Loads a stored SSA value into the target's canonical result register(s).
+    ///
+    /// When the value lives in an allocated register, it is moved from there
+    /// into the result register instead of loaded from a stack slot.
     pub(super) fn load_value_to_result(&mut self, value: ValueId) -> Result<PhpType> {
         let ty = self.value_php_type(value)?;
-        let offset = self.value_offset(value)?;
-        abi::emit_load(self.emitter, &ty.codegen_repr(), offset);
+        if let Some(reg) = self.allocation.register_of(value) {
+            let dst = if ty.codegen_repr() == PhpType::Float {
+                abi::float_result_reg(self.emitter)
+            } else {
+                abi::int_result_reg(self.emitter)
+            };
+            abi::emit_reg_move(self.emitter, dst, reg);
+        } else {
+            let offset = self.value_offset(value)?;
+            abi::emit_load(self.emitter, &ty.codegen_repr(), offset);
+        }
         Ok(ty)
     }
 
     /// Loads a single-register SSA value into a caller-selected register.
+    ///
+    /// When the value lives in an allocated register, it is moved register to
+    /// register (a no-op when the source already is the requested register).
     pub(super) fn load_value_to_reg(&mut self, value: ValueId, reg: &str) -> Result<PhpType> {
         let ty = self.value_php_type(value)?;
-        let offset = self.value_offset(value)?;
-        abi::load_at_offset(self.emitter, reg, offset);
+        if let Some(home) = self.allocation.register_of(value) {
+            abi::emit_reg_move(self.emitter, reg, home);
+        } else {
+            let offset = self.value_offset(value)?;
+            abi::load_at_offset(self.emitter, reg, offset);
+        }
         Ok(ty)
     }
 
@@ -286,11 +310,23 @@ impl<'a> FunctionContext<'a> {
         Ok(ty)
     }
 
-    /// Stores the current result register(s) into the SSA value's fixed stack slot.
+    /// Stores the current result register(s) into the SSA value's home.
+    ///
+    /// When the value lives in an allocated register, the result register is
+    /// moved into it; otherwise it is stored into the value's stack slot.
     pub(super) fn store_result_value(&mut self, value: ValueId) -> Result<()> {
         let ty = self.value_php_type(value)?;
-        let offset = self.value_offset(value)?;
-        self.store_current_result_at_offset(&ty, offset);
+        if let Some(reg) = self.allocation.register_of(value) {
+            let src = if ty.codegen_repr() == PhpType::Float {
+                abi::float_result_reg(self.emitter)
+            } else {
+                abi::int_result_reg(self.emitter)
+            };
+            abi::emit_reg_move(self.emitter, reg, src);
+        } else {
+            let offset = self.value_offset(value)?;
+            self.store_current_result_at_offset(&ty, offset);
+        }
         Ok(())
     }
 

--- a/src/codegen_ir/frame.rs
+++ b/src/codegen_ir/frame.rs
@@ -19,8 +19,9 @@ use crate::codegen::{
     emit_write_literal_stderr,
 };
 use crate::codegen::context::TRY_HANDLER_SLOT_SIZE;
-use crate::codegen::platform::Arch;
+use crate::codegen::platform::{Arch, Target};
 use crate::ir::{Function, Immediate, LocalKind, LocalSlotId, Op, Terminator, ValueDef};
+use crate::ir_passes::{allocate_registers, Allocation};
 use crate::types::PhpType;
 
 use super::context::FunctionContext;
@@ -28,17 +29,36 @@ use super::value_placement::{self, ValuePlacement};
 
 const FRAME_FOOTER_BYTES: usize = 16;
 
-/// Complete fixed frame layout for Phase 04 spill slots and addressable locals.
+/// Complete fixed frame layout for spill slots, addressable locals, and the
+/// callee-saved registers the register allocator decided to use.
 pub(super) struct FrameLayout {
     pub(super) value_placement: ValuePlacement,
     pub(super) local_offsets: HashMap<LocalSlotId, usize>,
     pub(super) try_handler_offsets: HashMap<i64, usize>,
     pub(super) concat_base_offset: usize,
     pub(super) frame_size: usize,
+    pub(super) allocation: Allocation,
+    pub(super) callee_saved_offsets: Vec<(&'static str, usize)>,
 }
 
-/// Computes fixed stack slots for SSA values and EIR locals.
-pub(super) fn layout_for_function(function: &Function) -> FrameLayout {
+/// Computes the register allocation and fixed stack slots for a function.
+///
+/// Every SSA value keeps a spill slot (register-allocated values simply leave
+/// theirs unused), and each callee-saved register the allocator uses gets a
+/// dedicated save slot so the prologue/epilogue can preserve it. When
+/// `regalloc_linear` is false the allocation is all-spilled, reproducing the
+/// original stack-only behavior.
+pub(super) fn layout_for_function(
+    function: &Function,
+    target: Target,
+    regalloc_linear: bool,
+) -> FrameLayout {
+    let allocation = if regalloc_linear {
+        allocate_registers(function, target)
+    } else {
+        Allocation::all_spilled()
+    };
+
     let value_placement = value_placement::allocate(function);
     let mut local_offsets = HashMap::new();
     let mut offset = value_placement.total_slot_bytes;
@@ -56,6 +76,11 @@ pub(super) fn layout_for_function(function: &Function) -> FrameLayout {
         offset += TRY_HANDLER_SLOT_SIZE;
         try_handler_offsets.insert(token, offset);
     }
+    let mut callee_saved_offsets = Vec::new();
+    for reg in allocation.used_callee_saved() {
+        offset += 8;
+        callee_saved_offsets.push((*reg, offset));
+    }
     offset += 8;
     let concat_base_offset = offset;
     let frame_size = align_to_16(offset + FRAME_FOOTER_BYTES);
@@ -65,6 +90,34 @@ pub(super) fn layout_for_function(function: &Function) -> FrameLayout {
         try_handler_offsets,
         concat_base_offset,
         frame_size,
+        allocation,
+        callee_saved_offsets,
+    }
+}
+
+/// Saves the callee-saved registers the allocator used into their reserved
+/// frame slots, preserving the caller's values for the function's lifetime.
+fn emit_callee_saved_saves(ctx: &mut FunctionContext<'_>) {
+    if ctx.callee_saved_offsets.is_empty() {
+        return;
+    }
+    ctx.emitter
+        .comment("save callee-saved registers used by the register allocator");
+    for (reg, offset) in ctx.callee_saved_offsets.clone() {
+        abi::store_at_offset(ctx.emitter, reg, offset);
+    }
+}
+
+/// Restores the callee-saved registers saved by `emit_callee_saved_saves`,
+/// returning the caller's values before frame teardown.
+fn emit_callee_saved_restores(ctx: &mut FunctionContext<'_>) {
+    if ctx.callee_saved_offsets.is_empty() {
+        return;
+    }
+    ctx.emitter
+        .comment("restore callee-saved registers used by the register allocator");
+    for (reg, offset) in ctx.callee_saved_offsets.clone() {
+        abi::load_at_offset(ctx.emitter, reg, offset);
     }
 }
 
@@ -94,6 +147,7 @@ pub(super) fn emit_main_prologue(ctx: &mut FunctionContext<'_>) {
     ctx.emitter.entry_label();
     abi::emit_frame_prologue(ctx.emitter, ctx.frame_size);
     capture_concat_base(ctx);
+    emit_callee_saved_saves(ctx);
     ctx.emitter.comment("save argc/argv to globals");
     abi::emit_store_process_args_to_globals(ctx.emitter);
     if ctx.heap_debug {
@@ -118,6 +172,7 @@ pub(super) fn emit_function_prologue_with_label(
     ctx.emitter.label_global(entry_label);
     abi::emit_frame_prologue(ctx.emitter, ctx.frame_size);
     capture_concat_base(ctx);
+    emit_callee_saved_saves(ctx);
     let mut incoming_args = abi::IncomingArgCursor::for_target(ctx.emitter.target, 0);
     for (index, param) in ctx.function.params.iter().enumerate() {
         let slot = LocalSlotId::from_raw(index as u32);
@@ -160,6 +215,7 @@ pub(super) fn emit_main_epilogue(ctx: &mut FunctionContext<'_>) {
     ctx.emitter.blank();
     ctx.emitter.comment("epilogue + exit(0)");
     emit_main_local_epilogue_cleanup(ctx);
+    emit_callee_saved_restores(ctx);
     abi::emit_frame_restore(ctx.emitter, ctx.frame_size);
     if ctx.gc_stats {
         emit_gc_stats(ctx);
@@ -562,6 +618,7 @@ pub(super) fn emit_function_epilogue(ctx: &mut FunctionContext<'_>) {
         .expect("codegen_ir bug: user function has no epilogue label");
     ctx.emitter.label(&label);
     emit_function_local_epilogue_cleanup(ctx);
+    emit_callee_saved_restores(ctx);
     abi::emit_frame_restore(ctx.emitter, ctx.frame_size);
     abi::emit_return(ctx.emitter);
     ctx.epilogue_emitted = true;

--- a/src/codegen_ir/mod.rs
+++ b/src/codegen_ir/mod.rs
@@ -96,10 +96,14 @@ pub fn generate_user_asm_from_ir(
         false,
         Emit::Executable,
         &exported_functions,
+        true,
     )
 }
 
 /// Generates user-code assembly from EIR using the same artifact options as the CLI pipeline.
+///
+/// `regalloc_linear` selects the linear-scan register allocator; when false the
+/// backend keeps every value on the stack (the `--regalloc=stack` fallback).
 pub fn generate_user_asm_from_ir_with_options(
     module: &Module,
     gc_stats: bool,
@@ -107,6 +111,7 @@ pub fn generate_user_asm_from_ir_with_options(
     requires_elephc_tls: bool,
     emit: Emit,
     exported_functions: &HashMap<String, ExportedFunction>,
+    regalloc_linear: bool,
 ) -> Result<String> {
     let mut emitter = match emit {
         Emit::Cdylib => Emitter::new_pic(module.target),
@@ -124,6 +129,7 @@ pub fn generate_user_asm_from_ir_with_options(
         heap_debug,
         requires_elephc_tls,
         emit,
+        regalloc_linear,
     )?;
     Ok(finalize_user_asm(module, emitter, data, emit, exported_functions))
 }

--- a/src/ir_passes/allocation.rs
+++ b/src/ir_passes/allocation.rs
@@ -1,0 +1,75 @@
+//! Purpose:
+//! The output of register allocation: where each EIR value lives (a physical
+//! register or its stack spill slot) and which callee-saved registers the
+//! function must preserve.
+//!
+//! Called from:
+//! - `crate::ir_passes::regalloc` produces it; the `codegen_ir` backend
+//!   consumes it through the value-access chokepoints and frame layout.
+//!
+//! Key details:
+//! - Registers are `&'static str` names, matching the rest of the backend.
+//! - A value with no register assignment is implicitly spilled: it keeps the
+//!   stack slot the frame layout reserved for it.
+
+use std::collections::HashMap;
+
+use crate::ir::ValueId;
+
+/// Where a value lives for the span the allocator assigned it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Location {
+    /// The value lives in this physical register.
+    Register(&'static str),
+    /// The value lives in its stack slot (no register assigned).
+    Spilled,
+}
+
+/// Register-allocation result for one function.
+#[derive(Debug, Clone, Default)]
+pub struct Allocation {
+    registers: HashMap<ValueId, &'static str>,
+    callee_saved: Vec<&'static str>,
+}
+
+impl Allocation {
+    /// Returns an allocation that keeps every value on the stack. Used for the
+    /// `stack` fallback and for functions the allocator declines to handle.
+    pub fn all_spilled() -> Self {
+        Self::default()
+    }
+
+    /// Builds an allocation from a value-to-register map and the set of
+    /// callee-saved registers it used, deduplicated and ordered for stable
+    /// prologue/epilogue emission.
+    pub(super) fn from_assignments(
+        registers: HashMap<ValueId, &'static str>,
+        mut callee_saved: Vec<&'static str>,
+    ) -> Self {
+        callee_saved.sort_unstable();
+        callee_saved.dedup();
+        Self {
+            registers,
+            callee_saved,
+        }
+    }
+
+    /// Returns where `value` lives: its register, or spilled if unassigned.
+    pub fn location(&self, value: ValueId) -> Location {
+        match self.registers.get(&value) {
+            Some(reg) => Location::Register(reg),
+            None => Location::Spilled,
+        }
+    }
+
+    /// Returns the register assigned to `value`, if any.
+    pub fn register_of(&self, value: ValueId) -> Option<&'static str> {
+        self.registers.get(&value).copied()
+    }
+
+    /// Returns the callee-saved registers this function must save in its
+    /// prologue and restore in its epilogue.
+    pub fn used_callee_saved(&self) -> &[&'static str] {
+        &self.callee_saved
+    }
+}

--- a/src/ir_passes/cfg.rs
+++ b/src/ir_passes/cfg.rs
@@ -1,0 +1,70 @@
+//! Purpose:
+//! Control-flow-graph helpers shared by the IR-level passes: successor lookup
+//! and reverse-postorder block ordering.
+//!
+//! Called from:
+//! - `crate::ir_passes::liveness` and `crate::ir_passes::intervals`.
+//!
+//! Key details:
+//! - Reverse postorder visits a definition before its dominated uses on
+//!   reducible CFGs, which is the order the linear-scan numbering relies on.
+
+use std::collections::HashSet;
+
+use crate::ir::{BlockId, Function, Terminator};
+
+/// Returns the successor blocks branched to by a terminator, in branch order.
+pub(super) fn successors(term: &Terminator) -> Vec<BlockId> {
+    match term {
+        Terminator::Br { target, .. } => vec![*target],
+        Terminator::CondBr {
+            then_target,
+            else_target,
+            ..
+        } => vec![*then_target, *else_target],
+        Terminator::Switch { cases, default, .. } => {
+            let mut targets: Vec<BlockId> = cases.iter().map(|case| case.target).collect();
+            targets.push(*default);
+            targets
+        }
+        Terminator::GeneratorSuspend { resume, .. } => vec![*resume],
+        Terminator::Return { .. }
+        | Terminator::Throw { .. }
+        | Terminator::Fatal { .. }
+        | Terminator::Unreachable => Vec::new(),
+    }
+}
+
+/// Computes the reverse-postorder traversal of `func`'s reachable blocks
+/// starting from the entry block.
+///
+/// Uses an explicit work stack rather than recursion so deeply nested functions
+/// cannot overflow. Blocks unreachable from the entry are omitted.
+pub(super) fn reverse_postorder(func: &Function) -> Vec<BlockId> {
+    let mut visited: HashSet<BlockId> = HashSet::new();
+    let mut postorder: Vec<BlockId> = Vec::new();
+    let mut stack: Vec<(BlockId, bool)> = vec![(func.entry, false)];
+
+    while let Some((block_id, processed)) = stack.pop() {
+        if processed {
+            postorder.push(block_id);
+            continue;
+        }
+        if !visited.insert(block_id) {
+            continue;
+        }
+        stack.push((block_id, true));
+        if let Some(block) = func.block(block_id) {
+            if let Some(term) = &block.terminator {
+                for succ in successors(term) {
+                    if !visited.contains(&succ) {
+                        stack.push((succ, false));
+                    }
+                }
+            }
+        }
+    }
+
+    postorder.reverse();
+    postorder
+}

--- a/src/ir_passes/intervals.rs
+++ b/src/ir_passes/intervals.rs
@@ -1,0 +1,146 @@
+//! Purpose:
+//! Builds linear-program-order live intervals for EIR values from per-block
+//! liveness. Intervals are the input to the linear-scan register allocator.
+//!
+//! Called from:
+//! - `crate::ir_passes::regalloc` (register allocation core).
+//!
+//! Key details:
+//! - Blocks are numbered in reverse postorder. Each block reserves a position
+//!   for its parameters (block entry), one per instruction, and one for its
+//!   terminator. Intervals are contiguous `[start, end]` ranges (classic
+//!   Poletto-Sarkar): a value is conservatively considered live across any hole
+//!   between its definition and its last use.
+
+use std::collections::HashMap;
+
+use crate::ir::{BlockId, Function, InstId, IrType, ValueDef, ValueId};
+use crate::ir_passes::cfg::reverse_postorder;
+use crate::ir_passes::liveness::{terminator_uses, LivenessInfo};
+
+/// A value's contiguous live range in linear program order: live from `start`
+/// (its definition point) through `end` (its last use or last live-out point).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveInterval {
+    /// The value this interval describes.
+    pub value: ValueId,
+    /// The value's IR type, used by the allocator to pick a register pool.
+    pub ir_type: IrType,
+    /// Linear position of the value's definition.
+    pub start: u32,
+    /// Linear position of the value's last use or last live-out edge.
+    pub end: u32,
+}
+
+/// Linear position numbering for a function: where each block's parameters,
+/// instructions, and terminator sit on the single linear axis the allocator
+/// scans.
+struct LinearNumbering {
+    /// Position assigned to a block's entry (where its parameters are defined).
+    block_start: HashMap<BlockId, u32>,
+    /// Position assigned to a block's terminator (its last live-out point).
+    block_end: HashMap<BlockId, u32>,
+    /// Position assigned to each instruction.
+    inst_pos: HashMap<InstId, u32>,
+    /// Blocks in reverse postorder, the order positions were assigned in.
+    order: Vec<BlockId>,
+}
+
+/// Numbers blocks in reverse postorder. Each block reserves one position for
+/// its entry/parameters, one per instruction, and one for its terminator, so
+/// definitions precede their dominated uses on the linear axis.
+fn number_positions(func: &Function) -> LinearNumbering {
+    let order = reverse_postorder(func);
+    let mut block_start = HashMap::new();
+    let mut block_end = HashMap::new();
+    let mut inst_pos = HashMap::new();
+    let mut pos = 0u32;
+
+    for &block_id in &order {
+        let block = func.block(block_id).expect("ordered block exists");
+        block_start.insert(block_id, pos);
+        pos += 1;
+        for inst_id in &block.instructions {
+            inst_pos.insert(*inst_id, pos);
+            pos += 1;
+        }
+        block_end.insert(block_id, pos);
+        pos += 1;
+    }
+
+    LinearNumbering {
+        block_start,
+        block_end,
+        inst_pos,
+        order,
+    }
+}
+
+/// Builds one contiguous live interval per value defined in a reachable block.
+///
+/// The start is the value's definition position. The end is the maximum of its
+/// use positions (instruction operands and terminator uses) and the terminator
+/// position of every block where the value is live-out, so values that stay
+/// live across edges and loop back-edges span the intervening positions.
+pub fn build_intervals(func: &Function, liveness: &LivenessInfo) -> Vec<LiveInterval> {
+    let numbering = number_positions(func);
+
+    let mut starts: HashMap<ValueId, u32> = HashMap::new();
+    let mut ends: HashMap<ValueId, u32> = HashMap::new();
+
+    // Seed each value with its definition position. Values defined in blocks
+    // unreachable from entry have no position and are skipped entirely.
+    for (index, value) in func.values.iter().enumerate() {
+        let value_id = ValueId::from_raw(index as u32);
+        let def_pos = match &value.def {
+            ValueDef::BlockParam { block, .. } => numbering.block_start.get(block).copied(),
+            ValueDef::Instruction { inst, .. } => numbering.inst_pos.get(inst).copied(),
+        };
+        if let Some(def_pos) = def_pos {
+            starts.insert(value_id, def_pos);
+            ends.insert(value_id, def_pos);
+        }
+    }
+
+    let extend = |value: ValueId, position: u32, ends: &mut HashMap<ValueId, u32>| {
+        if let Some(end) = ends.get_mut(&value) {
+            if position > *end {
+                *end = position;
+            }
+        }
+    };
+
+    for &block_id in &numbering.order {
+        let block = func.block(block_id).expect("ordered block exists");
+
+        for inst_id in &block.instructions {
+            let position = numbering.inst_pos[inst_id];
+            let inst = func.instruction(*inst_id).expect("valid instruction");
+            for operand in &inst.operands {
+                extend(*operand, position, &mut ends);
+            }
+        }
+
+        let terminator_position = numbering.block_end[&block_id];
+        if let Some(term) = &block.terminator {
+            for value in terminator_uses(term) {
+                extend(value, terminator_position, &mut ends);
+            }
+        }
+        for value in liveness.live_out_of(block_id) {
+            extend(*value, terminator_position, &mut ends);
+        }
+    }
+
+    let mut intervals: Vec<LiveInterval> = starts
+        .into_iter()
+        .map(|(value, start)| LiveInterval {
+            value,
+            ir_type: func.value(value).expect("value exists").ir_type,
+            start,
+            end: ends[&value].max(start),
+        })
+        .collect();
+    intervals.sort_by_key(|iv| (iv.start, iv.value.as_raw()));
+    intervals
+}

--- a/src/ir_passes/liveness.rs
+++ b/src/ir_passes/liveness.rs
@@ -133,7 +133,7 @@ fn block_facts(func: &Function, block: &BasicBlock) -> BlockFacts {
     let successors = block
         .terminator
         .as_ref()
-        .map(terminator_successors)
+        .map(crate::ir_passes::cfg::successors)
         .unwrap_or_default();
 
     BlockFacts {
@@ -145,7 +145,7 @@ fn block_facts(func: &Function, block: &BasicBlock) -> BlockFacts {
 
 /// Collects every value used by a terminator: branch arguments, conditions,
 /// switch scrutinees, returned/thrown values, and generator suspend operands.
-fn terminator_uses(term: &Terminator) -> Vec<ValueId> {
+pub(super) fn terminator_uses(term: &Terminator) -> Vec<ValueId> {
     match term {
         Terminator::Br { args, .. } => args.clone(),
         Terminator::CondBr {
@@ -186,27 +186,5 @@ fn terminator_uses(term: &Terminator) -> Vec<ValueId> {
             uses
         }
         Terminator::Fatal { .. } | Terminator::Unreachable => Vec::new(),
-    }
-}
-
-/// Collects the successor blocks branched to by a terminator.
-fn terminator_successors(term: &Terminator) -> Vec<BlockId> {
-    match term {
-        Terminator::Br { target, .. } => vec![*target],
-        Terminator::CondBr {
-            then_target,
-            else_target,
-            ..
-        } => vec![*then_target, *else_target],
-        Terminator::Switch { cases, default, .. } => {
-            let mut targets: Vec<BlockId> = cases.iter().map(|case| case.target).collect();
-            targets.push(*default);
-            targets
-        }
-        Terminator::GeneratorSuspend { resume, .. } => vec![*resume],
-        Terminator::Return { .. }
-        | Terminator::Throw { .. }
-        | Terminator::Fatal { .. }
-        | Terminator::Unreachable => Vec::new(),
     }
 }

--- a/src/ir_passes/liveness.rs
+++ b/src/ir_passes/liveness.rs
@@ -1,0 +1,212 @@
+//! Purpose:
+//! Backward dataflow liveness analysis over EIR functions. Computes per-block
+//! live-in and live-out value sets, the foundation for live-interval
+//! construction in the linear-scan register allocator.
+//!
+//! Called from:
+//! - `crate::ir_passes` interval construction and register allocation.
+//!
+//! Key details:
+//! - SSA-lite with block parameters: a block parameter is "defined" at block
+//!   entry; branch arguments at a terminator are "uses" at that terminator.
+//! - Iterates to a fixed point so loops converge; the CFG is small so a simple
+//!   worklist over blocks is sufficient.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::ir::{BasicBlock, BlockId, Function, Terminator, ValueId};
+
+/// Per-block liveness result: which values are live entering and leaving each
+/// block. Live-in/live-out are keyed by `BlockId` for every block in the
+/// function.
+pub struct LivenessInfo {
+    live_in: HashMap<BlockId, HashSet<ValueId>>,
+    live_out: HashMap<BlockId, HashSet<ValueId>>,
+}
+
+impl LivenessInfo {
+    /// Returns the set of values live on entry to `block`.
+    pub fn live_in_of(&self, block: BlockId) -> &HashSet<ValueId> {
+        self.live_in
+            .get(&block)
+            .expect("liveness queried for unknown block")
+    }
+
+    /// Returns the set of values live on exit from `block`.
+    pub fn live_out_of(&self, block: BlockId) -> &HashSet<ValueId> {
+        self.live_out
+            .get(&block)
+            .expect("liveness queried for unknown block")
+    }
+}
+
+/// Per-block local liveness facts, independent of control flow: the values
+/// defined in the block and the upward-exposed uses (used before any definition
+/// in the same block).
+struct BlockFacts {
+    /// Values defined in the block: instruction results plus block parameters.
+    defs: HashSet<ValueId>,
+    /// Values used in the block that are not defined in the block.
+    upward_uses: HashSet<ValueId>,
+    /// Successor blocks reached from this block's terminator.
+    successors: Vec<BlockId>,
+}
+
+/// Computes per-block liveness for `func` via backward dataflow to a fixed
+/// point.
+///
+/// Block parameters are treated as definitions at block entry, so values passed
+/// as branch arguments are uses in the predecessor's terminator and do not leak
+/// backwards through the successor's parameters. SSA single-definition lets us
+/// derive upward-exposed uses by simply excluding block-local definitions.
+pub fn compute_liveness(func: &Function) -> LivenessInfo {
+    let facts: HashMap<BlockId, BlockFacts> = func
+        .blocks
+        .iter()
+        .map(|block| (block.id, block_facts(func, block)))
+        .collect();
+
+    let mut live_in: HashMap<BlockId, HashSet<ValueId>> = func
+        .blocks
+        .iter()
+        .map(|block| (block.id, HashSet::new()))
+        .collect();
+    let mut live_out: HashMap<BlockId, HashSet<ValueId>> = live_in.clone();
+
+    // Iterate backwards over the block list until the sets stop changing. The
+    // CFG is small, so repeated full sweeps converge quickly without an
+    // explicit predecessor worklist.
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for block in func.blocks.iter().rev() {
+            let f = &facts[&block.id];
+
+            let mut new_out = HashSet::new();
+            for succ in &f.successors {
+                new_out.extend(live_in[succ].iter().copied());
+            }
+
+            let mut new_in = f.upward_uses.clone();
+            for value in new_out.iter().copied() {
+                if !f.defs.contains(&value) {
+                    new_in.insert(value);
+                }
+            }
+
+            if new_out != live_out[&block.id] || new_in != live_in[&block.id] {
+                changed = true;
+                live_out.insert(block.id, new_out);
+                live_in.insert(block.id, new_in);
+            }
+        }
+    }
+
+    LivenessInfo { live_in, live_out }
+}
+
+/// Computes the control-flow-independent liveness facts for a single block:
+/// its definitions, its upward-exposed uses, and its successors.
+fn block_facts(func: &Function, block: &BasicBlock) -> BlockFacts {
+    let mut defs: HashSet<ValueId> = block.params.iter().copied().collect();
+    let mut uses: HashSet<ValueId> = HashSet::new();
+
+    for inst_id in &block.instructions {
+        let inst = func
+            .instruction(*inst_id)
+            .expect("block references a valid instruction");
+        for operand in &inst.operands {
+            uses.insert(*operand);
+        }
+        if let Some(result) = inst.result {
+            defs.insert(result);
+        }
+    }
+
+    if let Some(term) = &block.terminator {
+        for value in terminator_uses(term) {
+            uses.insert(value);
+        }
+    }
+
+    let upward_uses = uses.difference(&defs).copied().collect();
+    let successors = block
+        .terminator
+        .as_ref()
+        .map(terminator_successors)
+        .unwrap_or_default();
+
+    BlockFacts {
+        defs,
+        upward_uses,
+        successors,
+    }
+}
+
+/// Collects every value used by a terminator: branch arguments, conditions,
+/// switch scrutinees, returned/thrown values, and generator suspend operands.
+fn terminator_uses(term: &Terminator) -> Vec<ValueId> {
+    match term {
+        Terminator::Br { args, .. } => args.clone(),
+        Terminator::CondBr {
+            cond,
+            then_args,
+            else_args,
+            ..
+        } => {
+            let mut uses = vec![*cond];
+            uses.extend(then_args.iter().copied());
+            uses.extend(else_args.iter().copied());
+            uses
+        }
+        Terminator::Switch {
+            scrutinee,
+            cases,
+            default_args,
+            ..
+        } => {
+            let mut uses = vec![*scrutinee];
+            for case in cases {
+                uses.extend(case.args.iter().copied());
+            }
+            uses.extend(default_args.iter().copied());
+            uses
+        }
+        Terminator::Return { value } => value.iter().copied().collect(),
+        Terminator::Throw { value } => vec![*value],
+        Terminator::GeneratorSuspend {
+            key,
+            value,
+            resume_args,
+            ..
+        } => {
+            let mut uses: Vec<ValueId> = key.iter().copied().collect();
+            uses.extend(value.iter().copied());
+            uses.extend(resume_args.iter().copied());
+            uses
+        }
+        Terminator::Fatal { .. } | Terminator::Unreachable => Vec::new(),
+    }
+}
+
+/// Collects the successor blocks branched to by a terminator.
+fn terminator_successors(term: &Terminator) -> Vec<BlockId> {
+    match term {
+        Terminator::Br { target, .. } => vec![*target],
+        Terminator::CondBr {
+            then_target,
+            else_target,
+            ..
+        } => vec![*then_target, *else_target],
+        Terminator::Switch { cases, default, .. } => {
+            let mut targets: Vec<BlockId> = cases.iter().map(|case| case.target).collect();
+            targets.push(*default);
+            targets
+        }
+        Terminator::GeneratorSuspend { resume, .. } => vec![*resume],
+        Terminator::Return { .. }
+        | Terminator::Throw { .. }
+        | Terminator::Fatal { .. }
+        | Terminator::Unreachable => Vec::new(),
+    }
+}

--- a/src/ir_passes/mod.rs
+++ b/src/ir_passes/mod.rs
@@ -10,9 +10,12 @@
 //! - Passes are read-only or produce sidecar tables (e.g. liveness, allocation).
 //!   They do not mutate `Function` in place.
 
+mod cfg;
+mod intervals;
 mod liveness;
 
 #[cfg(test)]
 mod tests;
 
+pub use intervals::{build_intervals, LiveInterval};
 pub use liveness::{compute_liveness, LivenessInfo};

--- a/src/ir_passes/mod.rs
+++ b/src/ir_passes/mod.rs
@@ -10,12 +10,16 @@
 //! - Passes are read-only or produce sidecar tables (e.g. liveness, allocation).
 //!   They do not mutate `Function` in place.
 
+mod allocation;
 mod cfg;
 mod intervals;
 mod liveness;
+mod regalloc;
 
 #[cfg(test)]
 mod tests;
 
+pub use allocation::{Allocation, Location};
 pub use intervals::{build_intervals, LiveInterval};
 pub use liveness::{compute_liveness, LivenessInfo};
+pub use regalloc::allocate_registers;

--- a/src/ir_passes/mod.rs
+++ b/src/ir_passes/mod.rs
@@ -1,0 +1,18 @@
+//! Purpose:
+//! IR-level analyses and transformations over EIR functions. Phase 06 starts
+//! here with liveness analysis, the foundation for the linear-scan register
+//! allocator. Later phases (peephole, CSE, LICM) live alongside it.
+//!
+//! Called from:
+//! - `crate::pipeline::compile()` after AST-to-EIR lowering, before codegen.
+//!
+//! Key details:
+//! - Passes are read-only or produce sidecar tables (e.g. liveness, allocation).
+//!   They do not mutate `Function` in place.
+
+mod liveness;
+
+#[cfg(test)]
+mod tests;
+
+pub use liveness::{compute_liveness, LivenessInfo};

--- a/src/ir_passes/regalloc.rs
+++ b/src/ir_passes/regalloc.rs
@@ -224,7 +224,10 @@ fn is_float_reg(reg: &str) -> bool {
 fn int_pool(target: Target) -> &'static [&'static str] {
     match target.arch {
         Arch::AArch64 => &["x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28"],
-        Arch::X86_64 => &["rbx", "r14", "r15"],
+        // Only rbx is reliably preserved across the hand-written x86_64 runtime
+        // routines and shared heap-marker codegen; r14/r15 are used there as
+        // scratch without ABI-compliant save/restore, so they are not allocated.
+        Arch::X86_64 => &["rbx"],
     }
 }
 

--- a/src/ir_passes/regalloc.rs
+++ b/src/ir_passes/regalloc.rs
@@ -1,0 +1,239 @@
+//! Purpose:
+//! Linear-scan register allocator (Poletto-Sarkar) over EIR functions. Assigns
+//! callee-saved registers to non-overlapping value live intervals, spilling to
+//! the stack under register pressure, with separate integer and float pools.
+//!
+//! Called from:
+//! - `crate::codegen_ir` per function, before instruction lowering.
+//!
+//! Key details:
+//! - Only callee-saved registers are allocated. They survive calls (so values
+//!   may live across calls without spilling) and are disjoint from the scratch
+//!   and result registers the instruction emitters use.
+//! - First cut: only single-word `NonHeap` scalars (`I64`, `F64`) are
+//!   register-eligible, and never block parameters or branch arguments, which
+//!   stay in stack slots so the existing block-parameter moves are unchanged.
+//!   Generators and functions with exception handlers fall back to all-spilled.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::codegen::platform::{Arch, Target};
+use crate::ir::{Function, IrType, Op, Ownership, Terminator, ValueId};
+use crate::ir_passes::allocation::Allocation;
+use crate::ir_passes::intervals::{build_intervals, LiveInterval};
+use crate::ir_passes::liveness::compute_liveness;
+
+/// Computes a register allocation for `func` on `target`.
+///
+/// Runs liveness and interval analysis, then a linear scan that assigns
+/// callee-saved registers to eligible intervals and spills the longest-lived
+/// interval when a pool is exhausted. Generators and functions containing
+/// exception handlers conservatively fall back to all-spilled.
+pub fn allocate_registers(func: &Function, target: Target) -> Allocation {
+    if func.flags.is_generator || has_exception_handlers(func) {
+        return Allocation::all_spilled();
+    }
+
+    let liveness = compute_liveness(func);
+    let intervals = build_intervals(func, &liveness);
+    let ineligible = ineligible_values(func);
+
+    let eligible: Vec<LiveInterval> = intervals
+        .into_iter()
+        .filter(|iv| is_eligible(func, iv, &ineligible))
+        .collect();
+
+    scan(&eligible, target)
+}
+
+/// Returns true when the function contains any exception handler. Such
+/// functions are skipped because a thrown exception may clobber registers
+/// before reaching a handler in this first cut.
+fn has_exception_handlers(func: &Function) -> bool {
+    func.instructions
+        .iter()
+        .any(|inst| inst.op == Op::TryPushHandler)
+}
+
+/// Collects values that must stay in stack slots regardless of their type:
+/// block parameters and values passed as branch arguments. These feed the
+/// slot-based block-parameter moves, which read them from their slots.
+fn ineligible_values(func: &Function) -> HashSet<ValueId> {
+    let mut ineligible = HashSet::new();
+    for block in &func.blocks {
+        for param in &block.params {
+            ineligible.insert(*param);
+        }
+        if let Some(term) = &block.terminator {
+            for arg in terminator_branch_args(term) {
+                ineligible.insert(arg);
+            }
+        }
+    }
+    ineligible
+}
+
+/// Returns the values a terminator passes as block-parameter arguments. These
+/// are distinct from condition/scrutinee/return uses, which are ordinary uses.
+fn terminator_branch_args(term: &Terminator) -> Vec<ValueId> {
+    match term {
+        Terminator::Br { args, .. } => args.clone(),
+        Terminator::CondBr {
+            then_args,
+            else_args,
+            ..
+        } => then_args.iter().chain(else_args).copied().collect(),
+        Terminator::Switch {
+            cases,
+            default_args,
+            ..
+        } => cases
+            .iter()
+            .flat_map(|case| case.args.iter().copied())
+            .chain(default_args.iter().copied())
+            .collect(),
+        Terminator::GeneratorSuspend { resume_args, .. } => resume_args.clone(),
+        Terminator::Return { .. }
+        | Terminator::Throw { .. }
+        | Terminator::Fatal { .. }
+        | Terminator::Unreachable => Vec::new(),
+    }
+}
+
+/// Returns true when an interval's value can live in a register: a single-word
+/// non-heap scalar that is not a block parameter or branch argument.
+fn is_eligible(func: &Function, iv: &LiveInterval, ineligible: &HashSet<ValueId>) -> bool {
+    if ineligible.contains(&iv.value) {
+        return false;
+    }
+    if !matches!(iv.ir_type, IrType::I64 | IrType::F64) {
+        return false;
+    }
+    func.value(iv.value)
+        .map(|value| value.ownership == Ownership::NonHeap)
+        .unwrap_or(false)
+}
+
+/// An interval currently holding a register during the scan.
+struct ActiveInterval {
+    /// Linear position where the interval ends.
+    end: u32,
+    /// Register the interval occupies.
+    reg: &'static str,
+    /// Value the interval describes.
+    value: ValueId,
+}
+
+/// Runs the linear scan over already-eligible, start-sorted intervals.
+///
+/// Maintains per-pool free lists and an active set. On pool exhaustion it
+/// spills the interval (active or current) whose end is furthest away, the
+/// Poletto-Sarkar heuristic, so the shorter-lived value keeps the register.
+fn scan(eligible: &[LiveInterval], target: Target) -> Allocation {
+    let mut free_int: Vec<&'static str> = int_pool(target).iter().rev().copied().collect();
+    let mut free_float: Vec<&'static str> = float_pool(target).iter().rev().copied().collect();
+    let mut active: Vec<ActiveInterval> = Vec::new();
+    let mut assignments: HashMap<ValueId, &'static str> = HashMap::new();
+    let mut used: Vec<&'static str> = Vec::new();
+
+    for iv in eligible {
+        expire_old_intervals(&mut active, iv.start, &mut free_int, &mut free_float);
+
+        let is_float = iv.ir_type == IrType::F64;
+        let free = if is_float { &mut free_float } else { &mut free_int };
+
+        if let Some(reg) = free.pop() {
+            assignments.insert(iv.value, reg);
+            used.push(reg);
+            active.push(ActiveInterval {
+                end: iv.end,
+                reg,
+                value: iv.value,
+            });
+        } else {
+            spill_at_interval(iv, is_float, &mut active, &mut assignments);
+        }
+    }
+
+    Allocation::from_assignments(assignments, used)
+}
+
+/// Frees registers held by intervals that end at or before `position`, so the
+/// register can be reused by the interval starting there.
+fn expire_old_intervals(
+    active: &mut Vec<ActiveInterval>,
+    position: u32,
+    free_int: &mut Vec<&'static str>,
+    free_float: &mut Vec<&'static str>,
+) {
+    active.retain(|a| {
+        if a.end <= position {
+            if is_float_reg(a.reg) {
+                free_float.push(a.reg);
+            } else {
+                free_int.push(a.reg);
+            }
+            false
+        } else {
+            true
+        }
+    });
+}
+
+/// Resolves register pressure for `current` when its pool is empty: either
+/// steals a register from the active interval that ends latest (spilling that
+/// interval) or spills `current` itself, whichever lives longer stays.
+fn spill_at_interval(
+    current: &LiveInterval,
+    is_float: bool,
+    active: &mut Vec<ActiveInterval>,
+    assignments: &mut HashMap<ValueId, &'static str>,
+) {
+    let furthest = active
+        .iter()
+        .enumerate()
+        .filter(|(_, a)| is_float_reg(a.reg) == is_float)
+        .max_by_key(|(_, a)| a.end);
+
+    let Some((index, a)) = furthest else {
+        // The pool is empty for this type; `current` stays spilled.
+        return;
+    };
+
+    if a.end > current.end {
+        let reg = a.reg;
+        assignments.remove(&a.value);
+        active.remove(index);
+        assignments.insert(current.value, reg);
+        active.push(ActiveInterval {
+            end: current.end,
+            reg,
+            value: current.value,
+        });
+    }
+    // Otherwise `current` has the furthest end and stays spilled.
+}
+
+/// Returns true when `reg` names a floating-point register.
+fn is_float_reg(reg: &str) -> bool {
+    reg.starts_with('d') || reg.starts_with("xmm")
+}
+
+/// Returns the integer callee-saved register pool for `target`, excluding the
+/// frame pointer, scratch registers, and registers the emitters use inline.
+fn int_pool(target: Target) -> &'static [&'static str] {
+    match target.arch {
+        Arch::AArch64 => &["x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28"],
+        Arch::X86_64 => &["rbx", "r14", "r15"],
+    }
+}
+
+/// Returns the float callee-saved register pool for `target`. SysV x86_64 has
+/// no callee-saved XMM registers, so float values are never register-allocated
+/// there and must stay spilled.
+fn float_pool(target: Target) -> &'static [&'static str] {
+    match target.arch {
+        Arch::AArch64 => &["d8", "d9", "d10", "d11", "d12", "d13", "d14"],
+        Arch::X86_64 => &[],
+    }
+}

--- a/src/ir_passes/tests/intervals_test.rs
+++ b/src/ir_passes/tests/intervals_test.rs
@@ -1,0 +1,128 @@
+//! Purpose:
+//! Tests for linear-program-order live-interval construction over EIR.
+//!
+//! Called from:
+//! - `cargo test` through Rust's test harness.
+//!
+//! Key details:
+//! - Functions are built by hand with `crate::ir::Builder`. Tests assert
+//!   relational properties (overlap, definition order) rather than absolute
+//!   position numbers, so they survive numbering-scheme changes.
+
+use crate::ir::{Builder, Function, IrType, Terminator, ValueId};
+use crate::ir_passes::{build_intervals, compute_liveness, LiveInterval};
+use crate::types::PhpType;
+
+/// Returns the interval describing `value`, panicking if none exists.
+fn interval_for(intervals: &[LiveInterval], value: ValueId) -> &LiveInterval {
+    intervals
+        .iter()
+        .find(|iv| iv.value == value)
+        .expect("missing interval for value")
+}
+
+/// Two intervals overlap when each starts strictly before the other ends. A
+/// value whose last use coincides with another value's definition does not
+/// overlap, so the register can be reused.
+fn overlap(a: &LiveInterval, b: &LiveInterval) -> bool {
+    a.start < b.end && b.start < a.end
+}
+
+/// In `v2 = v0 + v1`, the two operands are live simultaneously (they overlap),
+/// the result begins where the operands die (no overlap with either, so it can
+/// reuse a register), and definition order follows program order.
+#[test]
+fn straight_line_add_intervals_overlap_and_order() {
+    let mut function = Function::new("add".to_string(), IrType::I64, PhpType::Int);
+    {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+        let v0 = builder.emit_const_i64(1);
+        let v1 = builder.emit_const_i64(2);
+        let v2 = builder.emit_iadd(v0, v1);
+        builder.terminate(Terminator::Return { value: Some(v2) });
+    }
+
+    let v0 = ValueId::from_raw(0);
+    let v1 = ValueId::from_raw(1);
+    let v2 = ValueId::from_raw(2);
+    let liveness = compute_liveness(&function);
+    let intervals = build_intervals(&function, &liveness);
+
+    assert_eq!(intervals.len(), 3, "one interval per defined value");
+
+    let iv0 = interval_for(&intervals, v0);
+    let iv1 = interval_for(&intervals, v1);
+    let iv2 = interval_for(&intervals, v2);
+
+    assert!(iv0.start < iv0.end, "v0 spans a real range");
+    assert!(overlap(iv0, iv1), "both operands are live at the add");
+    assert!(
+        !overlap(iv0, iv2),
+        "v2 is born where v0 dies; it can reuse v0's register"
+    );
+    assert!(
+        !overlap(iv1, iv2),
+        "v2 is born where v1 dies; it can reuse v1's register"
+    );
+    assert!(iv0.start < iv1.start, "definition order follows program order");
+}
+
+/// A value defined before a loop and used inside it must have an interval that
+/// reaches past the loop body. Its end must be at least the position of its
+/// in-loop use, which (because the body is numbered after the entry) is greater
+/// than its definition point.
+#[test]
+fn loop_invariant_interval_spans_the_loop_body() {
+    let mut function = Function::new("loop_iv".to_string(), IrType::I64, PhpType::Int);
+    {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        let header = builder.create_named_block("header", vec![]);
+        let exit = builder.create_named_block("exit", vec![]);
+        builder.set_entry(entry);
+
+        builder.position_at_end(entry);
+        let invariant = builder.emit_const_i64(10);
+        builder.terminate(Terminator::Br {
+            target: header,
+            args: vec![],
+        });
+
+        builder.position_at_end(header);
+        let step = builder.emit_const_i64(1);
+        let _acc = builder.emit_iadd(invariant, step);
+        let cond = builder.emit_const_i64(0);
+        builder.terminate(Terminator::CondBr {
+            cond,
+            then_target: header,
+            then_args: vec![],
+            else_target: exit,
+            else_args: vec![],
+        });
+
+        builder.position_at_end(exit);
+        builder.terminate(Terminator::Return {
+            value: Some(invariant),
+        });
+    }
+
+    let invariant = ValueId::from_raw(0);
+    let step = ValueId::from_raw(1);
+    let liveness = compute_liveness(&function);
+    let intervals = build_intervals(&function, &liveness);
+
+    let iv_invariant = interval_for(&intervals, invariant);
+    let iv_step = interval_for(&intervals, step);
+
+    assert!(
+        iv_invariant.end > iv_step.start,
+        "invariant outlives the loop-body temporary that uses it"
+    );
+    assert!(
+        overlap(iv_invariant, iv_step),
+        "invariant is still live where the loop body computes with it"
+    );
+}

--- a/src/ir_passes/tests/liveness_test.rs
+++ b/src/ir_passes/tests/liveness_test.rs
@@ -1,0 +1,166 @@
+//! Purpose:
+//! Tests for backward-dataflow liveness analysis over EIR functions.
+//!
+//! Called from:
+//! - `cargo test` through Rust's test harness.
+//!
+//! Key details:
+//! - Functions are built by hand with `crate::ir::Builder`. Values are
+//!   referenced by `ValueId::from_raw` using their definition order.
+
+use crate::ir::{Builder, Function, IrType, Terminator, ValueId};
+use crate::ir_passes::compute_liveness;
+use crate::types::PhpType;
+
+/// Two constants defined in the entry block are used in a successor block, so
+/// they must be live-out of entry and live-in of the body. Nothing escapes the
+/// body. This exercises the core cross-block propagation of the dataflow.
+#[test]
+fn values_used_in_successor_are_live_across_the_edge() {
+    let mut function = Function::new("cross_block".to_string(), IrType::I64, PhpType::Int);
+    let (entry, body) = {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        let body = builder.create_named_block("body", vec![]);
+        builder.set_entry(entry);
+
+        builder.position_at_end(entry);
+        let _v0 = builder.emit_const_i64(1);
+        let _v1 = builder.emit_const_i64(2);
+        builder.terminate(Terminator::Br {
+            target: body,
+            args: vec![],
+        });
+
+        builder.position_at_end(body);
+        let v0 = ValueId::from_raw(0);
+        let v1 = ValueId::from_raw(1);
+        let sum = builder.emit_iadd(v0, v1);
+        builder.terminate(Terminator::Return { value: Some(sum) });
+        (entry, body)
+    };
+
+    let v0 = ValueId::from_raw(0);
+    let v1 = ValueId::from_raw(1);
+    let liveness = compute_liveness(&function);
+
+    let entry_out = liveness.live_out_of(entry);
+    assert!(entry_out.contains(&v0), "v0 must be live-out of entry");
+    assert!(entry_out.contains(&v1), "v1 must be live-out of entry");
+
+    let body_in = liveness.live_in_of(body);
+    assert!(body_in.contains(&v0), "v0 must be live-in of body");
+    assert!(body_in.contains(&v1), "v1 must be live-in of body");
+
+    assert!(
+        liveness.live_in_of(entry).is_empty(),
+        "nothing is live entering the entry block"
+    );
+    assert!(
+        liveness.live_out_of(body).is_empty(),
+        "nothing escapes the body block"
+    );
+}
+
+/// A value defined before a loop and used on every iteration must stay live
+/// across the loop's back-edge. This only holds if the dataflow iterates to a
+/// fixed point: the value is live-out of the loop header because the header
+/// branches back to itself and still needs the value.
+#[test]
+fn loop_invariant_value_stays_live_across_the_back_edge() {
+    let mut function = Function::new("loop_live".to_string(), IrType::I64, PhpType::Int);
+    let (entry, header, exit) = {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        let header = builder.create_named_block("header", vec![]);
+        let exit = builder.create_named_block("exit", vec![]);
+        builder.set_entry(entry);
+
+        builder.position_at_end(entry);
+        let invariant = builder.emit_const_i64(10);
+        builder.terminate(Terminator::Br {
+            target: header,
+            args: vec![],
+        });
+
+        builder.position_at_end(header);
+        let step = builder.emit_const_i64(1);
+        let _acc = builder.emit_iadd(invariant, step);
+        let cond = builder.emit_const_i64(0);
+        builder.terminate(Terminator::CondBr {
+            cond,
+            then_target: header,
+            then_args: vec![],
+            else_target: exit,
+            else_args: vec![],
+        });
+
+        builder.position_at_end(exit);
+        builder.terminate(Terminator::Return {
+            value: Some(invariant),
+        });
+        (entry, header, exit)
+    };
+
+    let invariant = ValueId::from_raw(0);
+    let liveness = compute_liveness(&function);
+
+    assert!(
+        liveness.live_out_of(entry).contains(&invariant),
+        "invariant live leaving entry"
+    );
+    assert!(
+        liveness.live_in_of(header).contains(&invariant),
+        "invariant live entering the loop header"
+    );
+    assert!(
+        liveness.live_out_of(header).contains(&invariant),
+        "invariant must survive the back-edge: live-out of the header"
+    );
+    assert!(
+        liveness.live_in_of(exit).contains(&invariant),
+        "invariant live entering exit where it is returned"
+    );
+}
+
+/// A block parameter is a definition at block entry, not a value that flows in
+/// from predecessors. The argument passed across the edge is consumed at the
+/// predecessor's terminator, so the parameter's value never appears in the
+/// successor's live-in set, and the argument does not propagate as itself.
+#[test]
+fn block_parameter_is_a_definition_not_a_live_in() {
+    let mut function = Function::new("param_def".to_string(), IrType::I64, PhpType::Int);
+    let (entry, body, param) = {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        let body = builder.create_named_block("body", vec![(IrType::I64, PhpType::Int)]);
+        builder.set_entry(entry);
+
+        builder.position_at_end(entry);
+        let arg = builder.emit_const_i64(7);
+        builder.terminate(Terminator::Br {
+            target: body,
+            args: vec![arg],
+        });
+
+        let param = builder.block_param(body, 0);
+        builder.position_at_end(body);
+        builder.terminate(Terminator::Return { value: Some(param) });
+        (entry, body, param)
+    };
+
+    let liveness = compute_liveness(&function);
+
+    assert!(
+        !liveness.live_in_of(body).contains(&param),
+        "a block parameter is defined at entry, never live-in"
+    );
+    assert!(
+        liveness.live_in_of(body).is_empty(),
+        "the argument is consumed at the edge; nothing flows into body"
+    );
+    assert!(
+        liveness.live_out_of(entry).is_empty(),
+        "the branch argument does not propagate across the edge as itself"
+    );
+}

--- a/src/ir_passes/tests/mod.rs
+++ b/src/ir_passes/tests/mod.rs
@@ -8,4 +8,5 @@
 //! - Functions are built with `crate::ir::Builder` so the tests exercise the
 //!   real IR data model without going through AST lowering.
 
+mod intervals_test;
 mod liveness_test;

--- a/src/ir_passes/tests/mod.rs
+++ b/src/ir_passes/tests/mod.rs
@@ -10,3 +10,4 @@
 
 mod intervals_test;
 mod liveness_test;
+mod regalloc_test;

--- a/src/ir_passes/tests/mod.rs
+++ b/src/ir_passes/tests/mod.rs
@@ -1,0 +1,11 @@
+//! Purpose:
+//! Unit tests for Phase 06 IR-level passes, built on hand-constructed EIR.
+//!
+//! Called from:
+//! - `cargo test` through Rust's test harness.
+//!
+//! Key details:
+//! - Functions are built with `crate::ir::Builder` so the tests exercise the
+//!   real IR data model without going through AST lowering.
+
+mod liveness_test;

--- a/src/ir_passes/tests/regalloc_test.rs
+++ b/src/ir_passes/tests/regalloc_test.rs
@@ -1,0 +1,187 @@
+//! Purpose:
+//! Tests for the linear-scan register allocator over EIR functions.
+//!
+//! Called from:
+//! - `cargo test` through Rust's test harness.
+//!
+//! Key details:
+//! - Functions are built by hand with `crate::ir::Builder`. Tests target the
+//!   AArch64 pool (eight integer, seven float callee-saved registers) so pool
+//!   sizes are deterministic.
+
+use crate::codegen::platform::{Arch, Platform, Target};
+use crate::ir::{Builder, Function, Immediate, IrType, Op, Ownership, Terminator, ValueId};
+use crate::ir_passes::allocate_registers;
+use crate::types::PhpType;
+
+/// The AArch64 target used by these tests, giving a fixed pool size.
+fn aarch64() -> Target {
+    Target::new(Platform::Linux, Arch::AArch64)
+}
+
+/// Emits a float constant in the current block and returns its value.
+fn emit_const_f64(builder: &mut Builder<'_>, value: f64) -> ValueId {
+    builder
+        .emit(
+            Op::ConstF64,
+            vec![],
+            Some(Immediate::F64(value)),
+            IrType::F64,
+            PhpType::Float,
+            Ownership::NonHeap,
+        )
+        .expect("const_f64 produces a value")
+}
+
+/// Three integer temporaries with low register pressure each receive a
+/// register, and the function records the callee-saved registers it used.
+#[test]
+fn straight_line_integers_receive_registers() {
+    let mut function = Function::new("ints".to_string(), IrType::I64, PhpType::Int);
+    {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+        let v0 = builder.emit_const_i64(1);
+        let v1 = builder.emit_const_i64(2);
+        let v2 = builder.emit_iadd(v0, v1);
+        builder.terminate(Terminator::Return { value: Some(v2) });
+    }
+
+    let allocation = allocate_registers(&function, aarch64());
+
+    for raw in 0..3 {
+        let reg = allocation.register_of(ValueId::from_raw(raw));
+        assert!(reg.is_some(), "value v{raw} should receive a register");
+        assert!(
+            reg.unwrap().starts_with('x'),
+            "integer value v{raw} belongs in the integer pool"
+        );
+    }
+    assert!(
+        !allocation.used_callee_saved().is_empty(),
+        "assigning registers must record callee-saved usage"
+    );
+}
+
+/// With more simultaneously-live values than the pool holds, the allocator
+/// spills at least one value rather than assigning a register twice, and never
+/// reports using more registers than the pool provides.
+#[test]
+fn register_pressure_forces_spills() {
+    const COUNT: u32 = 12; // AArch64 integer pool holds 8
+    let mut function = Function::new("pressure".to_string(), IrType::I64, PhpType::Int);
+    {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+
+        let consts: Vec<ValueId> = (0..COUNT).map(|i| builder.emit_const_i64(i as i64)).collect();
+        // Fold left so every constant stays live until its add: the first add
+        // sees all later constants still pending, creating peak pressure.
+        let mut acc = consts[0];
+        for &c in &consts[1..] {
+            acc = builder.emit_iadd(acc, c);
+        }
+        builder.terminate(Terminator::Return { value: Some(acc) });
+    }
+
+    let allocation = allocate_registers(&function, aarch64());
+
+    let spilled = (0..COUNT)
+        .filter(|&i| allocation.register_of(ValueId::from_raw(i)).is_none())
+        .count();
+    assert!(spilled >= 1, "more live values than registers must spill some");
+    assert!(
+        allocation.used_callee_saved().len() <= 8,
+        "cannot use more than the eight-register integer pool"
+    );
+}
+
+/// Integer and float values draw from separate register pools.
+#[test]
+fn integers_and_floats_use_separate_pools() {
+    let mut function = Function::new("mixed".to_string(), IrType::I64, PhpType::Int);
+    let (int_val, float_val) = {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+        let i = builder.emit_const_i64(1);
+        let f = emit_const_f64(&mut builder, 2.5);
+        builder.terminate(Terminator::Return { value: Some(i) });
+        (i, f)
+    };
+
+    let allocation = allocate_registers(&function, aarch64());
+
+    assert!(
+        allocation.register_of(int_val).unwrap().starts_with('x'),
+        "integer value uses an x-register"
+    );
+    assert!(
+        allocation.register_of(float_val).unwrap().starts_with('d'),
+        "float value uses a d-register"
+    );
+}
+
+/// Block parameters and branch arguments stay in stack slots so the existing
+/// slot-based block-parameter moves remain correct.
+#[test]
+fn block_parameters_and_branch_arguments_stay_spilled() {
+    let mut function = Function::new("params".to_string(), IrType::I64, PhpType::Int);
+    let (arg, param) = {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        let body = builder.create_named_block("body", vec![(IrType::I64, PhpType::Int)]);
+        builder.set_entry(entry);
+
+        builder.position_at_end(entry);
+        let arg = builder.emit_const_i64(7);
+        builder.terminate(Terminator::Br {
+            target: body,
+            args: vec![arg],
+        });
+
+        let param = builder.block_param(body, 0);
+        builder.position_at_end(body);
+        builder.terminate(Terminator::Return { value: Some(param) });
+        (arg, param)
+    };
+
+    let allocation = allocate_registers(&function, aarch64());
+
+    assert_eq!(
+        allocation.register_of(arg),
+        None,
+        "a branch argument must stay in its slot"
+    );
+    assert_eq!(
+        allocation.register_of(param),
+        None,
+        "a block parameter must stay in its slot"
+    );
+}
+
+/// Generator functions fall back to all-spilled in this first cut, because
+/// values must live in the generator state frame across suspends.
+#[test]
+fn generator_functions_are_all_spilled() {
+    let mut function = Function::new("gen".to_string(), IrType::I64, PhpType::Int);
+    {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+        let v0 = builder.emit_const_i64(1);
+        builder.terminate(Terminator::Return { value: Some(v0) });
+    }
+    function.flags.is_generator = true;
+
+    let allocation = allocate_registers(&function, aarch64());
+
+    assert_eq!(allocation.register_of(ValueId::from_raw(0)), None);
+    assert!(allocation.used_callee_saved().is_empty());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@ pub mod intrinsics;
 pub mod ir;
 /// AST-to-EIR lowering pass used by `--emit-ir` diagnostics.
 pub mod ir_lower;
+/// IR-level analyses and transforms (liveness, intervals, register allocation).
+pub mod ir_passes;
 /// Lexer for tokenizing PHP source.
 pub mod lexer;
 /// Magic constant substitution.

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,8 @@ mod intrinsics;
 mod ir;
 #[allow(dead_code, unused_imports)]
 mod ir_lower;
+#[allow(dead_code, unused_imports)]
+mod ir_passes;
 mod linker;
 mod lexer;
 mod magic_constants;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -48,6 +48,7 @@ pub(crate) fn compile(config: CliConfig) {
         check_only,
         emit_timings,
         emit_source_map,
+        regalloc_linear,
         target,
         mut extra_link_libs,
         extra_link_paths,
@@ -286,6 +287,7 @@ pub(crate) fn compile(config: CliConfig) {
             requires_elephc_tls,
             emit,
             &exported_functions,
+            regalloc_linear,
         ) {
             Ok(asm) => asm,
             Err(err) => {

--- a/tests/codegen/support/compiler.rs
+++ b/tests/codegen/support/compiler.rs
@@ -165,6 +165,10 @@ pub(crate) fn compile_source_to_asm_with_defines_repr(
         }
         TestCodegenBackend::Ir => {
             let exported_functions = HashMap::new();
+            // Honor ELEPHC_REGALLOC so the whole codegen suite can be run under
+            // both the linear-scan allocator (default) and the stack fallback.
+            let regalloc_linear =
+                !matches!(std::env::var("ELEPHC_REGALLOC").as_deref(), Ok("stack"));
             let user_asm = elephc::codegen_ir::generate_user_asm_from_ir_with_options(
                 &ir_module,
                 gc_stats,
@@ -172,6 +176,7 @@ pub(crate) fn compile_source_to_asm_with_defines_repr(
                 requires_elephc_tls,
                 elephc::codegen::Emit::Executable,
                 &exported_functions,
+                regalloc_linear,
             )
             .expect("EIR backend codegen failed for codegen fixture");
             let runtime_features = ir_module.required_runtime_features;


### PR DESCRIPTION
- **docs: rewrite eir-06 plan for full linear-scan register allocator**
- **feat(ir_passes): implement liveness analysis for EIR functions**
- **feat(ir_passes): build linear-order live intervals from liveness**
- **feat(ir_passes): linear-scan allocator core with int/float pools and spilling**
- **feat(codegen_ir): wire linear-scan allocator into EIR backend behind --regalloc**
- **docs: document linear-scan register allocation in the-ir.md**
- **fix(ir_passes): restrict x86_64 allocation pool to rbx**
- **docs: mark linear-scan register allocator complete in ROADMAP**
