### PR TITLE
feat: caller-saved reuse and use-weighted spill in regalloc

### DIFF
--- a/.benchmarks/README.md
+++ b/.benchmarks/README.md
@@ -1,0 +1,130 @@
+# Benchmark time-series
+
+This folder keeps a **committed historical record** of the benchmark suite, so
+performance trends survive even after GitHub expires the underlying CI
+artifacts (~90 days).
+
+## What's here
+
+| File | Purpose |
+|---|---|
+| `series.json` | The time-series data: one sample per day, branch `main`. |
+| `fetch_series.py` | Regenerates `series.json` from CI artifacts. |
+| `dashboard.py` | Local web dashboard to visualize the series. |
+| `dashboard.sh` | One-line launcher for the dashboard. |
+| `README.md` | This file. |
+
+## Viewing the dashboard
+
+The simplest way to browse the data is a small local dashboard (Python stdlib
+only — no `pip install`). Use the launcher:
+
+```bash
+./.benchmarks/dashboard.sh
+```
+
+or call the script directly (identical behaviour; extra args are forwarded):
+
+```bash
+python3 .benchmarks/dashboard.py
+```
+
+It reads `series.json`, embeds it into an HTML page, serves it on
+`http://127.0.0.1:8000/`, and opens your browser. Charts use Chart.js from a CDN
+(needs internet); the data is inlined so no `fetch`/CORS dance is required.
+Stop it with `Ctrl-C`.
+
+```bash
+python3 .benchmarks/dashboard.py --port 9000   # different port
+python3 .benchmarks/dashboard.py --no-open     # serve without opening a browser
+```
+
+The dashboard shows per-case stat cards (latest, delta vs first, min/max), an
+absolute median-time line chart, and an "× slower than C" ratio chart.
+
+## Where the data comes from
+
+The numbers are **not** produced locally. They come from the CI benchmark job:
+
+- Workflow: `.github/workflows/ci.yml`, job **"Benchmark Suite"** (runs on the
+  `macos-14` Apple Silicon runner).
+- Generator: `scripts/benchmark_suite.py`, invoked as
+  `--iterations 3 --warmup 1`, which compiles each case in
+  `benchmarks/cases/` with the release `elephc` binary, runs it, and records the
+  **median wall-clock time in milliseconds**.
+- Each CI run uploads a `benchmark-results` artifact containing
+  `benchmark-results.json`. `fetch_series.py` collects those artifacts and folds
+  them into the single `series.json` stored here.
+
+### Cases measured
+
+The cases live in `benchmarks/cases/<name>/` (`main.php`, `main.c`,
+`expected.txt`):
+
+- `sum_loop`
+- `array_sum`
+- `string_concat`
+
+Each record carries `elephc_ms`, `c_ms`, and `php_ms`:
+
+- `elephc_ms` — the compiled elephc binary (the metric we track).
+- `c_ms` — an `-O2` C baseline compiled on the same runner, for reference.
+- `php_ms` — the PHP interpreter. **Usually `null`**: PHP is not installed on
+  the GitHub runners, so the suite skips it. It is kept in the schema so local
+  runs (where `php` exists) populate it.
+
+### Sampling policy
+
+`series.json` contains **one sample per calendar day** (the last CI run of that
+day) and **only from `main`**. This keeps a clean product-evolution line without
+per-PR noise. Every record records the source `commit` and CI `run_id` so any
+point can be traced back to the exact run.
+
+> Note: each point is a single CI median on a shared cloud runner, so absolute
+> values carry runner noise. Read **trends and step-changes**, not sub-millisecond
+> differences between adjacent days.
+
+## How to update
+
+Re-run the fetch script from anywhere inside the repo (requires an authenticated
+[`gh`](https://cli.github.com/) and `python3`):
+
+```bash
+python3 .benchmarks/fetch_series.py
+```
+
+**The update is incremental and non-destructive.** The script reads the existing
+`series.json`, keeps every point already recorded, and only downloads dates it
+doesn't have yet. Points whose CI artifacts have since expired stay in the file —
+**history is never lost by re-running.** (As a side benefit, refreshes are fast:
+already-recorded days are not re-downloaded.)
+
+Commit the refreshed file:
+
+```bash
+git add .benchmarks/series.json
+git commit -m "chore: refresh benchmark series"
+```
+
+Useful flags:
+
+```bash
+python3 .benchmarks/fetch_series.py --branch some-branch   # sample another branch
+python3 .benchmarks/fetch_series.py --all-runs             # keep every run, not 1/day
+python3 .benchmarks/fetch_series.py --out /tmp/series.json # write elsewhere
+python3 .benchmarks/fetch_series.py --rebuild              # DESTRUCTIVE: rebuild from
+                                                           # scratch, drops expired history
+```
+
+Because artifacts expire after ~90 days, refresh periodically so recent points
+are captured here before they vanish upstream. Avoid `--rebuild` unless you
+specifically want to discard the committed history and start over.
+
+## Reading the data
+
+`series.json` is a flat list — trivial to load in Python, `jq`, or a notebook.
+Quick `jq` example, the `sum_loop` elephc time per day:
+
+```bash
+jq -r '.series[] | "\(.date)\t\(.cases.sum_loop.elephc_ms)"' .benchmarks/series.json
+```

--- a/.benchmarks/dashboard.py
+++ b/.benchmarks/dashboard.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""Serve a small local dashboard for the benchmark time-series.
+
+Reads .benchmarks/series.json, embeds it into a self-contained HTML page
+(Chart.js + fonts from CDN), serves it on localhost with the stdlib http.server,
+and opens a browser. No dependencies beyond Python 3; the charts/fonts need
+internet access to their CDNs, but the data itself is inlined into the page.
+
+Usage:
+
+    python3 .benchmarks/dashboard.py            # serve + open browser
+    python3 .benchmarks/dashboard.py --port 9000
+    python3 .benchmarks/dashboard.py --no-open  # just serve
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import webbrowser
+from functools import partial
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+SERIES_PATH = Path(__file__).resolve().parent / "series.json"
+
+PAGE = r"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>elephc · benchmark telemetry</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<style>
+  :root {
+    --bg:        #08090b;
+    --bg-tint:   #0e1217;
+    --panel:     rgba(255,255,255,.022);
+    --panel-bd:  rgba(255,255,255,.075);
+    --fg:        #eef2f4;
+    --muted:     #67737f;
+    --faint:     rgba(255,255,255,.055);
+    --c1:        #ff7a45;   /* sum_loop      */
+    --c2:        #2bd4bd;   /* array_sum     */
+    --c3:        #a98bff;   /* string_concat */
+    --signal:    #f3b14b;   /* UI accent     */
+  }
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    margin: 0; min-height: 100vh; color: var(--fg);
+    background: var(--bg);
+    font-family: "JetBrains Mono", ui-monospace, Menlo, monospace;
+    font-size: 13px; letter-spacing: -.01em;
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+  }
+  /* atmosphere: radial glows + a fine measurement grid */
+  body::before {
+    content: ""; position: fixed; inset: 0; z-index: -2; pointer-events: none;
+    background:
+      radial-gradient(900px 520px at 78% -8%, rgba(43,212,189,.10), transparent 60%),
+      radial-gradient(820px 520px at 12% 4%,  rgba(255,122,69,.09),  transparent 58%),
+      radial-gradient(1200px 800px at 50% 120%, rgba(169,139,255,.07), transparent 55%),
+      var(--bg-tint);
+  }
+  body::after {
+    content: ""; position: fixed; inset: 0; z-index: -1; pointer-events: none;
+    opacity: .35;
+    background-image:
+      linear-gradient(var(--faint) 1px, transparent 1px),
+      linear-gradient(90deg, var(--faint) 1px, transparent 1px);
+    background-size: 46px 46px;
+    -webkit-mask-image: radial-gradient(circle at 50% 30%, #000 0%, transparent 78%);
+            mask-image: radial-gradient(circle at 50% 30%, #000 0%, transparent 78%);
+  }
+  /* film grain */
+  .grain {
+    position: fixed; inset: -50%; z-index: 0; pointer-events: none; opacity: .035;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.85' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  }
+  .wrap { position: relative; z-index: 1; max-width: 1180px; margin: 0 auto; padding: 60px 40px 80px; }
+
+  /* ---- masthead ---- */
+  .masthead {
+    display: flex; align-items: flex-end; justify-content: space-between;
+    gap: 28px; padding-bottom: 26px; border-bottom: 1px solid var(--panel-bd);
+  }
+  .brand { display: flex; align-items: baseline; gap: 16px; }
+  .brand .mark {
+    font-family: "Instrument Serif", serif; font-size: 64px; line-height: .82;
+    font-style: italic; letter-spacing: -.02em;
+  }
+  .brand .mark .e { color: var(--signal); }
+  .brand .tag {
+    text-transform: uppercase; letter-spacing: .42em; font-size: 10px;
+    color: var(--muted); padding-bottom: 9px;
+  }
+  .report { text-align: right; font-size: 11px; color: var(--muted); line-height: 1.85; }
+  .report b { color: var(--fg); font-weight: 500; }
+  .report .live {
+    display: inline-flex; align-items: center; gap: 7px; color: var(--c2);
+  }
+  .report .live::before {
+    content: ""; width: 7px; height: 7px; border-radius: 50%;
+    background: var(--c2); box-shadow: 0 0 0 0 rgba(43,212,189,.6);
+    animation: pulse 2.4s ease-out infinite;
+  }
+  @keyframes pulse {
+    0% { box-shadow: 0 0 0 0 rgba(43,212,189,.55); }
+    70%,100% { box-shadow: 0 0 0 9px rgba(43,212,189,0); }
+  }
+
+  /* ---- readout gauges ---- */
+  .readouts {
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px;
+    margin: 34px 0 30px;
+  }
+  .gauge {
+    position: relative; overflow: hidden;
+    background: var(--panel); border: 1px solid var(--panel-bd);
+    border-radius: 14px; padding: 20px 22px 18px;
+    backdrop-filter: blur(6px);
+  }
+  .gauge::before {
+    content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 3px;
+    background: var(--ck); box-shadow: 0 0 22px 1px var(--ck);
+  }
+  .gauge .name {
+    display: flex; align-items: center; gap: 9px;
+    font-size: 12px; color: var(--fg); margin-bottom: 16px;
+  }
+  .gauge .name .id { color: var(--muted); margin-left: auto; font-size: 10px; letter-spacing: .14em; text-transform: uppercase; }
+  .gauge .reading { display: flex; align-items: baseline; gap: 8px; }
+  .gauge .val {
+    font-family: "Instrument Serif", serif; font-size: 56px; line-height: .85;
+    letter-spacing: -.01em; font-variant-numeric: tabular-nums;
+  }
+  .gauge .unit { font-size: 13px; color: var(--muted); }
+  .spark { margin: 16px 0 12px; height: 38px; }
+  .spark svg { display: block; width: 100%; height: 38px; overflow: visible; }
+  .gauge .foot { display: flex; align-items: center; justify-content: space-between; font-size: 11px; }
+  .delta { display: inline-flex; align-items: center; gap: 6px; padding: 3px 9px; border-radius: 999px; font-weight: 500; }
+  .delta.up   { color: var(--c1); background: rgba(255,122,69,.10); }
+  .delta.down { color: var(--c2); background: rgba(43,212,189,.10); }
+  .range { color: var(--muted); font-variant-numeric: tabular-nums; }
+
+  /* ---- chart panels ---- */
+  .panel {
+    background: var(--panel); border: 1px solid var(--panel-bd);
+    border-radius: 14px; padding: 22px 24px 20px; margin-bottom: 20px;
+    backdrop-filter: blur(6px);
+  }
+  .panel header {
+    display: flex; align-items: baseline; justify-content: space-between;
+    margin-bottom: 18px; gap: 16px;
+  }
+  .panel h2 {
+    margin: 0; font-family: "Instrument Serif", serif; font-size: 25px;
+    font-weight: 400; letter-spacing: .01em;
+  }
+  .panel .hint { font-size: 11px; color: var(--muted); }
+  .legend { display: flex; gap: 18px; flex-wrap: wrap; }
+  .legend button {
+    background: none; border: 0; color: var(--fg); cursor: pointer;
+    font-family: inherit; font-size: 11px; display: inline-flex; align-items: center; gap: 8px;
+    padding: 0; opacity: 1; transition: opacity .2s;
+  }
+  .legend button.off { opacity: .3; }
+  .legend .swatch { width: 16px; height: 3px; border-radius: 2px; box-shadow: 0 0 9px 0 currentColor; }
+  .canvas-box { position: relative; height: 360px; }
+
+  footer {
+    margin-top: 34px; padding-top: 20px; border-top: 1px solid var(--panel-bd);
+    color: var(--muted); font-size: 11px; line-height: 1.9;
+  }
+  footer code { color: var(--fg); background: rgba(255,255,255,.05); padding: 1px 6px; border-radius: 5px; }
+
+  ::selection { background: rgba(243,177,75,.28); }
+  ::-webkit-scrollbar { width: 11px; height: 11px; }
+  ::-webkit-scrollbar-thumb { background: rgba(255,255,255,.10); border-radius: 6px; border: 3px solid transparent; background-clip: content-box; }
+
+  /* page-load reveal */
+  @keyframes rise { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: none; } }
+  .reveal { animation: rise .8s cubic-bezier(.2,.75,.2,1) both; }
+
+  @media (max-width: 820px) {
+    .wrap { padding: 38px 20px 60px; }
+    .readouts { grid-template-columns: 1fr; }
+    .masthead { flex-direction: column; align-items: flex-start; gap: 18px; }
+    .report { text-align: left; }
+    .brand .mark { font-size: 52px; }
+  }
+</style>
+</head>
+<body>
+  <div class="grain"></div>
+  <div class="wrap">
+    <header class="masthead reveal">
+      <div class="brand">
+        <div class="mark"><span class="e">e</span>lephc</div>
+        <div class="tag">benchmark&nbsp;telemetry</div>
+      </div>
+      <div class="report" id="report"></div>
+    </header>
+
+    <section class="readouts" id="readouts"></section>
+
+    <section class="panel reveal" style="animation-delay:.32s">
+      <header>
+        <div>
+          <h2>Median execution time</h2>
+          <div class="hint">milliseconds · lower is better · compiled <code style="all:unset">elephc</code> binary</div>
+        </div>
+        <div class="legend" id="legend-abs"></div>
+      </header>
+      <div class="canvas-box"><canvas id="absChart"></canvas></div>
+    </section>
+
+    <section class="panel reveal" style="animation-delay:.44s">
+      <header>
+        <div>
+          <h2>Distance from C</h2>
+          <div class="hint">× slower than the <code style="all:unset">-O2</code> C baseline on the same runner</div>
+        </div>
+        <div class="legend" id="legend-ratio"></div>
+      </header>
+      <div class="canvas-box"><canvas id="ratioChart"></canvas></div>
+    </section>
+
+    <footer class="reveal" style="animation-delay:.56s" id="footer"></footer>
+  </div>
+
+<script>
+const PAYLOAD = __DATA__;
+const META = { sum_loop:   { color: "#ff7a45", label: "sum_loop" },
+               array_sum:  { color: "#2bd4bd", label: "array_sum" },
+               string_concat: { color: "#a98bff", label: "string_concat" } };
+
+const series = PAYLOAD.series;
+const cases  = Object.keys(META).filter(c => series.some(p => p.cases[c]));
+const labels = series.map(p => p.date);
+const fmtDate = d => d.slice(5);                       // MM-DD
+const val = (p, c, k) => (p.cases[c] ? p.cases[c][k] : null);
+
+/* ---------- masthead report ---------- */
+document.getElementById("report").innerHTML =
+  `<span class="live">recovered from CI</span><br>` +
+  `<b>${PAYLOAD.points}</b> samples · branch <b>${PAYLOAD.branch}</b><br>` +
+  `<b>${labels[0]}</b> → <b>${labels[labels.length-1]}</b><br>` +
+  `${PAYLOAD.sampling}`;
+
+document.getElementById("footer").innerHTML =
+  `Source <code>.benchmarks/series.json</code>, recovered from GitHub Actions artifacts ` +
+  `(<code>${PAYLOAD.workflow || "Benchmark Suite"}</code>). ` +
+  `Refresh with <code>python3 .benchmarks/fetch_series.py</code>. ` +
+  `Each point is one CI median on a shared runner — read the <em>shape</em>, not sub-millisecond deltas.`;
+
+/* ---------- helpers ---------- */
+function hexA(hex, a) {
+  const n = parseInt(hex.slice(1), 16);
+  return `rgba(${n>>16&255},${n>>8&255},${n&255},${a})`;
+}
+function sparkSVG(vals, color) {
+  const w = 100, h = 38, lo = Math.min(...vals), hi = Math.max(...vals), sp = (hi - lo) || 1;
+  const pts = vals.map((v, i) => [ i / (vals.length - 1) * w, h - ((v - lo) / sp) * (h - 6) - 3 ]);
+  const line = pts.map(p => `${p[0].toFixed(1)},${p[1].toFixed(1)}`).join(" ");
+  const area = `0,${h} ${line} ${w},${h}`;
+  const last = pts[pts.length - 1];
+  const gid = "g" + Math.round(lo * 1e4) + color.slice(1);
+  return `<svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="none">
+    <defs><linearGradient id="${gid}" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="${hexA(color,.32)}"/><stop offset="1" stop-color="${hexA(color,0)}"/>
+    </linearGradient></defs>
+    <polygon points="${area}" fill="url(#${gid})"/>
+    <polyline points="${line}" fill="none" stroke="${color}" stroke-width="1.6"
+      stroke-linejoin="round" stroke-linecap="round" style="filter:drop-shadow(0 0 4px ${hexA(color,.7)})"/>
+    <circle cx="${last[0].toFixed(1)}" cy="${last[1].toFixed(1)}" r="2.4" fill="${color}"/>
+  </svg>`;
+}
+
+/* ---------- readout gauges ---------- */
+const readoutsEl = document.getElementById("readouts");
+const counters = [];
+cases.forEach((c, i) => {
+  const vals = series.map(p => val(p, c, "elephc_ms")).filter(v => v != null);
+  const first = vals[0], last = vals[vals.length - 1];
+  const min = Math.min(...vals), max = Math.max(...vals);
+  const pct = (last - first) / first * 100;
+  const worse = pct > 0;
+  const color = META[c].color;
+  const el = document.createElement("div");
+  el.className = "gauge reveal";
+  el.style.setProperty("--ck", color);
+  el.style.animationDelay = (0.10 + i * 0.09) + "s";
+  el.innerHTML = `
+    <div class="name"><span style="color:${color}">${META[c].label}</span>
+      <span class="id">kernel ${String(i+1).padStart(2,"0")}</span></div>
+    <div class="reading"><span class="val" data-to="${last.toFixed(2)}">0.00</span><span class="unit">ms</span></div>
+    <div class="spark">${sparkSVG(vals, color)}</div>
+    <div class="foot">
+      <span class="delta ${worse ? "up" : "down"}">${worse ? "▲" : "▼"} ${Math.abs(pct).toFixed(0)}%
+        <span style="color:var(--muted);font-weight:400">vs start</span></span>
+      <span class="range">${min.toFixed(2)} – ${max.toFixed(2)}</span>
+    </div>`;
+  readoutsEl.appendChild(el);
+  counters.push(el.querySelector(".val"));
+});
+
+/* count-up once the cards reveal */
+function countUp(el) {
+  const to = parseFloat(el.dataset.to), dur = 1050, t0 = performance.now();
+  const ease = x => 1 - Math.pow(1 - x, 4);
+  (function tick(now) {
+    const k = Math.min(1, (now - t0) / dur);
+    el.textContent = (to * ease(k)).toFixed(2);
+    if (k < 1) requestAnimationFrame(tick);
+  })(t0);
+}
+setTimeout(() => counters.forEach(countUp), 380);
+
+/* ---------- Chart.js theming ---------- */
+Chart.defaults.font.family = "'JetBrains Mono', monospace";
+Chart.defaults.font.size = 11;
+Chart.defaults.color = "#67737f";
+
+/* per-series colored glow under each line */
+const glow = {
+  id: "glow",
+  beforeDatasetDraw(chart, args) {
+    const ds = chart.data.datasets[args.index];
+    chart.ctx.save();
+    chart.ctx.shadowColor = ds.borderColor;
+    chart.ctx.shadowBlur = 14;
+  },
+  afterDatasetDraw(chart) { chart.ctx.restore(); },
+};
+
+function gradientFill(color) {
+  return (ctx) => {
+    const { chart } = ctx;
+    const { ctx: c, chartArea } = chart;
+    if (!chartArea) return hexA(color, .12);
+    const g = c.createLinearGradient(0, chartArea.top, 0, chartArea.bottom);
+    g.addColorStop(0, hexA(color, .26));
+    g.addColorStop(1, hexA(color, 0));
+    return g;
+  };
+}
+
+function mkDataset(c, data) {
+  const color = META[c].color;
+  return {
+    label: META[c].label, data,
+    borderColor: color, backgroundColor: gradientFill(color),
+    fill: true, tension: .32, borderWidth: 2,
+    pointRadius: 0, pointHoverRadius: 5,
+    pointBackgroundColor: color, pointHoverBorderColor: "#08090b", pointHoverBorderWidth: 2,
+    spanGaps: true,
+  };
+}
+
+const axes = (yTitle, suffix) => ({
+  x: {
+    ticks: { maxRotation: 0, autoSkipPadding: 28, callback(v) { return fmtDate(labels[v]); } },
+    grid: { color: "rgba(255,255,255,.04)", drawTicks: false },
+    border: { color: "rgba(255,255,255,.10)" },
+  },
+  y: {
+    title: { display: true, text: yTitle, color: "#67737f", font: { size: 10 } },
+    grace: "12%", grid: { color: "rgba(255,255,255,.045)", drawTicks: false },
+    border: { display: false },
+    ticks: { padding: 8, callback(v) { return v + suffix; } },
+  },
+});
+
+const tooltip = (suffix) => ({
+  backgroundColor: "rgba(8,9,11,.94)", borderColor: "rgba(255,255,255,.12)", borderWidth: 1,
+  titleColor: "#eef2f4", bodyColor: "#c3ccd2", padding: 12, cornerRadius: 9,
+  usePointStyle: true, boxPadding: 6, titleFont: { weight: "700" },
+  callbacks: { label: (x) => `  ${x.dataset.label}  ${x.parsed.y?.toFixed(2)}${suffix}` },
+});
+
+function buildChart(canvasId, datasets, yTitle, suffix) {
+  return new Chart(document.getElementById(canvasId), {
+    type: "line",
+    data: { labels: labels.map((_, i) => i), datasets },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      interaction: { mode: "index", intersect: false },
+      animation: { duration: 1200, easing: "easeOutQuart" },
+      layout: { padding: { top: 6, right: 6 } },
+      plugins: { legend: { display: false }, tooltip: tooltip(suffix) },
+      scales: axes(yTitle, suffix),
+    },
+    plugins: [glow],
+  });
+}
+
+const absChart = buildChart("absChart",
+  cases.map(c => mkDataset(c, series.map(p => val(p, c, "elephc_ms")))), "ms", " ms");
+
+const ratioChart = buildChart("ratioChart",
+  cases.map(c => mkDataset(c, series.map(p => {
+    const e = val(p, c, "elephc_ms"), cc = val(p, c, "c_ms");
+    return (e != null && cc) ? e / cc : null;
+  }))), "× C", "×");
+
+/* ---------- custom interactive legends ---------- */
+function buildLegend(containerId, chart) {
+  const box = document.getElementById(containerId);
+  chart.data.datasets.forEach((ds, i) => {
+    const b = document.createElement("button");
+    b.innerHTML = `<span class="swatch" style="background:${ds.borderColor};color:${ds.borderColor}"></span>${ds.label}`;
+    b.onclick = () => {
+      const vis = chart.isDatasetVisible(i);
+      chart.setDatasetVisibility(i, !vis);
+      b.classList.toggle("off", vis);
+      chart.update();
+    };
+    box.appendChild(b);
+  });
+}
+buildLegend("legend-abs", absChart);
+buildLegend("legend-ratio", ratioChart);
+</script>
+</body>
+</html>
+"""
+
+
+def build_page(series_path: Path) -> bytes:
+    """Read the series JSON and inline it into the dashboard HTML."""
+    data = json.loads(series_path.read_text())
+    html = PAGE.replace("__DATA__", json.dumps(data))
+    return html.encode("utf-8")
+
+
+class Handler(BaseHTTPRequestHandler):
+    """Serve the rendered dashboard for any GET; silence default logging."""
+
+    def __init__(self, *args, page: bytes, **kwargs):
+        self._page = page
+        super().__init__(*args, **kwargs)
+
+    def do_GET(self) -> None:
+        """Return the embedded dashboard HTML for every path."""
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(self._page)))
+        self.end_headers()
+        self.wfile.write(self._page)
+
+    def log_message(self, *args) -> None:
+        """Suppress the noisy per-request stderr logging."""
+
+
+def main() -> None:
+    """Parse args, render the page, serve it, and optionally open a browser."""
+    p = argparse.ArgumentParser(description="Local benchmark dashboard.")
+    p.add_argument("--port", type=int, default=8000, help="Port to listen on (default: 8000).")
+    p.add_argument("--no-open", action="store_true", help="Don't open a browser automatically.")
+    args = p.parse_args()
+
+    if not SERIES_PATH.exists():
+        raise SystemExit(f"missing {SERIES_PATH} — run fetch_series.py first")
+
+    page = build_page(SERIES_PATH)
+    server = HTTPServer(("127.0.0.1", args.port), partial(Handler, page=page))
+    url = f"http://127.0.0.1:{args.port}/"
+    print(f"benchmark dashboard at {url}  (Ctrl-C to stop)")
+    if not args.no_open:
+        webbrowser.open(url)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nstopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/.benchmarks/dashboard.sh
+++ b/.benchmarks/dashboard.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Launch the local benchmark dashboard.
+# Thin wrapper around dashboard.py so you don't have to remember the path.
+# Any arguments are forwarded (e.g. --port 9000, --no-open).
+#
+#   ./.benchmarks/dashboard.sh
+#   ./.benchmarks/dashboard.sh --port 9000
+
+set -euo pipefail
+
+# Resolve the directory this script lives in, so it works from anywhere.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PYTHON="$(command -v python3 || command -v python || true)"
+if [ -z "$PYTHON" ]; then
+  echo "error: python3 not found on PATH" >&2
+  exit 1
+fi
+
+exec "$PYTHON" "$SCRIPT_DIR/dashboard.py" "$@"

--- a/.benchmarks/fetch_series.py
+++ b/.benchmarks/fetch_series.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Rebuild the historical benchmark time-series from CI artifacts.
+
+The CI workflow (.github/workflows/ci.yml, job "Benchmark Suite") runs
+scripts/benchmark_suite.py on every push/PR and uploads a `benchmark-results`
+artifact containing benchmark-results.json. GitHub keeps those artifacts for ~90
+days. This script reconstructs a single tidy time-series out of them so the data
+survives artifact expiry as a committed file (.benchmarks/series.json).
+
+Sampling policy: only runs on `main`, one sample per calendar day (the last run
+of that day), to keep a clean product-evolution line without per-PR noise.
+
+Requires: `gh` (authenticated) and `python3`. Run from anywhere inside the repo:
+
+    python3 .benchmarks/fetch_series.py
+
+Pass --out to write somewhere else, --all-runs to keep every run instead of one
+per day, or --branch to sample a branch other than main.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ARTIFACT_NAME = "benchmark-results"
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI options controlling output path, branch, and sampling."""
+    p = argparse.ArgumentParser(description="Rebuild benchmark series from CI artifacts.")
+    p.add_argument("--out", type=Path, default=Path(__file__).resolve().parent / "series.json",
+                   help="Where to write the series JSON (default: .benchmarks/series.json).")
+    p.add_argument("--branch", default="main", help="Branch to sample (default: main).")
+    p.add_argument("--all-runs", action="store_true",
+                   help="Keep every run instead of one sample per day.")
+    p.add_argument("--rebuild", action="store_true",
+                   help="Overwrite from scratch instead of merging into the "
+                        "existing series (DESTRUCTIVE: drops expired history).")
+    return p.parse_args()
+
+
+def repo_slug() -> str:
+    """Return the current repository as `owner/name` via gh."""
+    return subprocess.run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+        text=True, capture_output=True, check=True).stdout.strip()
+
+
+def list_artifacts(repo: str, branch: str) -> list[dict]:
+    """List all non-expired benchmark-results artifacts for the given branch.
+
+    Returns one dict per artifact with created_at, run id, and head commit sha.
+    """
+    jq = (f'.artifacts[] | select(.name=="{ARTIFACT_NAME}" and .expired==false '
+          f'and .workflow_run.head_branch=="{branch}") '
+          f'| {{created_at: .created_at, run_id: .workflow_run.id, '
+          f'sha: .workflow_run.head_sha}}')
+    raw = subprocess.run(
+        ["gh", "api", f"repos/{repo}/actions/artifacts?per_page=100", "--paginate", "--jq", jq],
+        text=True, capture_output=True, check=True).stdout
+    items = [json.loads(line) for line in raw.splitlines() if line.strip()]
+    items.sort(key=lambda x: x["created_at"])
+    return items
+
+
+def sample_one_per_day(items: list[dict]) -> list[dict]:
+    """Collapse to the last artifact of each calendar day (items must be sorted)."""
+    by_day: dict[str, dict] = {}
+    for it in items:
+        by_day[it["created_at"][:10]] = it
+    return [by_day[k] for k in sorted(by_day)]
+
+
+def download_results(repo: str, run_id: int, dest: Path) -> dict | None:
+    """Download benchmark-results.json for one run; return parsed JSON or None."""
+    subprocess.run(["gh", "run", "download", str(run_id), "-R", repo,
+                    "-n", ARTIFACT_NAME, "-D", str(dest)],
+                   capture_output=True, check=False)
+    jf = dest / "benchmark-results.json"
+    if not jf.exists():
+        return None
+    return json.loads(jf.read_text())
+
+
+def extract(record_meta: dict, data: dict) -> dict:
+    """Flatten one run's benchmark JSON into a per-day series record."""
+    rec = {
+        "date": record_meta["created_at"][:10],
+        "timestamp": record_meta["created_at"],
+        "commit": record_meta["sha"][:8],
+        "run_id": record_meta["run_id"],
+        "cases": {},
+    }
+    for c in data.get("cases", []):
+        rec["cases"][c["case"]] = {
+            "elephc_ms": c["elephc"]["median_ms"],
+            "c_ms": c["c"]["median_ms"],
+            "php_ms": c["php"]["median_ms"],
+        }
+    return rec
+
+
+def load_existing(out: Path) -> dict[str, dict]:
+    """Load already-committed series points keyed by date, or empty if absent."""
+    if not out.exists():
+        return {}
+    try:
+        prior = json.loads(out.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return {rec["date"]: rec for rec in prior.get("series", [])}
+
+
+def main() -> None:
+    """Fetch, sample, and merge the benchmark time-series JSON.
+
+    By default this is INCREMENTAL: points already in the output file are kept,
+    and only dates not yet recorded are fetched and added. This guarantees that
+    history is never lost when old CI artifacts expire. Pass --rebuild to discard
+    the existing file and rebuild purely from currently-available artifacts.
+    """
+    args = parse_args()
+    repo = repo_slug()
+    print(f"repo: {repo}  branch: {args.branch}", file=sys.stderr)
+
+    existing = {} if args.rebuild else load_existing(args.out)
+    if existing:
+        print(f"existing committed points: {len(existing)} (kept)", file=sys.stderr)
+
+    artifacts = list_artifacts(repo, args.branch)
+    print(f"non-expired artifacts on {args.branch}: {len(artifacts)}", file=sys.stderr)
+    if not args.all_runs:
+        artifacts = sample_one_per_day(artifacts)
+        print(f"sampled (1/day): {len(artifacts)}", file=sys.stderr)
+
+    # Skip artifacts whose date we already have: avoids re-downloading the whole
+    # history on every refresh and preserves the originally-recorded values.
+    pending = [m for m in artifacts if m["created_at"][:10] not in existing]
+    print(f"new dates to fetch: {len(pending)}", file=sys.stderr)
+
+    merged = dict(existing)
+    added = 0
+    with tempfile.TemporaryDirectory(prefix="bench-series-") as tmp:
+        for i, meta in enumerate(pending, 1):
+            dest = Path(tmp) / str(meta["run_id"])
+            data = download_results(repo, meta["run_id"], dest)
+            if data is None:
+                print(f"  MISS {meta['created_at'][:10]} run={meta['run_id']}", file=sys.stderr)
+                continue
+            merged[meta["created_at"][:10]] = extract(meta, data)
+            added += 1
+            print(f"  [{i}/{len(pending)}] +{meta['created_at'][:10]} {meta['sha'][:8]}",
+                  file=sys.stderr)
+
+    series = [merged[d] for d in sorted(merged)]
+    print(f"added {added} new point(s); total {len(series)}", file=sys.stderr)
+
+    payload = {
+        "source": "GitHub Actions CI artifacts (benchmark-results)",
+        "workflow": ".github/workflows/ci.yml :: Benchmark Suite",
+        "generator": "scripts/benchmark_suite.py",
+        "branch": args.branch,
+        "sampling": "all-runs" if args.all_runs else "one-per-day (last run of each day)",
+        "points": len(series),
+        "series": series,
+    }
+    args.out.write_text(json.dumps(payload, indent=2) + "\n")
+    print(f"wrote {args.out} ({len(series)} points)", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.benchmarks/series.json
+++ b/.benchmarks/series.json
@@ -1,0 +1,1114 @@
+{
+  "source": "GitHub Actions CI artifacts (benchmark-results)",
+  "workflow": ".github/workflows/ci.yml :: Benchmark Suite",
+  "generator": "scripts/benchmark_suite.py",
+  "branch": "main",
+  "sampling": "one-per-day (last run of each day)",
+  "points": 48,
+  "series": [
+    {
+      "date": "2026-04-24",
+      "timestamp": "2026-04-24T15:49:54Z",
+      "commit": "3a46cdd7",
+      "run_id": 24898534283,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 4.204375000028904,
+          "c_ms": 1.5396669999745427,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 25.8896249999907,
+          "c_ms": 2.4204169999961778,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 2.8412910000383818,
+          "c_ms": 2.02974999996286,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-04-25",
+      "timestamp": "2026-04-25T19:50:06Z",
+      "commit": "65bfd1a7",
+      "run_id": 24939201391,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 3.8417499999923166,
+          "c_ms": 6.085125000026892,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 39.0077920000067,
+          "c_ms": 4.581124999958774,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 6.1127500000566215,
+          "c_ms": 4.6865000000479995,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-04-26",
+      "timestamp": "2026-04-26T18:24:50Z",
+      "commit": "dc2df7a9",
+      "run_id": 24963799386,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 2.490207999926497,
+          "c_ms": 1.318541999808076,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 24.987750000036613,
+          "c_ms": 2.2484999999505817,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 2.295042000241665,
+          "c_ms": 1.1746249997486302,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-04-27",
+      "timestamp": "2026-04-27T20:07:20Z",
+      "commit": "ebab2d2a",
+      "run_id": 25016827917,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 3.8802500000088003,
+          "c_ms": 1.8937500000220098,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 28.0364999999847,
+          "c_ms": 2.8052499999944303,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 2.7448330000083843,
+          "c_ms": 1.5480000000138716,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-04-28",
+      "timestamp": "2026-04-28T16:07:14Z",
+      "commit": "9f9d6c7b",
+      "run_id": 25063957647,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 3.164957999999274,
+          "c_ms": 1.6545000000007803,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 28.072832999995967,
+          "c_ms": 2.138040999994928,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 2.321124999994595,
+          "c_ms": 1.3117920000098593,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-04-29",
+      "timestamp": "2026-04-29T20:26:55Z",
+      "commit": "d98948b0",
+      "run_id": 25132004516,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 3.1750830000021324,
+          "c_ms": 1.6164590000187218,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 26.853749999986576,
+          "c_ms": 2.7393750000044292,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 2.981458999983033,
+          "c_ms": 1.3673329999903672,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-04-30",
+      "timestamp": "2026-04-30T16:44:41Z",
+      "commit": "8e191aab",
+      "run_id": 25177691738,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 6.823709000002509,
+          "c_ms": 2.9227499999819884,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 30.8863330000122,
+          "c_ms": 4.392875000007734,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 4.070749999982581,
+          "c_ms": 3.1189590000053613,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-01",
+      "timestamp": "2026-05-01T20:03:11Z",
+      "commit": "3f69c6f2",
+      "run_id": 25230774575,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 6.569082999988041,
+          "c_ms": 1.7470839999873533,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 27.91874999999777,
+          "c_ms": 2.8068750000045384,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 3.145249999988664,
+          "c_ms": 1.608207999993283,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-02",
+      "timestamp": "2026-05-02T20:10:47Z",
+      "commit": "e6d21ae2",
+      "run_id": 25260766213,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 4.536834000020917,
+          "c_ms": 2.4083750000158943,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 26.911917000006724,
+          "c_ms": 2.737459000002218,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 2.5242499999649226,
+          "c_ms": 1.4549170000464073,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-03",
+      "timestamp": "2026-05-03T20:33:09Z",
+      "commit": "d2f0d9de",
+      "run_id": 25290057022,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 3.3507079999708367,
+          "c_ms": 3.0307910000146876,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 27.232292000007874,
+          "c_ms": 2.53795900005116,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 3.244709000000512,
+          "c_ms": 2.037292000011348,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-04",
+      "timestamp": "2026-05-04T16:09:34Z",
+      "commit": "ae0f8db1",
+      "run_id": 25329473577,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 6.333958000027451,
+          "c_ms": 2.447791999998117,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 29.08445799994297,
+          "c_ms": 3.2787080000389324,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 3.337999999985186,
+          "c_ms": 1.4211669999895093,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-05",
+      "timestamp": "2026-05-05T18:08:41Z",
+      "commit": "5527161d",
+      "run_id": 25393696167,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 6.159458000013274,
+          "c_ms": 1.6937500000153705,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 26.215750000005755,
+          "c_ms": 2.454916999965917,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 2.5878750000174477,
+          "c_ms": 1.372083000035218,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-06",
+      "timestamp": "2026-05-06T22:52:04Z",
+      "commit": "c3f01ea6",
+      "run_id": 25465541183,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 6.534832999932405,
+          "c_ms": 3.03141700010201,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 28.156625000065105,
+          "c_ms": 2.8442919999633887,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 2.9823749998740823,
+          "c_ms": 1.6816250001738808,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-08",
+      "timestamp": "2026-05-08T15:08:30Z",
+      "commit": "4e7d097d",
+      "run_id": 25563088696,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 5.236332999857041,
+          "c_ms": 3.522375000102329,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 28.836707999971622,
+          "c_ms": 4.268125000180589,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 3.496124999855965,
+          "c_ms": 2.6975420000781014,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-09",
+      "timestamp": "2026-05-09T22:02:40Z",
+      "commit": "228fceb5",
+      "run_id": 25612900655,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 2.8172499999072897,
+          "c_ms": 1.6742499999509164,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 25.76641699999982,
+          "c_ms": 3.049791999956142,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 2.795416999902045,
+          "c_ms": 1.463749999970787,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-10",
+      "timestamp": "2026-05-10T20:17:54Z",
+      "commit": "fbd63e3f",
+      "run_id": 25638720292,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 4.430791000231693,
+          "c_ms": 2.885165999941819,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 27.77770899956522,
+          "c_ms": 2.4686249998921994,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 3.2961249999061693,
+          "c_ms": 1.3719580001634313,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-11",
+      "timestamp": "2026-05-11T20:16:57Z",
+      "commit": "a52bd197",
+      "run_id": 25694765911,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 4.441833999976552,
+          "c_ms": 1.4854169999694022,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 27.92545799997015,
+          "c_ms": 2.4050000000102045,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 2.6147499999638057,
+          "c_ms": 1.3965830000302049,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-12",
+      "timestamp": "2026-05-12T15:03:19Z",
+      "commit": "3f2c891c",
+      "run_id": 25742989820,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 11.181083999986186,
+          "c_ms": 3.1628330000330607,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 34.681750000004286,
+          "c_ms": 3.329291000000012,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 4.898749999995289,
+          "c_ms": 5.9027919999721234,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-13",
+      "timestamp": "2026-05-13T20:34:32Z",
+      "commit": "d5ce615d",
+      "run_id": 25824804666,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 4.962499999919601,
+          "c_ms": 2.4934580000035567,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 27.611374999992222,
+          "c_ms": 4.262249999896994,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 3.870042000016838,
+          "c_ms": 2.4483749999717475,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-14",
+      "timestamp": "2026-05-14T21:52:58Z",
+      "commit": "115398fc",
+      "run_id": 25887741681,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 5.325874999982716,
+          "c_ms": 2.9109580000010737,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 34.14791700001274,
+          "c_ms": 3.878458000002638,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 4.016250000006494,
+          "c_ms": 1.9473339999933614,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-15",
+      "timestamp": "2026-05-15T20:13:03Z",
+      "commit": "f7932fea",
+      "run_id": 25939067808,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 8.785625000001573,
+          "c_ms": 6.061875000000327,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 41.040917000003674,
+          "c_ms": 3.753958999993756,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 6.352292000002535,
+          "c_ms": 2.6552090000109274,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-16",
+      "timestamp": "2026-05-16T21:30:54Z",
+      "commit": "b5756e8c",
+      "run_id": 25973420371,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 8.253792000004978,
+          "c_ms": 1.4626659999521507,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 28.52087499991285,
+          "c_ms": 2.872167000077752,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 18.2268749999821,
+          "c_ms": 3.4363750000920845,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-17",
+      "timestamp": "2026-05-17T10:10:57Z",
+      "commit": "ceaf445b",
+      "run_id": 25987949680,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 8.879625000020042,
+          "c_ms": 1.557125000005044,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 28.14391699999419,
+          "c_ms": 2.493208000004188,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 19.152750000017704,
+          "c_ms": 1.4827079999975012,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-18",
+      "timestamp": "2026-05-18T17:53:32Z",
+      "commit": "3d6e42a5",
+      "run_id": 26050652551,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 9.536250000110158,
+          "c_ms": 2.280666999922687,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 28.99162499988961,
+          "c_ms": 3.0670420001115417,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 20.681333999846174,
+          "c_ms": 2.5469170000178565,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-19",
+      "timestamp": "2026-05-19T21:42:30Z",
+      "commit": "a578d1c6",
+      "run_id": 26127008295,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 8.046541999988222,
+          "c_ms": 1.7173749999983556,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 26.50833299998112,
+          "c_ms": 2.6945000000182517,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 18.114417000049343,
+          "c_ms": 1.626750000013999,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-20",
+      "timestamp": "2026-05-20T18:17:13Z",
+      "commit": "528862a0",
+      "run_id": 26181305560,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 9.342791999984001,
+          "c_ms": 2.571750000015527,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 28.3700410000165,
+          "c_ms": 2.9934579999917332,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 19.957417000000532,
+          "c_ms": 2.9267909999930453,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-21",
+      "timestamp": "2026-05-21T18:50:10Z",
+      "commit": "41d520c4",
+      "run_id": 26246305449,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 8.650459000023147,
+          "c_ms": 4.1717499999549545,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 27.03195899999855,
+          "c_ms": 3.200666999987334,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 19.7303330000409,
+          "c_ms": 2.9183339999576674,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-22",
+      "timestamp": "2026-05-22T16:36:34Z",
+      "commit": "c1b7c3e4",
+      "run_id": 26299892401,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 14.458250000018324,
+          "c_ms": 10.41020899998557,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 30.311208999989958,
+          "c_ms": 4.186375000017506,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 20.503875000031258,
+          "c_ms": 2.745207999964805,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-26",
+      "timestamp": "2026-05-26T07:26:49Z",
+      "commit": "c1052d06",
+      "run_id": 26438442970,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 9.107416999995621,
+          "c_ms": 2.9870839999830423,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 33.018749999996544,
+          "c_ms": 3.1607920000169543,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 20.513499999992746,
+          "c_ms": 1.8728750000036598,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-27",
+      "timestamp": "2026-05-27T16:24:43Z",
+      "commit": "f25d761c",
+      "run_id": 26524033875,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 12.627416000043468,
+          "c_ms": 3.8330410000071424,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 27.417332999959854,
+          "c_ms": 6.451249999997799,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 23.293249999994714,
+          "c_ms": 2.979957999968974,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-28",
+      "timestamp": "2026-05-28T18:57:01Z",
+      "commit": "d2126623",
+      "run_id": 26595579629,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 8.411458000068706,
+          "c_ms": 2.4124169999595324,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 25.651374999938525,
+          "c_ms": 2.359374999969077,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 17.51483299995016,
+          "c_ms": 1.5565840000135722,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-05-29",
+      "timestamp": "2026-05-29T13:40:19Z",
+      "commit": "2ac52cb3",
+      "run_id": 26640509757,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 19.137750000027154,
+          "c_ms": 3.3782919999794103,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 35.17749999997477,
+          "c_ms": 4.404207999982646,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 20.73108299998694,
+          "c_ms": 4.540749999989657,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-06-01",
+      "timestamp": "2026-06-01T17:42:35Z",
+      "commit": "f20bd5b7",
+      "run_id": 26771484319,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 7.446791999996094,
+          "c_ms": 1.372750000001588,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 25.85554099999854,
+          "c_ms": 2.3561250000057044,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 17.05741700001795,
+          "c_ms": 1.3277500000015152,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-06-02",
+      "timestamp": "2026-06-02T09:04:48Z",
+      "commit": "f5ad2832",
+      "run_id": 26809709475,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 8.672749999959706,
+          "c_ms": 1.6016669999316946,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 28.092500000070686,
+          "c_ms": 2.4884169999950245,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 18.73191700008192,
+          "c_ms": 1.855167000030633,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-06-03",
+      "timestamp": "2026-06-03T11:45:39Z",
+      "commit": "ce0f6df4",
+      "run_id": 26882480264,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 9.257499999989705,
+          "c_ms": 2.668209000034949,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 34.23812500000167,
+          "c_ms": 2.650082999934966,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 20.292832999984967,
+          "c_ms": 2.1035419999861915,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-06-04",
+      "timestamp": "2026-06-04T17:36:24Z",
+      "commit": "24dfd6ad",
+      "run_id": 26968601885,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 10.253583000007893,
+          "c_ms": 3.7609590000329263,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 34.32624999999234,
+          "c_ms": 4.536708000046019,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 22.927958000025228,
+          "c_ms": 3.5428329999831476,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-06-05",
+      "timestamp": "2026-06-05T20:59:38Z",
+      "commit": "e2745626",
+      "run_id": 27039479894,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 8.188834000065981,
+          "c_ms": 1.543250000054286,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 25.546415999997407,
+          "c_ms": 2.43749999992815,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 18.64100000000235,
+          "c_ms": 2.565166999943358,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-06-06",
+      "timestamp": "2026-06-06T20:41:38Z",
+      "commit": "c27e38e7",
+      "run_id": 27073274675,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 7.729082999958337,
+          "c_ms": 1.5484169999808728,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 25.637792000111403,
+          "c_ms": 3.323749999935899,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 17.024167000045054,
+          "c_ms": 1.3764999999921201,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-06-07",
+      "timestamp": "2026-06-07T15:46:57Z",
+      "commit": "09cb0523",
+      "run_id": 27097157205,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 9.580083999935596,
+          "c_ms": 2.968624999994063,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 26.932834000035655,
+          "c_ms": 2.769334000049639,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 18.921709000096598,
+          "c_ms": 1.720707999993465,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-06-08",
+      "timestamp": "2026-06-08T18:59:44Z",
+      "commit": "c70d2b38",
+      "run_id": 27160009458,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 7.569499999988238,
+          "c_ms": 1.3222919999975602,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 25.297208000040428,
+          "c_ms": 2.104083000006085,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 17.74399999999332,
+          "c_ms": 1.2425830000211135,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-06-09",
+      "timestamp": "2026-06-09T18:57:12Z",
+      "commit": "bb0f65e6",
+      "run_id": 27228616501,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 8.45191700000214,
+          "c_ms": 1.9563330000096357,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 28.545707999967362,
+          "c_ms": 2.8092500000411746,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 19.313249999981963,
+          "c_ms": 1.9035409999901276,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-06-10",
+      "timestamp": "2026-06-10T18:31:59Z",
+      "commit": "ea0dac20",
+      "run_id": 27297352665,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 6.433042000026035,
+          "c_ms": 1.8983329999855414,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 28.453166999952373,
+          "c_ms": 2.8652080000028946,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 19.015707999983533,
+          "c_ms": 1.5811669999266087,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-06-11",
+      "timestamp": "2026-06-11T08:55:04Z",
+      "commit": "379e734a",
+      "run_id": 27335341421,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 9.220916999993278,
+          "c_ms": 4.218541000000187,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 32.05549999995583,
+          "c_ms": 3.7607079999588677,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 20.149374999959946,
+          "c_ms": 2.0323329999882844,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-06-12",
+      "timestamp": "2026-06-12T12:59:22Z",
+      "commit": "fe0498d3",
+      "run_id": 27416912163,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 7.598416999996971,
+          "c_ms": 3.1527909999908843,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 32.308542000009766,
+          "c_ms": 3.765375000000404,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 4.034708999995473,
+          "c_ms": 4.24412500001381,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-06-13",
+      "timestamp": "2026-06-13T20:37:00Z",
+      "commit": "e9c1fac9",
+      "run_id": 27478239105,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 8.873042000004716,
+          "c_ms": 2.7089999999816428,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 30.648250000012922,
+          "c_ms": 4.201666999961162,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 5.804791999935333,
+          "c_ms": 2.5582089999716118,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-06-14",
+      "timestamp": "2026-06-14T13:59:04Z",
+      "commit": "9cf7ef59",
+      "run_id": 27501001884,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 7.008915999904275,
+          "c_ms": 3.0887500001881563,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 32.381749999785825,
+          "c_ms": 3.9488749998781714,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 4.474416999983077,
+          "c_ms": 2.1758749999207794,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-06-15",
+      "timestamp": "2026-06-15T17:44:22Z",
+      "commit": "1dfb72a0",
+      "run_id": 27564836579,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 4.763916999991125,
+          "c_ms": 1.8197919998783618,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 25.7603749998907,
+          "c_ms": 2.5613749999138236,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 2.7616249999482534,
+          "c_ms": 2.0392500000525615,
+          "php_ms": null
+        }
+      }
+    },
+    {
+      "date": "2026-06-16",
+      "timestamp": "2026-06-16T13:47:20Z",
+      "commit": "2fee9a0e",
+      "run_id": 27621508747,
+      "cases": {
+        "array_sum": {
+          "elephc_ms": 6.566625000004933,
+          "c_ms": 2.174459000002571,
+          "php_ms": null
+        },
+        "string_concat": {
+          "elephc_ms": 28.528416999961337,
+          "c_ms": 3.3449579999569323,
+          "php_ms": null
+        },
+        "sum_loop": {
+          "elephc_ms": 2.975541999944653,
+          "c_ms": 2.0001670000056038,
+          "php_ms": null
+        }
+      }
+    }
+  ]
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -694,7 +694,7 @@ imposed. See `docs/internals/the-ir.md`.
 - [x] Default backend switch from AST to EIR, with `--ast-backend` retained as an explicit fallback
 - [x] CI default-EIR gate, frozen fallback smoke coverage, and IR-only benchmark job for parity and regression tracking
 - [x] Linear-scan register allocator (Poletto-Sarkar) with liveness analysis, live intervals, allocation table, separate int / float pools, and callee-saved preservation across calls
-- [ ] Register-pressure mitigations: caller-saved reuse for non-call-crossing intervals; better spill heuristic
+- [x] Register-pressure mitigations: caller-saved reuse for non-call-crossing intervals; better spill heuristic. The linear-scan allocator now classifies each live interval as call-free (never crosses a clobber point — an instruction/terminator whose lowering emits a call or touches a caller-saved register, per the safe-by-default allowlist in `src/ir_passes/clobber.rs`) and assigns call-free intervals from caller-saved pools that need no prologue save/restore (`x12`–`x15`/`d16`–`d23` on aarch64, `rsi`/`rdi`/`r8`/`r9`/`xmm2`–`xmm7` on x86_64), falling back to callee-saved (`x21`–`x28`/`d8`–`d14`/`rbx`) for cross-call values. This notably unlocks register allocation for x86_64 floats (no callee-saved XMM) and integers (callee pool is only `rbx`). The spill heuristic is now use-weighted: under pressure the rarely-used, furthest-reaching interval is evicted first, keeping hot values in registers
 
 Expected outcome: EIR is the default and only active implementation backend in
 v0.24.x. The legacy AST backend is frozen behind `--ast-backend` for diagnostics

--- a/docs/internals/the-ir.md
+++ b/docs/internals/the-ir.md
@@ -1095,22 +1095,46 @@ The pass has four stages:
    across edges or a loop back-edge spans the intervening positions.
 3. **Scan** (`regalloc.rs`): intervals are walked in start order against an
    active set; a free register from the matching pool is assigned, otherwise the
-   interval with the furthest end point is spilled. Integer and float values
-   draw from separate pools.
+   use-weighted spill heuristic evicts the cheapest interval. Integer and float
+   values draw from separate pools.
 4. **Frame integration** (`codegen_ir/frame.rs`): the allocation is stored in
    the frame layout, each used callee-saved register gets a save slot, and the
    value-access chokepoints (`load_value_to_result`, `load_value_to_reg`,
    `store_result_value`) read and write registers instead of slots.
 
-Only callee-saved registers are allocated, so values survive calls without
-spilling and never collide with the scratch or result registers the emitters
-use. The prologue saves and the epilogue restores exactly the callee-saved
-registers the allocator used. On aarch64 the pools are `x21`–`x28` and
-`d8`–`d14`. On x86_64 only `rbx` is allocated: `r14` and `r15` are used as
-scratch by hand-written runtime routines and shared heap-marker codegen without
-ABI-compliant save/restore, so they are not safe to hold values across calls.
-SysV x86_64 also has no callee-saved XMM registers, so float values are never
-register-allocated there and stay in stack slots.
+### Caller-saved reuse for non-call-crossing intervals
+
+The allocator distinguishes two register classes. A value whose live range
+never crosses a **clobber point** — any instruction or terminator whose lowering
+emits a call or touches a caller-saved register — is *call-free* and prefers a
+**caller-saved** register, which needs no prologue save/restore. A value that
+does live across a clobber point uses a **callee-saved** register, which survives
+calls. `src/ir_passes/clobber.rs` holds the audited allowlist of volatile-safe
+opcodes (constants, integer/float arithmetic, comparisons, scalar conversions);
+it is safe-by-default, so an unlisted opcode merely forgoes the caller-saved
+optimization rather than risking a clobbered value. The caller-saved pools are
+disjoint from every register those volatile-safe lowerings touch:
+
+| Class | aarch64 int | aarch64 float | x86_64 int | x86_64 float |
+|---|---|---|---|---|
+| Caller-saved | `x12`–`x15` | `d16`–`d23` | `rsi`,`rdi`,`r8`,`r9` | `xmm2`–`xmm7` |
+| Callee-saved | `x21`–`x28` | `d8`–`d14` | `rbx` | (none) |
+
+This is especially valuable on x86_64, where the callee-saved integer pool is
+just `rbx` and there are no callee-saved XMM registers at all: call-free integer
+and float values can now use the caller-saved pools instead of always spilling.
+On x86_64 `r14` and `r15` are still never allocated — they are used as scratch by
+hand-written runtime routines and shared heap-marker codegen without
+ABI-compliant save/restore. A float that lives across a call on x86_64 still
+spills, because no XMM register survives the call.
+
+The spill heuristic is use-weighted: under pressure the allocator evicts the
+interval with the lowest use count, breaking ties toward the furthest end (the
+classic furthest-use rule), so frequently-used "hot" values keep their
+registers.
+
+The prologue saves and the epilogue restores exactly the callee-saved registers
+the allocator used; caller-saved registers need neither.
 
 The first cut register-allocates only single-word `NonHeap` scalars (`I64`,
 `F64`) that are neither block parameters nor branch arguments, keeping the

--- a/src/ir_passes/clobber.rs
+++ b/src/ir_passes/clobber.rs
@@ -1,0 +1,66 @@
+//! Purpose:
+//! Classifies which EIR opcodes and terminators are "volatile-safe": their
+//! `codegen_ir` lowering emits no call and touches only the fixed result and
+//! scratch registers, never the caller-saved registers the allocator may hand
+//! out to non-call-crossing intervals.
+//!
+//! Called from:
+//! - `crate::ir_passes::intervals` to mark each live interval as call-free.
+//!
+//! Key details:
+//! - Safe-by-default in the correctness direction: the allowlist returns `true`
+//!   only for opcodes whose lowering was audited to (a) emit no `bl`/`call`,
+//!   (b) clobber a register set contained in {result, x9/x10/x11 and d0/d1 on
+//!   AArch64; rax/rdx/rcx/r10/r11 and xmm0/xmm1 on x86_64}, and (c) load their
+//!   SSA operands before using any scratch. Every other opcode falls through to
+//!   `false`, so a forgotten opcode only loses an optimization opportunity — it
+//!   can never place a live value in a register the lowering then clobbers.
+//! - Because the caller-saved pools (`x12`–`x15`, `d16`–`d23`, `rsi`/`rdi`/`r8`/
+//!   `r9`, `xmm2`–`xmm7`) are disjoint from every register the allowlisted
+//!   lowerings touch, a value that lives only across allowlisted ops keeps its
+//!   caller-saved register intact with no prologue save/restore.
+
+use crate::ir::{Op, Terminator};
+
+/// Returns true when `op`'s lowering neither emits a call nor touches a
+/// caller-saved register outside the fixed result/scratch set.
+///
+/// Used to decide whether a live interval spanning this instruction can safely
+/// keep a value in a caller-saved register. The default is `false`: only the
+/// audited pure-compute opcodes below are treated as volatile-safe.
+pub(super) fn op_is_volatile_safe(op: Op) -> bool {
+    use Op::*;
+    matches!(
+        op,
+        // Constants materialized directly into the result register.
+        ConstI64 | ConstBool | ConstNull | ConstF64
+        // Integer arithmetic, bitwise, and shift: result + secondary/tertiary
+        // scratch only (see `lower_inst::arithmetic`).
+        | IAdd | ISub | IMul | INeg
+        | IBitAnd | IBitOr | IBitXor | IBitNot
+        | IShl | IShrA | ISMod | IDiv
+        // Floating-point arithmetic: d0/d1 or xmm0/xmm1 only (`lower_inst::floats`).
+        | FAdd | FSub | FMul | FDiv | FNeg
+        // Integer/float comparisons: result + secondary scratch only.
+        | ICmp | FCmp
+        // Scalar int<->float conversions: inline scvtf/fcvtzs / cvtsi2sd/cvttsd2si.
+        | IToF | FToI
+        | Nop
+    )
+}
+
+/// Returns true when `term`'s lowering neither emits a call nor clobbers a
+/// caller-saved register holding another live value.
+///
+/// Branches, multi-way switches, and returns only materialize their already
+/// computed condition/scrutinee/return value through the standard chokepoints;
+/// throws, generator suspends, fatals, and unreachable are conservatively unsafe.
+pub(super) fn terminator_is_volatile_safe(term: &Terminator) -> bool {
+    matches!(
+        term,
+        Terminator::Br { .. }
+            | Terminator::CondBr { .. }
+            | Terminator::Switch { .. }
+            | Terminator::Return { .. }
+    )
+}

--- a/src/ir_passes/intervals.rs
+++ b/src/ir_passes/intervals.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 
 use crate::ir::{BlockId, Function, InstId, IrType, ValueDef, ValueId};
 use crate::ir_passes::cfg::reverse_postorder;
+use crate::ir_passes::clobber::{op_is_volatile_safe, terminator_is_volatile_safe};
 use crate::ir_passes::liveness::{terminator_uses, LivenessInfo};
 
 /// A value's contiguous live range in linear program order: live from `start`
@@ -30,6 +31,15 @@ pub struct LiveInterval {
     pub start: u32,
     /// Linear position of the value's last use or last live-out edge.
     pub end: u32,
+    /// Number of times the value is used (as an instruction operand or
+    /// terminator use). Drives the spill heuristic: frequently-used values are
+    /// cheaper to keep in registers and more expensive to spill.
+    pub weight: u32,
+    /// True when no instruction or terminator that could clobber a caller-saved
+    /// register executes while the value is live (strictly after its definition,
+    /// up to and including its last use). Such intervals may use caller-saved
+    /// registers, which need no prologue save/restore.
+    pub call_free: bool,
 }
 
 /// Linear position numbering for a function: where each block's parameters,
@@ -102,6 +112,9 @@ pub fn build_intervals(func: &Function, liveness: &LivenessInfo) -> Vec<LiveInte
         }
     }
 
