### PR TITLE
ci(conf): add missing platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,34 @@ jobs:
       - name: Run codegen test shard
         run: cargo nextest run --profile ci --archive-file nextest-archive.tar.zst -E 'binary(codegen_tests)' --partition hash:${{ matrix.shard }}/16 --no-fail-fast --retries 1 --flaky-result pass -j ${{ matrix.platform.nextest_jobs }}
 
+  # Linux musl (Alpine/musl via Docker) — fidelity gate. The glibc fan-out
+  # above is fast, but float formatting and other libc-sensitive runtime paths
+  # differ under musl. Reuse the canonical scripts/test-linux-*.sh developers
+  # run locally: the checkout runs on the glibc host (JavaScript actions do not
+  # run inside a musl container), then the script builds the rust:1.95-alpine
+  # image and runs the full cargo test suite in the container. Native arch on
+  # both runners, so --platform linux/{amd64,arm64} does not emulate.
+  linux-musl-tests:
+    name: Linux musl Full Suite (${{ matrix.arch.name }})
+    runs-on: ${{ matrix.arch.runner }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - { name: x86_64, runner: ubuntu-24.04, script: test-linux-x86_64.sh }
+          - { name: aarch64, runner: ubuntu-24.04-arm, script: test-linux-arm64.sh }
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run full test suite in Alpine/musl Docker
+        run: ./scripts/${{ matrix.arch.script }}
+        env:
+          # The script defaults to serial (RUST_TEST_THREADS=1) for emulated
+          # local runs; native CI runners can safely parallelize isolated
+          # codegen tests.
+          ELEPHC_TEST_THREADS: "4"
+
   image-api-sync:
     name: Image API stubs in sync
     runs-on: ubuntu-latest
@@ -297,6 +325,7 @@ jobs:
       - build
       - non-codegen-tests
       - codegen-tests
+      - linux-musl-tests
       - image-api-sync
       - builtins-docs-sync
     if: always()
@@ -306,6 +335,7 @@ jobs:
           test "${{ needs.build.result }}" = "success"
           test "${{ needs.non-codegen-tests.result }}" = "success"
           test "${{ needs.codegen-tests.result }}" = "success"
+          test "${{ needs.linux-musl-tests.result }}" = "success"
           test "${{ needs.image-api-sync.result }}" = "success"
           test "${{ needs.builtins-docs-sync.result }}" = "success"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel superseded PR runs (a new push to the same PR aborts the in-flight run);
+# never cancel runs on `main`, since the release gate keys off the "Build & Test"
+# check on the exact tagged commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   BRIDGE_CRATES: >-
@@ -18,23 +25,24 @@ env:
     -p elephc-web
 
 jobs:
-  non-codegen-tests:
-    name: Build & Non-Codegen Tests (${{ matrix.platform.name }})
+  # Compile once per target, then fan out test execution to thin jobs that
+  # download the nextest archive and run partitions without recompiling. The
+  # build job is the only compile-bearing job per target; warnings check,
+  # bridge staticlibs and doctests live here so the fan-out jobs stay thin.
+  build:
+    name: Build & Archive (${{ matrix.platform.name }})
     runs-on: ${{ matrix.platform.runner }}
-    timeout-minutes: 60
+    timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:
         platform:
           - name: macos-aarch64
             runner: macos-14
-            nextest_jobs: 1
           - name: linux-x86_64
             runner: ubuntu-24.04
-            nextest_jobs: 1
           - name: linux-aarch64
             runner: ubuntu-24.04-arm
-            nextest_jobs: 1
     steps:
       - uses: actions/checkout@v4
 
@@ -86,21 +94,40 @@ jobs:
         # staticlibs: libelephc_tls.a (https:// / TLS), libelephc_pdo.a (PDO),
         # libelephc_crypto.a (hash / HMAC family), libelephc_phar.a (PHAR),
         # libelephc_tz.a (DateTimeZone introspection), libelephc_image.a
-        # (GD / Exif / Imagick / Gmagick / Cairo), and libelephc_web.a.
-        # Build all of them up front so every CI platform validates native support
-        # crates before integration tests need them.
+        # (GD / Exif / Imagick / Gmagick / Cairo), and libelephc_web.a. The
+        # fan-out jobs download these alongside the test archive instead of
+        # rebuilding them.
         run: cargo build $BRIDGE_CRATES
 
-      - name: Run non-codegen tests
-        run: cargo nextest run --profile ci --workspace -E 'not binary(codegen_tests)' --no-fail-fast --retries 1 --flaky-result pass -j ${{ matrix.platform.nextest_jobs }}
+      - name: Archive test binaries
+        # Produce a self-contained nextest archive (test binaries + the elephc
+        # CLI used by codegen tests). The fan-out jobs run partitions from this
+        # archive with no compilation.
+        run: cargo nextest archive --workspace --archive-file nextest-archive.tar.zst
 
       - name: Run doctests
         run: cargo test --workspace --doc
 
-  codegen-tests:
-    name: Codegen Tests (${{ matrix.platform.name }} ${{ matrix.shard }}/16)
+      - name: Upload test archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-archive-${{ matrix.platform.name }}
+          path: |
+            nextest-archive.tar.zst
+            target/debug/libelephc_tls.a
+            target/debug/libelephc_pdo.a
+            target/debug/libelephc_crypto.a
+            target/debug/libelephc_phar.a
+            target/debug/libelephc_tz.a
+            target/debug/libelephc_image.a
+            target/debug/libelephc_web.a
+          retention-days: 1
+
+  non-codegen-tests:
+    name: Non-Codegen Tests (${{ matrix.platform.name }})
     runs-on: ${{ matrix.platform.runner }}
-    timeout-minutes: 75
+    needs: build
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -114,23 +141,11 @@ jobs:
           - name: linux-aarch64
             runner: ubuntu-24.04-arm
             nextest_jobs: 1
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Rust build state
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/git
-            ~/.cargo/registry
-            target
-          key: rust-${{ matrix.platform.name }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            rust-${{ matrix.platform.name }}-
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
@@ -154,18 +169,76 @@ jobs:
             tzdata \
             zlib1g-dev
 
-      - name: Build bridge/native support crates
-        # The codegen test runner links compiled programs against bridge
-        # staticlibs: libelephc_tls.a (https:// / TLS), libelephc_pdo.a (PDO),
-        # libelephc_crypto.a (hash / HMAC family), libelephc_phar.a (PHAR),
-        # libelephc_tz.a (DateTimeZone introspection), libelephc_image.a
-        # (GD / Exif / Imagick / Gmagick / Cairo), and libelephc_web.a.
-        # Build all of them up front so every CI platform validates native support
-        # crates before integration tests need them.
-        run: cargo build $BRIDGE_CRATES
+      - name: Download test archive
+        uses: actions/download-artifact@v4
+        with:
+          name: test-archive-${{ matrix.platform.name }}
+
+      - name: Refresh bridge staticlib timestamps
+        # Keep the downloaded staticlibs newer than the freshly checked-out
+        # sources so the test runner reuses them instead of rebuilding.
+        run: touch target/debug/libelephc_*.a
+
+      - name: Run non-codegen tests
+        run: cargo nextest run --profile ci --archive-file nextest-archive.tar.zst -E 'not binary(codegen_tests)' --no-fail-fast --retries 1 --flaky-result pass -j ${{ matrix.platform.nextest_jobs }}
+
+  codegen-tests:
+    name: Codegen Tests (${{ matrix.platform.name }} ${{ matrix.shard }}/16)
+    runs-on: ${{ matrix.platform.runner }}
+    needs: build
+    timeout-minutes: 75
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: macos-aarch64
+            runner: macos-14
+            nextest_jobs: 1
+          - name: linux-x86_64
+            runner: ubuntu-24.04
+            nextest_jobs: 1
+          - name: linux-aarch64
+            runner: ubuntu-24.04-arm
+            nextest_jobs: 1
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Install native test dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install pcre2
+
+      - name: Install native test dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            binutils \
+            build-essential \
+            file \
+            libbz2-dev \
+            libpcre2-dev \
+            libssl-dev \
+            pkg-config \
+            tzdata \
+            zlib1g-dev
+
+      - name: Download test archive
+        uses: actions/download-artifact@v4
+        with:
+          name: test-archive-${{ matrix.platform.name }}
+
+      - name: Refresh bridge staticlib timestamps
+        run: touch target/debug/libelephc_*.a
 
       - name: Run codegen test shard
-        run: cargo nextest run --profile ci --test codegen_tests --partition hash:${{ matrix.shard }}/16 --no-fail-fast --retries 1 --flaky-result pass -j ${{ matrix.platform.nextest_jobs }}
+        run: cargo nextest run --profile ci --archive-file nextest-archive.tar.zst -E 'binary(codegen_tests)' --partition hash:${{ matrix.shard }}/16 --no-fail-fast --retries 1 --flaky-result pass -j ${{ matrix.platform.nextest_jobs }}
 
   image-api-sync:
     name: Image API stubs in sync
@@ -221,6 +294,7 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     needs:
+      - build
       - non-codegen-tests
       - codegen-tests
       - image-api-sync
@@ -229,6 +303,7 @@ jobs:
     steps:
       - name: Verify test jobs
         run: |
+          test "${{ needs.build.result }}" = "success"
           test "${{ needs.non-codegen-tests.result }}" = "success"
           test "${{ needs.codegen-tests.result }}" = "success"
           test "${{ needs.image-api-sync.result }}" = "success"


### PR DESCRIPTION
Previously CI only exercised macos-aarch64 (macos-14). Add native Linux coverage for the other two supported targets:

- linux-glibc-non-codegen / linux-glibc-codegen: native x86_64 (ubuntu-24.04) and aarch64 (ubuntu-24.04-arm) runners; codegen is sharded for fast feedback.
- linux-musl-tests: full cargo test in the Alpine/musl Docker image via scripts/test-linux-*.sh, keeping exact parity with local Linux testing.

The Build & Test aggregator (and therefore the release gate) now depends on all three supported targets.