### PR TITLE
fix: support associative literal defaults on array properties (#407)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to elephc, a PHP-to-native compiler written in Rust.
 Releases are listed newest first.
 
+## [Unreleased]
+- Fixed associative-array property defaults (issue #407): a typed `array` (or untyped) property initialized with an associative literal such as `['a' => 1]` is now stored as associative (hash) storage, so string-key reads and writes (`$this->data['a']`, `$this->data[$key]`) type-check and run instead of failing with "Array index must be integer". The EIR backend also lowers string-keyed associative literal defaults for instance and static properties instead of rejecting them as an unsupported `object_new` feature.
+
 ## [0.25.2] - 2026-06-26
 - `--web`: compile a PHP program into a standalone prefork HTTP server binary with per-request top-level execution, `echo`/`print` response bodies, `$_SERVER`/`$_GET`/`$_POST` and `php://input` request input, PHP-compatible `http_response_code()`/`header()` handling, configurable listen address/workers/body limit, clean signal shutdown, worker respawn, bounded keep-alive handling, fixed-heap request cleanup, and full sharded CI coverage across macOS ARM64, Linux x86_64, and Linux ARM64.
 - Fixed a heap leak when releasing string-keyed associative arrays (issue #408): promoting an indexed array to hash storage (`array_to_hash`) built the result hash from a copy of the source array but never freed that source array, leaking one allocation per conversion. Reassigning an assoc array in a loop — or, under `--web`, rebuilding the request superglobals each request — slowly exhausted the heap. The conversion now releases the temporary source array, so the heap stays flat.
@@ -402,6 +405,7 @@ Releases are listed newest first.
 ## [0.1.0] - 2026-03-22
 - Initial compiler: echo, variables, integers, arithmetic and string concatenation, comparison operators, control flow (`if`/`while`/`for`/`break`/`continue`), functions, logical/assignment/increment operators.
 
+[Unreleased]: https://github.com/illegalstudio/elephc/compare/v0.25.2...HEAD
 [0.25.2]: https://github.com/illegalstudio/elephc/compare/v0.25.1...v0.25.2
 [0.25.1]: https://github.com/illegalstudio/elephc/compare/v0.25.0...v0.25.1
 [0.25.0]: https://github.com/illegalstudio/elephc/compare/v0.24.3...v0.25.0

--- a/docs/php/classes.md
+++ b/docs/php/classes.md
@@ -237,6 +237,19 @@ Property type declarations are checked at compile time for both instance and sta
 
 Property default values are applied both for the normal `new ClassName()` form and for dynamic `new $variable()` instantiation (and therefore for runtime-instantiated stream wrappers and stream filters). When the class name resolves to a known class, dynamic instantiation follows the same allocation path as direct construction, so constructor arguments are evaluated and `__construct` runs normally.
 
+An `array`-typed (or untyped) property may take an associative literal default such as `['a' => 1]`. The property is then stored as an associative array, so string-key reads and writes (`$this->data['a']`, `$this->data[$key]`) type-check and run like any other associative array. A positional literal default (`[1, 2, 3]`) keeps integer-keyed list storage.
+
+```php
+<?php
+class Bag {
+    public array $data = ['a' => 1, 'b' => 2];
+    public function get(string $key): int {
+        return $this->data[$key] ?? 0;
+    }
+}
+echo (new Bag())->get('a'); // 1
+```
+
 ### Asymmetric visibility (`private(set)`)
 
 PHP 8.4 asymmetric visibility lets a property be read more widely than it can be written. A `(set)` modifier after a visibility keyword sets the write visibility independently of the read visibility:

--- a/src/codegen/runtime/arrays/hash_normalize_key.rs
+++ b/src/codegen/runtime/arrays/hash_normalize_key.rs
@@ -16,7 +16,7 @@ use crate::codegen::platform::Arch;
 /// Dispatches to the target-specific implementation after a blank line and global label.
 /// For ARM64: input x1=string_ptr, x2=string_len; output x1=key_lo, x2=key_hi where
 /// key_hi=-1 indicates an integer key and key_hi=0 signals a string key (x1/x2 unchanged).
-/// For x86_64 Linux: input rdi=string_ptr, rsi=string_len; output rax=key_lo, rdx=key_hi
+/// For x86_64 Linux: input rax=string_ptr, rdx=string_len; output rax=key_lo, rdx=key_hi
 /// with the same conventions. String keys return with rax/rdx (x1/x2) untouched.
 pub fn emit_hash_normalize_key(emitter: &mut Emitter) {
     if emitter.target.arch == Arch::X86_64 {
@@ -104,7 +104,7 @@ pub fn emit_hash_normalize_key(emitter: &mut Emitter) {
 
 /// Emits the x86_64 Linux variant of `__rt_hash_normalize_key`.
 ///
-/// Input registers: rdi=string_ptr, rsi=string_len.
+/// Input registers: rax=string_ptr, rdx=string_len (rdi/rsi/rcx/r8/r9/r10 are used as scratch).
 /// Output: rax=key_lo, rdx=key_hi where key_hi=-1 marks an integer key and key_hi=0
 /// means the original string pointer/length are returned unchanged (string key).
 /// The function validates numeric strings against PHP array-key semantics:

--- a/src/codegen_ir/block_emit.rs
+++ b/src/codegen_ir/block_emit.rs
@@ -653,9 +653,9 @@ fn emit_static_property_default_value(
         }
         LiteralDefaultValue::AssocArray {
             value_type,
-            elements,
+            entries,
         } => {
-            emit_assoc_array_literal_default_to_result(ctx, value_type, elements)?;
+            emit_assoc_array_literal_default_to_result(ctx, value_type, entries)?;
         }
         LiteralDefaultValue::EmptyAssocArray { value_type } => {
             emit_empty_assoc_array_literal_to_result(ctx, value_type);

--- a/src/codegen_ir/literal_defaults.rs
+++ b/src/codegen_ir/literal_defaults.rs
@@ -9,7 +9,8 @@
 //! Key details:
 //! - This is intentionally narrower than full PHP expression lowering: only
 //!   scalar, string, null, indexed-array literals with scalar/string/null
-//!   elements, and empty associative arrays land here.
+//!   elements, and associative-array literals (empty, positional, or with
+//!   constant integer/string keys and scalar/string/null values) land here.
 
 use crate::codegen::platform::Arch;
 use crate::codegen::{
@@ -42,7 +43,7 @@ pub(crate) enum LiteralDefaultValue {
     },
     AssocArray {
         value_type: PhpType,
-        elements: Vec<LiteralArrayElement>,
+        entries: Vec<LiteralAssocEntry>,
     },
     EmptyAssocArray {
         value_type: PhpType,
@@ -56,6 +57,21 @@ pub(crate) enum LiteralArrayElement {
     Float(f64),
     Str(String),
     Null,
+}
+
+/// Literal associative-array key that can be materialized without evaluating code. Positional
+/// literals stored into hash slots use integer keys; `ArrayLiteralAssoc` keys may be integer or
+/// string. String keys are normalized at emit time so PHP numeric-string keys become integer keys.
+pub(crate) enum LiteralArrayKey {
+    Int(i64),
+    Str(String),
+}
+
+/// One literal associative-array entry: a constant key paired with a constant value, ready to be
+/// inserted into a freshly allocated hash without evaluating any runtime expression.
+pub(crate) struct LiteralAssocEntry {
+    key: LiteralArrayKey,
+    value: LiteralArrayElement,
 }
 
 /// Converts a supported default expression into a direct storage value.
@@ -120,13 +136,41 @@ pub(crate) fn literal_default_value(
             if items.is_empty() {
                 return Ok(LiteralDefaultValue::EmptyAssocArray { value_type });
             }
-            let elements = items
+            // A positional literal stored into hash storage takes PHP's implicit 0,1,2,... keys.
+            let entries = items
                 .iter()
-                .map(|item| literal_array_element(context, &value_type, &item.kind, op_name))
+                .enumerate()
+                .map(|(index, item)| {
+                    Ok(LiteralAssocEntry {
+                        key: LiteralArrayKey::Int(index as i64),
+                        value: literal_array_element(context, &value_type, &item.kind, op_name)?,
+                    })
+                })
                 .collect::<Result<Vec<_>>>()?;
             Ok(LiteralDefaultValue::AssocArray {
                 value_type,
-                elements,
+                entries,
+            })
+        }
+        (PhpType::AssocArray { value, .. }, ExprKind::ArrayLiteralAssoc(items)) => {
+            let value_type = value.as_ref().codegen_repr();
+            let entries = items
+                .iter()
+                .map(|(key, value_expr)| {
+                    Ok(LiteralAssocEntry {
+                        key: literal_array_key(context, &key.kind, op_name)?,
+                        value: literal_array_element(
+                            context,
+                            &value_type,
+                            &value_expr.kind,
+                            op_name,
+                        )?,
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(LiteralDefaultValue::AssocArray {
+                value_type,
+                entries,
             })
         }
         (PhpType::Array(elem_type), ExprKind::ArrayLiteral(items)) => {
@@ -247,22 +291,27 @@ pub(super) fn emit_array_literal_default_to_result(
     Ok(())
 }
 
-/// Emits a positional array literal as an integer-keyed associative-array default.
+/// Emits an associative-array literal default into the canonical result register. Allocates an
+/// empty hash, then inserts each constant key/value entry through `__rt_hash_set`. The hash pointer
+/// flows through the result register across insertions because the runtime may reallocate it on
+/// growth. For each entry the normalized key is staged on the temporary stack while the value is
+/// materialized, so value-staging calls (string persistence, key normalization) cannot clobber it.
 pub(crate) fn emit_assoc_array_literal_default_to_result(
     ctx: &mut FunctionContext<'_>,
     value_type: &PhpType,
-    elements: &[LiteralArrayElement],
+    entries: &[LiteralAssocEntry],
 ) -> Result<()> {
     emit_empty_assoc_array_literal_to_result(ctx, value_type);
-    for (index, element) in elements.iter().enumerate() {
+    for entry in entries {
         abi::emit_push_reg(ctx.emitter, abi::int_result_reg(ctx.emitter));
-        let actual_value_type = emit_array_element_value(ctx, element);
-        materialize_assoc_literal_value(ctx, value_type, &actual_value_type)?;
         match ctx.emitter.target.arch {
             Arch::AArch64 => {
+                materialize_assoc_literal_key_aarch64(ctx, &entry.key);
+                abi::emit_push_reg_pair(ctx.emitter, "x1", "x2");
+                let actual_value_type = emit_array_element_value(ctx, &entry.value);
+                materialize_assoc_literal_value(ctx, value_type, &actual_value_type)?;
+                abi::emit_pop_reg_pair(ctx.emitter, "x1", "x2");
                 abi::emit_pop_reg(ctx.emitter, "x0");
-                abi::emit_load_int_immediate(ctx.emitter, "x1", index as i64);
-                abi::emit_load_int_immediate(ctx.emitter, "x2", -1);
                 abi::emit_load_int_immediate(
                     ctx.emitter,
                     "x5",
@@ -270,9 +319,12 @@ pub(crate) fn emit_assoc_array_literal_default_to_result(
                 );
             }
             Arch::X86_64 => {
+                materialize_assoc_literal_key_x86_64(ctx, &entry.key);
+                abi::emit_push_reg_pair(ctx.emitter, "rsi", "rdx");
+                let actual_value_type = emit_array_element_value(ctx, &entry.value);
+                materialize_assoc_literal_value(ctx, value_type, &actual_value_type)?;
+                abi::emit_pop_reg_pair(ctx.emitter, "rsi", "rdx");
                 abi::emit_pop_reg(ctx.emitter, "rdi");
-                abi::emit_load_int_immediate(ctx.emitter, "rsi", index as i64);
-                abi::emit_load_int_immediate(ctx.emitter, "rdx", -1);
                 abi::emit_load_int_immediate(
                     ctx.emitter,
                     "r9",
@@ -283,6 +335,45 @@ pub(crate) fn emit_assoc_array_literal_default_to_result(
         abi::emit_call_label(ctx.emitter, "__rt_hash_set");
     }
     Ok(())
+}
+
+/// Materializes a constant associative-array key into the AArch64 hash key registers `x1`/`x2`.
+/// Integer keys load directly with the integer-key sentinel in `x2`; string keys load the literal
+/// pointer/length and run `__rt_hash_normalize_key`, so PHP numeric-string keys collapse to integer
+/// keys while genuine string keys keep `x1`/`x2` as pointer/length.
+fn materialize_assoc_literal_key_aarch64(ctx: &mut FunctionContext<'_>, key: &LiteralArrayKey) {
+    match key {
+        LiteralArrayKey::Int(value) => {
+            abi::emit_load_int_immediate(ctx.emitter, "x1", *value);
+            abi::emit_load_int_immediate(ctx.emitter, "x2", -1);
+        }
+        LiteralArrayKey::Str(value) => {
+            let (label, len) = ctx.data.add_string(value.as_bytes());
+            abi::emit_symbol_address(ctx.emitter, "x1", &label);
+            abi::emit_load_int_immediate(ctx.emitter, "x2", len as i64);
+            abi::emit_call_label(ctx.emitter, "__rt_hash_normalize_key");
+        }
+    }
+}
+
+/// Materializes a constant associative-array key into the x86_64 hash key registers `rsi`/`rdx`.
+/// Integer keys load directly with the integer-key sentinel in `rdx`; string keys load the literal
+/// pointer/length into `rax`/`rdx` (the `__rt_hash_normalize_key` input registers), normalize
+/// (result in `rax`/`rdx`), and move the normalized low word into `rsi` for the `__rt_hash_set` ABI.
+fn materialize_assoc_literal_key_x86_64(ctx: &mut FunctionContext<'_>, key: &LiteralArrayKey) {
+    match key {
+        LiteralArrayKey::Int(value) => {
+            abi::emit_load_int_immediate(ctx.emitter, "rsi", *value);
+            abi::emit_load_int_immediate(ctx.emitter, "rdx", -1);
+        }
+        LiteralArrayKey::Str(value) => {
+            let (label, len) = ctx.data.add_string(value.as_bytes());
+            abi::emit_symbol_address(ctx.emitter, "rax", &label);
+            abi::emit_load_int_immediate(ctx.emitter, "rdx", len as i64);
+            abi::emit_call_label(ctx.emitter, "__rt_hash_normalize_key");
+            ctx.emitter.instruction("mov rsi, rax");                            // move the normalized key low word into the hash ABI key register
+        }
+    }
 }
 
 /// Converts one supported literal expression into an indexed-array element payload.
@@ -339,6 +430,29 @@ fn literal_array_element(
             _ => Err(unsupported_literal_default(context, elem_type, op_name)),
         },
         _ => Err(unsupported_literal_default(context, elem_type, op_name)),
+    }
+}
+
+/// Converts a constant associative-array key expression into a materializable hash key, applying
+/// PHP's literal key coercions: booleans and floats become integer keys, `null` becomes the empty
+/// string key, and numeric strings are normalized to integer keys later at emit time. Unsupported
+/// key forms fall through to the shared unsupported-default error rather than miscompiling.
+fn literal_array_key(context: &str, expr: &ExprKind, op_name: &str) -> Result<LiteralArrayKey> {
+    match expr {
+        ExprKind::StringLiteral(value) => Ok(LiteralArrayKey::Str(value.clone())),
+        ExprKind::IntLiteral(value) => Ok(LiteralArrayKey::Int(*value)),
+        ExprKind::BoolLiteral(value) => Ok(LiteralArrayKey::Int(i64::from(*value))),
+        ExprKind::Null => Ok(LiteralArrayKey::Str(String::new())),
+        ExprKind::FloatLiteral(value) => Ok(LiteralArrayKey::Int(*value as i64)),
+        ExprKind::Negate(inner) => match &inner.kind {
+            ExprKind::IntLiteral(value) => value
+                .checked_neg()
+                .map(LiteralArrayKey::Int)
+                .ok_or_else(|| unsupported_literal_default(context, &PhpType::Int, op_name)),
+            ExprKind::FloatLiteral(value) => Ok(LiteralArrayKey::Int((-value) as i64)),
+            _ => Err(unsupported_literal_default(context, &PhpType::Int, op_name)),
+        },
+        _ => Err(unsupported_literal_default(context, &PhpType::Int, op_name)),
     }
 }
 

--- a/src/codegen_ir/lower_inst/objects.rs
+++ b/src/codegen_ir/lower_inst/objects.rs
@@ -1996,10 +1996,10 @@ fn emit_property_default(
         }
         LiteralDefaultValue::AssocArray {
             value_type,
-            elements,
+            entries,
         } => {
             abi::emit_push_reg(ctx.emitter, object_reg);
-            emit_assoc_array_literal_default_to_result(ctx, value_type, elements)?;
+            emit_assoc_array_literal_default_to_result(ctx, value_type, entries)?;
             abi::emit_pop_reg(ctx.emitter, object_reg);
             let int_reg = abi::int_result_reg(ctx.emitter);
             abi::emit_store_to_address(ctx.emitter, int_reg, object_reg, default.offset);

--- a/src/types/checker/schema/classes/properties.rs
+++ b/src/types/checker/schema/classes/properties.rs
@@ -9,7 +9,7 @@
 //! - Class metadata is shared globally after construction, so validation must reject inconsistent inheritance early.
 
 use crate::errors::CompileError;
-use crate::parser::ast::{ClassProperty, Visibility};
+use crate::parser::ast::{ClassProperty, Expr, ExprKind, Visibility};
 use crate::span::Span;
 use crate::types::traits::FlattenedClass;
 use crate::types::PhpType;
@@ -101,7 +101,7 @@ fn apply_static_property(
             &format!("Static property {}::${} default", class.name, prop.name),
         )?;
         state.declared_static_properties.insert(prop.name.clone());
-        declared_ty
+        refine_declared_array_type_from_default(declared_ty, prop.default.as_ref())
     } else if let Some(default) = &prop.default {
         state.declared_static_properties.remove(&prop.name);
         infer_expr_type_syntactic(default)
@@ -255,7 +255,7 @@ fn apply_instance_property(
             &format!("Property {}::${} default", class.name, prop.name),
         )?;
         state.declared_properties.insert(prop.name.clone());
-        declared_ty
+        refine_declared_array_type_from_default(declared_ty, prop.default.as_ref())
     } else if let Some(default) = &prop.default {
         infer_expr_type_syntactic(default)
     } else {
@@ -348,7 +348,7 @@ fn apply_instance_property_redeclaration(
             &format!("Property {}::${} default", class.name, prop.name),
         )?;
         state.declared_properties.insert(prop.name.clone());
-        declared_ty
+        refine_declared_array_type_from_default(declared_ty, prop.default.as_ref())
     } else if let Some(default) = &prop.default {
         infer_expr_type_syntactic(default)
     } else {
@@ -635,7 +635,7 @@ where
         )),
         (true, Some(child)) => {
             let parent = parent_ty();
-            if &parent != child {
+            if !php_property_types_invariant(&parent, child) {
                 return Err(CompileError::new(
                     span,
                     &format!(
@@ -648,6 +648,39 @@ where
         }
         (false, None) => Ok(()),
     }
+}
+
+/// Reports whether `ty` is one of elephc's PHP `array` storage shapes. The compiler internally
+/// splits the single PHP `array` hint into integer-keyed `Array` (list) and `AssocArray` (hash)
+/// storage; both correspond to the same PHP-visible `array` type.
+fn is_php_array_family(ty: &PhpType) -> bool {
+    matches!(ty, PhpType::Array(_) | PhpType::AssocArray { .. })
+}
+
+/// Checks PHP property-type invariance between a parent and child redeclaration. Property types
+/// are invariant in PHP, but both `Array` and `AssocArray` (and any element/value refinement of
+/// them) denote the same PHP `array` hint, so any two array-family types are treated as invariant.
+/// This keeps associative-default refinement from spuriously rejecting a redeclared `array`
+/// property whose default has a different element shape.
+fn php_property_types_invariant(parent: &PhpType, child: &PhpType) -> bool {
+    if is_php_array_family(parent) && is_php_array_family(child) {
+        return true;
+    }
+    parent == child
+}
+
+/// Refines a declared generic `array` property type using its default value. PHP's `array` hint is
+/// ambiguous between list and hash storage; an associative literal default (`['a' => 1]`) is stored
+/// as `AssocArray` so string-key access type-checks, mirroring how untyped associative-default
+/// properties are inferred. Non-array hints, missing defaults, and positional/empty array defaults
+/// keep the declared type unchanged.
+fn refine_declared_array_type_from_default(declared_ty: PhpType, default: Option<&Expr>) -> PhpType {
+    if let (PhpType::Array(_), Some(default)) = (&declared_ty, default) {
+        if matches!(default.kind, ExprKind::ArrayLiteralAssoc(_)) {
+            return infer_expr_type_syntactic(default);
+        }
+    }
+    declared_ty
 }
 
 /// Resolves the declared type for a property from its `type_expr` using

--- a/tests/codegen/regressions/arrays.rs
+++ b/tests/codegen/regressions/arrays.rs
@@ -798,3 +798,112 @@ echo "|", count($ok), ":", $ok[0], $ok[2];
     );
     assert_eq!(out, "arr:0|3:abab");
 }
+
+/// Regression (issue #407): reading a typed `array` property by a *variable* string key must
+/// type-check and run. The declared `array` hint stored the property as an int-keyed `Array`, so
+/// `$this->data[$key]` was rejected with "Array index must be integer"; an associative literal
+/// default must refine the property to associative (hash) storage so string keys are accepted.
+#[test]
+fn test_typed_array_property_assoc_default_variable_key() {
+    let out = compile_and_run(
+        r#"<?php
+class Bag {
+    public array $data = ['a' => 1];
+    public function get(string $key): int {
+        return $this->data[$key] ?? 0;
+    }
+}
+$b = new Bag();
+echo $b->get('a');
+"#,
+    );
+    assert_eq!(out, "1");
+}
+
+/// Regression (issue #407 companion): the same typed `array` property must also accept a *literal*
+/// string key both from inside a method and through direct external property access. The issue
+/// claimed literal keys already worked, but on 0.25.x they failed identically until the associative
+/// literal default refined the property type.
+#[test]
+fn test_typed_array_property_assoc_default_literal_key() {
+    let out = compile_and_run(
+        r#"<?php
+class Bag {
+    public array $data = ['a' => 1, 'b' => 2];
+    public function get(): int { return $this->data['a']; }
+}
+$b = new Bag();
+echo $b->get(), $b->data['b'];
+"#,
+    );
+    assert_eq!(out, "12");
+}
+
+/// Regression: an *untyped* property initialized with an associative literal default
+/// (`public $data = ['a' => 1]`) must lower its default through the EIR backend. Previously the
+/// associative literal (`ExprKind::ArrayLiteralAssoc`) was not handled by the property-default
+/// emitter, failing with "unsupported EIR backend feature: object_new for default value".
+#[test]
+fn test_untyped_property_assoc_literal_default() {
+    let out = compile_and_run(
+        r#"<?php
+class Bag {
+    public $data = ['a' => 1, 'b' => 2];
+    public function get(string $key): int { return $this->data[$key] ?? 0; }
+}
+$b = new Bag();
+echo $b->get('a'), $b->get('b'), $b->get('missing');
+"#,
+    );
+    assert_eq!(out, "120");
+}
+
+/// Regression: an associative literal property default with string keys and string values must
+/// round-trip its keys and values, exercising the string-keyed hash-insert path of the EIR
+/// property-default emitter (key normalization plus persistent string values).
+#[test]
+fn test_typed_array_property_assoc_default_string_values() {
+    let out = compile_and_run(
+        r#"<?php
+class Req {
+    public array $headers = ['Host' => 'example.com', 'Accept' => 'text/html'];
+    public function header(string $name): string { return $this->headers[$name] ?? ''; }
+}
+$r = new Req();
+echo $r->header('Host'), "|", $r->header('Accept');
+"#,
+    );
+    assert_eq!(out, "example.com|text/html");
+}
+
+/// Regression: a child may redeclare an inherited `array` property whose associative literal
+/// default has a different element/value shape than the parent's. Both denote the same PHP `array`
+/// hint, so refining each to its own associative storage type must not trip property-type
+/// invariance (which would spuriously report "must be AssocArray<int>, not AssocArray<string>").
+#[test]
+fn test_redeclared_array_property_assoc_default_different_value_shape() {
+    let out = compile_and_run(
+        r#"<?php
+class Base { public array $data = ['a' => 1]; }
+class Child extends Base { public array $data = ['a' => 'x', 'b' => 'y']; }
+$c = new Child();
+echo $c->data['a'], $c->data['b'];
+"#,
+    );
+    assert_eq!(out, "xy");
+}
+
+/// Regression: a static property with an associative literal default must lower through the same
+/// EIR static-property initialization path, so string-key reads work on static array properties.
+#[test]
+fn test_static_array_property_assoc_literal_default() {
+    let out = compile_and_run(
+        r#"<?php
+class Config {
+    public static array $map = ['debug' => 1, 'verbose' => 0];
+}
+echo Config::$map['debug'], Config::$map['verbose'];
+"#,
+    );
+    assert_eq!(out, "10");
+}


### PR DESCRIPTION
Typed `array` (or untyped) properties initialized with an associative
literal such as `['a' => 1]` are now stored as associative (hash)
storage, so string-key reads/writes type-check and run instead of
failing with "Array index must be integer".

- Type checker: refine a declared `array` property to `AssocArray` when
  its default is an associative literal (instance, redeclaration, and
  static paths); treat both array-family shapes as the same PHP `array`
  hint for property-type invariance.
- EIR backend: lower `ArrayLiteralAssoc` property/static-property
  defaults, materializing per-entry integer or string keys (string keys
  normalized via __rt_hash_normalize_key) on ARM64 and x86_64, fixing
  the "unsupported object_new ... AssocArray" error.
- Fix a misleading x86_64 input-register comment on __rt_hash_normalize_key.

Closes #407