+    let mut weights: HashMap<ValueId, u32> = HashMap::new();
+    let mut clobbers: Vec<u32> = Vec::new();
+
     let extend = |value: ValueId, position: u32, ends: &mut HashMap<ValueId, u32>| {
         if let Some(end) = ends.get_mut(&value) {
             if position > *end {
@@ -118,6 +131,10 @@ pub fn build_intervals(func: &Function, liveness: &LivenessInfo) -> Vec<LiveInte
             let inst = func.instruction(*inst_id).expect("valid instruction");
             for operand in &inst.operands {
                 extend(*operand, position, &mut ends);
+                *weights.entry(*operand).or_insert(0) += 1;
+            }
+            if !op_is_volatile_safe(inst.op) {
+                clobbers.push(position);
             }
         }
 
@@ -125,6 +142,10 @@ pub fn build_intervals(func: &Function, liveness: &LivenessInfo) -> Vec<LiveInte
         if let Some(term) = &block.terminator {
             for value in terminator_uses(term) {
                 extend(value, terminator_position, &mut ends);
+                *weights.entry(value).or_insert(0) += 1;
+            }
+            if !terminator_is_volatile_safe(term) {
+                clobbers.push(terminator_position);
             }
         }
         for value in liveness.live_out_of(block_id) {
@@ -132,15 +153,42 @@ pub fn build_intervals(func: &Function, liveness: &LivenessInfo) -> Vec<LiveInte
         }
     }
 
+    clobbers.sort_unstable();
+
     let mut intervals: Vec<LiveInterval> = starts
         .into_iter()
-        .map(|(value, start)| LiveInterval {
-            value,
-            ir_type: func.value(value).expect("value exists").ir_type,
-            start,
-            end: ends[&value].max(start),
+        .map(|(value, start)| {
+            let end = ends[&value].max(start);
+            LiveInterval {
+                value,
+                ir_type: func.value(value).expect("value exists").ir_type,
+                start,
+                end,
+                weight: weights.get(&value).copied().unwrap_or(0),
+                call_free: is_call_free(&clobbers, start, end),
+            }
         })
         .collect();
     intervals.sort_by_key(|iv| (iv.start, iv.value.as_raw()));
     intervals
+}
+
+/// Returns true when no clobber position lies in the closed range
+/// `[start, end]`.
+///
+/// Both endpoints are included. A clobber at the definition position (`start`)
+/// means the defining instruction is itself a clobber: a call-emitting op such
+/// as `Call` stores its result into the value's register and only then runs its
+/// trailing argument-cleanup calls, which clobber caller-saved registers and so
+/// would corrupt the just-stored result. A clobber at the last-use position
+/// (`end`) means a multi-operand clobbering op can call a runtime helper while
+/// materializing an earlier operand, clobbering a caller-saved register that
+/// still holds this value before it is read. Either case disqualifies the
+/// interval from a caller-saved register.
+fn is_call_free(clobbers: &[u32], start: u32, end: u32) -> bool {
+    // First clobber with position >= start.
+    let lo = clobbers.partition_point(|&pos| pos < start);
+    // First clobber with position > end.
+    let hi = clobbers.partition_point(|&pos| pos <= end);
+    lo >= hi
 }

--- a/src/ir_passes/mod.rs
+++ b/src/ir_passes/mod.rs
@@ -12,6 +12,7 @@
 
 mod allocation;
 mod cfg;
+mod clobber;
 mod intervals;
 mod liveness;
 mod regalloc;

--- a/src/ir_passes/regalloc.rs
+++ b/src/ir_passes/regalloc.rs
@@ -1,15 +1,21 @@
 //! Purpose:
 //! Linear-scan register allocator (Poletto-Sarkar) over EIR functions. Assigns
-//! callee-saved registers to non-overlapping value live intervals, spilling to
-//! the stack under register pressure, with separate integer and float pools.
+//! registers to non-overlapping value live intervals, spilling to the stack
+//! under register pressure, with separate integer and float pools.
 //!
 //! Called from:
 //! - `crate::codegen_ir` per function, before instruction lowering.
 //!
 //! Key details:
-//! - Only callee-saved registers are allocated. They survive calls (so values
-//!   may live across calls without spilling) and are disjoint from the scratch
-//!   and result registers the instruction emitters use.
+//! - Two register classes are allocated. Values whose live range never crosses a
+//!   clobber point (call-free, per `crate::ir_passes::clobber`) prefer
+//!   caller-saved registers, which need no prologue save/restore. Values that
+//!   live across a clobber point use callee-saved registers, which survive
+//!   calls. Both classes are disjoint from the scratch/result registers the
+//!   instruction emitters use.
+//! - The spill heuristic is use-weighted: under pressure the rarely-used,
+//!   furthest-reaching interval is evicted first, keeping hot values in
+//!   registers.
 //! - First cut: only single-word `NonHeap` scalars (`I64`, `F64`) are
 //!   register-eligible, and never block parameters or branch arguments, which
 //!   stay in stack slots so the existing block-parameter moves are unchanged.
@@ -114,6 +120,29 @@ fn is_eligible(func: &Function, iv: &LiveInterval, ineligible: &HashSet<ValueId>
         .unwrap_or(false)
 }
 
+/// Which of the four register pools an active interval drew its register from.
+/// Determines the free list a register returns to on expiry, and whether the
+/// function must save/restore the register (only callee-saved pools).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PoolKind {
+    /// Caller-saved integer pool (`x12`–`x15` / `rsi`,`rdi`,`r8`,`r9`).
+    CallerInt,
+    /// Callee-saved integer pool (`x21`–`x28` / `rbx`).
+    CalleeInt,
+    /// Caller-saved float pool (`d16`–`d23` / `xmm2`–`xmm7`).
+    CallerFloat,
+    /// Callee-saved float pool (`d8`–`d14`; empty on x86_64).
+    CalleeFloat,
+}
+
+impl PoolKind {
+    /// Returns true when registers from this pool are callee-saved and so must
+    /// be preserved across the function via prologue/epilogue save/restore.
+    fn is_callee_saved(self) -> bool {
+        matches!(self, PoolKind::CalleeInt | PoolKind::CalleeFloat)
+    }
+}
+
 /// An interval currently holding a register during the scan.
 struct ActiveInterval {
     /// Linear position where the interval ends.
@@ -122,36 +151,91 @@ struct ActiveInterval {
     reg: &'static str,
     /// Value the interval describes.
     value: ValueId,
+    /// Use count, used to choose the cheapest interval to spill.
+    weight: u32,
+    /// Pool the register came from, so it returns to the right free list.
+    pool: PoolKind,
+}
+
+/// Mutable free lists for the four register pools during a scan.
+struct FreePools {
+    caller_int: Vec<&'static str>,
+    callee_int: Vec<&'static str>,
+    caller_float: Vec<&'static str>,
+    callee_float: Vec<&'static str>,
+}
+
+impl FreePools {
+    /// Builds the four free lists for `target`, ordered so `pop` hands out the
+    /// lowest-numbered register first.
+    fn new(target: Target) -> Self {
+        let rev = |regs: &[&'static str]| -> Vec<&'static str> { regs.iter().rev().copied().collect() };
+        Self {
+            caller_int: rev(caller_int_pool(target)),
+            callee_int: rev(callee_int_pool(target)),
+            caller_float: rev(caller_float_pool(target)),
+            callee_float: rev(callee_float_pool(target)),
+        }
+    }
+
+    /// Returns the free list for a pool kind.
+    fn list_mut(&mut self, pool: PoolKind) -> &mut Vec<&'static str> {
+        match pool {
+            PoolKind::CallerInt => &mut self.caller_int,
+            PoolKind::CalleeInt => &mut self.callee_int,
+            PoolKind::CallerFloat => &mut self.caller_float,
+            PoolKind::CalleeFloat => &mut self.callee_float,
+        }
+    }
+}
+
+/// Returns the pools an interval may draw from, most-preferred first.
+///
+/// Call-free intervals prefer caller-saved registers, which need no save or
+/// restore, and fall back to callee-saved under pressure. Intervals that live
+/// across a clobber point may only use callee-saved registers, which survive
+/// calls and any caller-saved register the lowering touches.
+fn candidate_pools(iv: &LiveInterval) -> &'static [PoolKind] {
+    let is_float = iv.ir_type == IrType::F64;
+    match (is_float, iv.call_free) {
+        (false, true) => &[PoolKind::CallerInt, PoolKind::CalleeInt],
+        (false, false) => &[PoolKind::CalleeInt],
+        (true, true) => &[PoolKind::CallerFloat, PoolKind::CalleeFloat],
+        (true, false) => &[PoolKind::CalleeFloat],
+    }
 }
 
 /// Runs the linear scan over already-eligible, start-sorted intervals.
 ///
-/// Maintains per-pool free lists and an active set. On pool exhaustion it
-/// spills the interval (active or current) whose end is furthest away, the
-/// Poletto-Sarkar heuristic, so the shorter-lived value keeps the register.
+/// Maintains four per-pool free lists (caller/callee × int/float) and an active
+/// set. Each interval is assigned from its preferred pool; on exhaustion it
+/// spills using a use-weighted heuristic that keeps frequently-used values in
+/// registers.
 fn scan(eligible: &[LiveInterval], target: Target) -> Allocation {
-    let mut free_int: Vec<&'static str> = int_pool(target).iter().rev().copied().collect();
-    let mut free_float: Vec<&'static str> = float_pool(target).iter().rev().copied().collect();
+    let mut free = FreePools::new(target);
     let mut active: Vec<ActiveInterval> = Vec::new();
     let mut assignments: HashMap<ValueId, &'static str> = HashMap::new();
     let mut used: Vec<&'static str> = Vec::new();
 
     for iv in eligible {
-        expire_old_intervals(&mut active, iv.start, &mut free_int, &mut free_float);
+        expire_old_intervals(&mut active, iv.start, &mut free);
 
-        let is_float = iv.ir_type == IrType::F64;
-        let free = if is_float { &mut free_float } else { &mut free_int };
-
-        if let Some(reg) = free.pop() {
+        let pools = candidate_pools(iv);
+        if let Some(pool) = pools.iter().copied().find(|&p| !free.list_mut(p).is_empty()) {
+            let reg = free.list_mut(pool).pop().expect("pool checked non-empty");
+            if pool.is_callee_saved() {
+                used.push(reg);
+            }
             assignments.insert(iv.value, reg);
-            used.push(reg);
             active.push(ActiveInterval {
                 end: iv.end,
                 reg,
                 value: iv.value,
+                weight: iv.weight,
+                pool,
             });
         } else {
-            spill_at_interval(iv, is_float, &mut active, &mut assignments);
+            spill_at_interval(iv, pools, &mut active, &mut assignments, &mut used);
         }
     }
 
@@ -160,19 +244,10 @@ fn scan(eligible: &[LiveInterval], target: Target) -> Allocation {
 
 /// Frees registers held by intervals that end at or before `position`, so the
 /// register can be reused by the interval starting there.
-fn expire_old_intervals(
-    active: &mut Vec<ActiveInterval>,
-    position: u32,
-    free_int: &mut Vec<&'static str>,
-    free_float: &mut Vec<&'static str>,
-) {
+fn expire_old_intervals(active: &mut Vec<ActiveInterval>, position: u32, free: &mut FreePools) {
     active.retain(|a| {
         if a.end <= position {
-            if is_float_reg(a.reg) {
-                free_float.push(a.reg);
-            } else {
-                free_int.push(a.reg);
-            }
+            free.list_mut(a.pool).push(a.reg);
             false
         } else {
             true
@@ -180,48 +255,74 @@ fn expire_old_intervals(
     });
 }
 
-/// Resolves register pressure for `current` when its pool is empty: either
-/// steals a register from the active interval that ends latest (spilling that
-/// interval) or spills `current` itself, whichever lives longer stays.
+/// Resolves register pressure for `current` when all its candidate pools are
+/// exhausted.
+///
+/// Among `current` and every active interval that holds a register in one of
+/// `current`'s candidate pools, the cheapest interval to spill is chosen: the
+/// one with the lowest use weight, breaking ties toward the furthest end so the
+/// freed register stays available longest (the classic furthest-use rule). If
+/// `current` is the cheapest, it stays spilled; otherwise the victim is evicted
+/// and `current` takes its register.
 fn spill_at_interval(
     current: &LiveInterval,
-    is_float: bool,
+    pools: &[PoolKind],
     active: &mut Vec<ActiveInterval>,
     assignments: &mut HashMap<ValueId, &'static str>,
+    used: &mut Vec<&'static str>,
 ) {
-    let furthest = active
+    // The interior victim with the best (lowest) spill cost among matching-pool
+    // actives, if any beats `current`.
+    let victim = active
         .iter()
         .enumerate()
-        .filter(|(_, a)| is_float_reg(a.reg) == is_float)
-        .max_by_key(|(_, a)| a.end);
+        .filter(|(_, a)| pools.contains(&a.pool))
+        .min_by(|(_, a), (_, b)| spill_cost(a.weight, a.end).cmp(&spill_cost(b.weight, b.end)));
 
-    let Some((index, a)) = furthest else {
-        // The pool is empty for this type; `current` stays spilled.
+    let Some((index, a)) = victim else {
+        // No matching-pool active to steal from; `current` stays spilled.
         return;
     };
 
-    if a.end > current.end {
-        let reg = a.reg;
-        assignments.remove(&a.value);
-        active.remove(index);
-        assignments.insert(current.value, reg);
-        active.push(ActiveInterval {
-            end: current.end,
-            reg,
-            value: current.value,
-        });
+    // Keep `current` spilled when it is itself the cheapest to spill.
+    if spill_cost(current.weight, current.end) <= spill_cost(a.weight, a.end) {
+        return;
     }
-    // Otherwise `current` has the furthest end and stays spilled.
+
+    let reg = a.reg;
+    let pool = a.pool;
+    assignments.remove(&a.value);
+    active.remove(index);
+    if pool.is_callee_saved() {
+        // The register was already clobbered when first assigned; ensure it is
+        // recorded so the prologue/epilogue preserves it for `current` too.
+        used.push(reg);
+    }
+    assignments.insert(current.value, reg);
+    active.push(ActiveInterval {
+        end: current.end,
+        reg,
+        value: current.value,
+        weight: current.weight,
+        pool,
+    });
 }
 
-/// Returns true when `reg` names a floating-point register.
-fn is_float_reg(reg: &str) -> bool {
-    reg.starts_with('d') || reg.starts_with("xmm")
+/// Returns a spill-cost key for an interval: lower is cheaper to spill.
+///
+/// Ordered by use weight ascending (rarely-used values spill first), then by
+/// furthest end (`Reverse`), so among equally-used intervals the one that would
+/// otherwise block a register the longest is the cheaper victim. Spilling the
+/// furthest-reaching interval frees the register for the longest stretch and
+/// minimizes future pressure — the classic furthest-use rule applied as the
+/// tie-breaker under the use-weighted primary criterion.
+fn spill_cost(weight: u32, end: u32) -> (u32, std::cmp::Reverse<u32>) {
+    (weight, std::cmp::Reverse(end))
 }
 
 /// Returns the integer callee-saved register pool for `target`, excluding the
 /// frame pointer, scratch registers, and registers the emitters use inline.
-fn int_pool(target: Target) -> &'static [&'static str] {
+fn callee_int_pool(target: Target) -> &'static [&'static str] {
     match target.arch {
         Arch::AArch64 => &["x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28"],
         // Only rbx is reliably preserved across the hand-written x86_64 runtime
@@ -232,11 +333,41 @@ fn int_pool(target: Target) -> &'static [&'static str] {
 }
 
 /// Returns the float callee-saved register pool for `target`. SysV x86_64 has
-/// no callee-saved XMM registers, so float values are never register-allocated
-/// there and must stay spilled.
-fn float_pool(target: Target) -> &'static [&'static str] {
+/// no callee-saved XMM registers, so float values that live across a clobber
+/// point are never register-allocated there and must stay spilled.
+fn callee_float_pool(target: Target) -> &'static [&'static str] {
     match target.arch {
         Arch::AArch64 => &["d8", "d9", "d10", "d11", "d12", "d13", "d14"],
         Arch::X86_64 => &[],
+    }
+}
+
+/// Returns the integer caller-saved register pool for `target`.
+///
+/// These registers are clobbered by any call, so they may only hold values
+/// whose live range never crosses a clobber point. The audited volatile-safe
+/// op lowerings (see `crate::ir_passes::clobber`) never touch them, so a
+/// call-free value keeps its register intact with no save/restore.
+fn caller_int_pool(target: Target) -> &'static [&'static str] {
+    match target.arch {
+        // x12–x15 are caller-saved temporaries the volatile-safe lowerings never use.
+        Arch::AArch64 => &["x12", "x13", "x14", "x15"],
+        // rsi/rdi/r8/r9 are caller-saved argument registers, untouched by the
+        // volatile-safe lowerings (which use rax/rdx/rcx/r10/r11 only).
+        Arch::X86_64 => &["rsi", "rdi", "r8", "r9"],
+    }
+}
+
+/// Returns the float caller-saved register pool for `target`.
+///
+/// On x86_64, where there are no callee-saved XMM registers, this is the only
+/// way float values are register-allocated at all, enabled for call-free
+/// intervals. The volatile-safe float lowerings use only d0/d1 and xmm0/xmm1.
+fn caller_float_pool(target: Target) -> &'static [&'static str] {
+    match target.arch {
+        // d16–d23 are caller-saved vector registers never used by the backend
+        // as arguments, results, or scratch.
+        Arch::AArch64 => &["d16", "d17", "d18", "d19", "d20", "d21", "d22", "d23"],
+        Arch::X86_64 => &["xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7"],
     }
 }

--- a/src/ir_passes/tests/regalloc_test.rs
+++ b/src/ir_passes/tests/regalloc_test.rs
@@ -33,10 +33,11 @@ fn emit_const_f64(builder: &mut Builder<'_>, value: f64) -> ValueId {
         .expect("const_f64 produces a value")
 }
 
-/// Three integer temporaries with low register pressure each receive a
-/// register, and the function records the callee-saved registers it used.
+/// A purely arithmetic, call-free function assigns every temporary a
+/// caller-saved register and records no callee-saved usage, so a leaf function
+/// needs no prologue/epilogue save/restore.
 #[test]
-fn straight_line_integers_receive_registers() {
+fn straight_line_integers_use_caller_saved_registers() {
     let mut function = Function::new("ints".to_string(), IrType::I64, PhpType::Int);
     {
         let mut builder = Builder::new(&mut function);
@@ -51,17 +52,19 @@ fn straight_line_integers_receive_registers() {
 
     let allocation = allocate_registers(&function, aarch64());
 
+    let caller_int = ["x12", "x13", "x14", "x15"];
     for raw in 0..3 {
         let reg = allocation.register_of(ValueId::from_raw(raw));
         assert!(reg.is_some(), "value v{raw} should receive a register");
         assert!(
-            reg.unwrap().starts_with('x'),
-            "integer value v{raw} belongs in the integer pool"
+            caller_int.contains(&reg.unwrap()),
+            "call-free integer value v{raw} should use a caller-saved register, got {:?}",
+            reg
         );
     }
     assert!(
-        !allocation.used_callee_saved().is_empty(),
-        "assigning registers must record callee-saved usage"
+        allocation.used_callee_saved().is_empty(),
+        "a call-free function must not save any callee-saved registers"
     );
 }
 
@@ -70,7 +73,8 @@ fn straight_line_integers_receive_registers() {
 /// reports using more registers than the pool provides.
 #[test]
 fn register_pressure_forces_spills() {
-    const COUNT: u32 = 12; // AArch64 integer pool holds 8
+    // AArch64 call-free integer pool holds 12 (4 caller-saved + 8 callee-saved).
+    const COUNT: u32 = 16;
     let mut function = Function::new("pressure".to_string(), IrType::I64, PhpType::Int);
     {
         let mut builder = Builder::new(&mut function);
@@ -96,7 +100,7 @@ fn register_pressure_forces_spills() {
     assert!(spilled >= 1, "more live values than registers must spill some");
     assert!(
         allocation.used_callee_saved().len() <= 8,
-        "cannot use more than the eight-register integer pool"
+        "cannot use more than the eight-register callee-saved integer pool"
     );
 }
 
@@ -162,6 +166,221 @@ fn block_parameters_and_branch_arguments_stay_spilled() {
         allocation.register_of(param),
         None,
         "a block parameter must stay in its slot"
+    );
+}
+
+/// The x86_64 target used by these tests, exercising the caller-saved float
+/// pool (x86_64 has no callee-saved XMM registers).
+fn x86_64() -> Target {
+    Target::new(Platform::Linux, Arch::X86_64)
+}
+
+/// Emits a void-result call that no other value consumes, acting purely as a
+/// clobber point between its surrounding instructions.
+fn emit_clobber_call(builder: &mut Builder<'_>) {
+    builder.emit(
+        Op::Call,
+        vec![],
+        Some(Immediate::I64(0)),
+        IrType::Void,
+        PhpType::Void,
+        Ownership::NonHeap,
+    );
+}
+
+/// A value that lives across a call must use a callee-saved register, which
+/// survives the call, and the function records that register for save/restore.
+#[test]
+fn value_live_across_call_uses_callee_saved() {
+    let mut function = Function::new("across".to_string(), IrType::I64, PhpType::Int);
+    let live = {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+        let v0 = builder.emit_const_i64(1);
+        emit_clobber_call(&mut builder); // clobber point between def and use
+        let v1 = builder.emit_iadd(v0, v0); // v0 is live across the call
+        builder.terminate(Terminator::Return { value: Some(v1) });
+        v0
+    };
+
+    let allocation = allocate_registers(&function, aarch64());
+
+    let reg = allocation.register_of(live).expect("cross-call value gets a register");
+    let callee_int = ["x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28"];
+    assert!(
+        callee_int.contains(&reg),
+        "a value live across a call must use a callee-saved register, got {reg}"
+    );
+    assert!(
+        allocation.used_callee_saved().contains(&reg),
+        "the callee-saved register holding a cross-call value must be recorded"
+    );
+}
+
+/// Regression: a call's *result* must never use a caller-saved register, even
+/// when nothing else clobbers between the call and the result's use. The call
+/// lowering runs its argument-cleanup calls (`decref`) AFTER storing the result,
+/// which would clobber a caller-saved result register. The defining instruction
+/// being a clobber (its position is `start`) must disqualify the value from the
+/// caller-saved pool.
+#[test]
+fn call_result_is_never_caller_saved() {
+    let mut function = Function::new("callret".to_string(), IrType::I64, PhpType::Int);
+    let call_result = {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+        // A call that produces an integer result consumed by a volatile-safe op.
+        let result = builder
+            .emit(
+                Op::Call,
+                vec![],
+                Some(Immediate::I64(0)),
+                IrType::I64,
+                PhpType::Int,
+                Ownership::NonHeap,
+            )
+            .expect("call produces a value");
+        let doubled = builder.emit_iadd(result, result);
+        builder.terminate(Terminator::Return { value: Some(doubled) });
+        result
+    };
+
+    let allocation = allocate_registers(&function, aarch64());
+
+    let caller_saved = ["x12", "x13", "x14", "x15", "d16", "d17", "d18", "d19"];
+    if let Some(reg) = allocation.register_of(call_result) {
+        assert!(
+            !caller_saved.contains(&reg),
+            "a call result must not live in a caller-saved register (the call's \
+             trailing cleanup clobbers it), got {reg}"
+        );
+    }
+}
+
+/// On x86_64, where there are no callee-saved XMM registers, a call-free float
+/// value is still register-allocated from the caller-saved XMM pool.
+#[test]
+fn call_free_float_uses_caller_saved_xmm_on_x86_64() {
+    let mut function = Function::new("floats".to_string(), IrType::F64, PhpType::Float);
+    let sum = {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+        let a = emit_const_f64(&mut builder, 1.5);
+        let b = emit_const_f64(&mut builder, 2.5);
+        let sum = builder
+            .emit(
+                Op::FAdd,
+                vec![a, b],
+                None,
+                IrType::F64,
+                PhpType::Float,
+                Ownership::NonHeap,
+            )
+            .expect("fadd produces a value");
+        builder.terminate(Terminator::Return { value: Some(sum) });
+        sum
+    };
+
+    let allocation = allocate_registers(&function, x86_64());
+
+    let reg = allocation.register_of(sum).expect("call-free float gets a register on x86_64");
+    assert!(
+        reg.starts_with("xmm"),
+        "call-free float should use a caller-saved XMM register, got {reg}"
+    );
+    assert!(
+        allocation.used_callee_saved().is_empty(),
+        "caller-saved XMM registers need no save/restore"
+    );
+}
+
+/// A float value that lives across a call on x86_64 cannot be register-allocated
+/// (no callee-saved XMM and the caller-saved pool is clobbered by the call), so
+/// it stays spilled.
+#[test]
+fn float_live_across_call_spills_on_x86_64() {
+    let mut function = Function::new("fspill".to_string(), IrType::F64, PhpType::Float);
+    let live = {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+        let a = emit_const_f64(&mut builder, 1.5);
+        emit_clobber_call(&mut builder);
+        let sum = builder
+            .emit(
+                Op::FAdd,
+                vec![a, a],
+                None,
+                IrType::F64,
+                PhpType::Float,
+                Ownership::NonHeap,
+            )
+            .expect("fadd produces a value");
+        builder.terminate(Terminator::Return { value: Some(sum) });
+        a
+    };
+
+    let allocation = allocate_registers(&function, x86_64());
+
+    assert_eq!(
+        allocation.register_of(live),
+        None,
+        "a float live across a call on x86_64 must stay spilled"
+    );
+}
+
+/// Under register pressure the use-weighted spill heuristic keeps a
+/// frequently-used value in a register and spills a rarely-used one instead.
+#[test]
+fn spill_heuristic_keeps_frequently_used_value() {
+    // Fill the entire call-free integer pool (4 caller + 8 callee = 12) with
+    // long-lived constants, then introduce one more long-lived value. The pool
+    // is exhausted, so the allocator must spill exactly one of the long-lived
+    // intervals. The hot value below is used far more often than the others.
+    const FILLERS: u32 = 12;
+    let mut function = Function::new("heur".to_string(), IrType::I64, PhpType::Int);
+    let (hot, fillers) = {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+
+        // One value used many times: defined first, kept live to the end.
+        let hot = builder.emit_const_i64(1);
+        let fillers: Vec<ValueId> = (0..FILLERS).map(|i| builder.emit_const_i64(i as i64 + 2)).collect();
+        // Reference `hot` repeatedly so its use weight dominates.
+        let mut acc = hot;
+        for _ in 0..6 {
+            acc = builder.emit_iadd(acc, hot);
+        }
+        // Keep every filler live to the same point by folding them in last.
+        for &f in &fillers {
+            acc = builder.emit_iadd(acc, f);
+        }
+        builder.terminate(Terminator::Return { value: Some(acc) });
+        (hot, fillers)
+    };
+
+    let allocation = allocate_registers(&function, aarch64());
+
+    assert!(
+        allocation.register_of(hot).is_some(),
+        "the most frequently-used value must keep its register under pressure"
+    );
+    let spilled_fillers = fillers
+        .iter()
+        .filter(|&&f| allocation.register_of(f).is_none())
+        .count();
+    assert!(
+        spilled_fillers >= 1,
+        "a rarely-used value should be spilled before the hot value"
     );
 }
 


### PR DESCRIPTION
Register-pressure mitigations for the linear-scan allocator:

- Classify each live interval as call-free (no clobber point in [start,end],
  where a clobber is any instruction/terminator whose lowering emits a call or
  touches a caller-saved register). Volatile-safe opcodes are an audited,
  safe-by-default allowlist in src/ir_passes/clobber.rs.
- Call-free intervals draw from new caller-saved pools that need no prologue
  save/restore (x12-x15/d16-d23 on aarch64; rsi/rdi/r8/r9/xmm2-xmm7 on x86_64),
  falling back to callee-saved for cross-call values. This unlocks register
  allocation for x86_64 floats (no callee-saved XMM) and integers (callee pool
  was only rbx).
- Use-weighted spill heuristic: evict the lowest-weight interval first, breaking
  ties toward the furthest end (classic furthest-use), keeping hot values in
  registers.

A call's result is never caller-saved: the call lowering runs its decref
cleanup after storing the result, which would clobber a caller-saved result
register. Locked by a regression test.

Verified: macOS + Docker Linux x86_64/ARM64 full suites green; clobber-allowlist
audited per opcode; docs/internals/the-ir.md updated.
