### PR TITLE
fix: preserve associative shape for array method parameters (#406)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to elephc, a PHP-to-native compiler written in Rust.
 Releases are listed newest first.
 
 ## [Unreleased]
+- Fixed associative-array method parameters (issue #406): an `array`-typed parameter of an instance or static method now preserves the associative shape known at the call site, exactly like a free-function `array` parameter. String-key access (`$d['a']`) type-checks instead of failing with "Array index must be integer", and `json_encode()` of the parameter emits a JSON object instead of a JSON list with garbage values. A declared generic `array` parameter is sharpened from the call-site argument type during method-call inference, and the sharpened shape is used when checking the method body.
 - Fixed associative-array property defaults (issue #407): a typed `array` (or untyped) property initialized with an associative literal such as `['a' => 1]` is now stored as associative (hash) storage, so string-key reads and writes (`$this->data['a']`, `$this->data[$key]`) type-check and run instead of failing with "Array index must be integer". The EIR backend also lowers string-keyed associative literal defaults for instance and static properties instead of rejecting them as an unsupported `object_new` feature.
 
 ## [0.25.2] - 2026-06-26

--- a/src/types/checker/inference/objects/methods.rs
+++ b/src/types/checker/inference/objects/methods.rs
@@ -353,6 +353,16 @@ impl Checker {
                 };
                 for (i, arg_ty) in arg_types.iter().enumerate() {
                     if i < regular_param_count
+                        && declared_flags.get(i).copied().unwrap_or(false)
+                        && Self::is_generic_array_hint(&sig.params[i].1)
+                        && matches!(arg_ty, PhpType::Array(_) | PhpType::AssocArray { .. })
+                    {
+                        // Sharpen a declared generic `array` parameter to the call-site array
+                        // shape so method `array` params keep their associative shape, matching
+                        // how free-function `array` parameters are specialized (issue #406).
+                        sig.params[i].1 = Self::specialize_generic_array_hint(&sig.params[i].1, arg_ty);
+                    }
+                    if i < regular_param_count
                         && !declared_flags.get(i).copied().unwrap_or(false)
                         && !matches!(*arg_ty, PhpType::Void | PhpType::Never | PhpType::Callable)
                     {
@@ -747,6 +757,16 @@ impl Checker {
                 };
                 for (i, arg_ty) in arg_types.iter().enumerate() {
                     if i < regular_param_count
+                        && static_declared_flags.get(i).copied().unwrap_or(false)
+                        && Self::is_generic_array_hint(&sig.params[i].1)
+                        && matches!(arg_ty, PhpType::Array(_) | PhpType::AssocArray { .. })
+                    {
+                        // Sharpen a declared generic `array` parameter to the call-site array
+                        // shape so static-method `array` params keep their associative shape,
+                        // matching free-function specialization (issue #406).
+                        sig.params[i].1 = Self::specialize_generic_array_hint(&sig.params[i].1, arg_ty);
+                    }
+                    if i < regular_param_count
                         && !static_declared_flags.get(i).copied().unwrap_or(false)
                         && !matches!(*arg_ty, PhpType::Void | PhpType::Never | PhpType::Callable)
                     {
@@ -799,6 +819,16 @@ impl Checker {
                     sig.params.len()
                 };
                 for (i, arg_ty) in arg_types.iter().enumerate() {
+                    if i < regular_param_count
+                        && instance_declared_flags.get(i).copied().unwrap_or(false)
+                        && Self::is_generic_array_hint(&sig.params[i].1)
+                        && matches!(arg_ty, PhpType::Array(_) | PhpType::AssocArray { .. })
+                    {
+                        // Sharpen a declared generic `array` parameter to the call-site array
+                        // shape on `parent::`/`self::` instance dispatch, matching free-function
+                        // specialization (issue #406).
+                        sig.params[i].1 = Self::specialize_generic_array_hint(&sig.params[i].1, arg_ty);
+                    }
                     if i < regular_param_count
                         && !instance_declared_flags.get(i).copied().unwrap_or(false)
                         && !matches!(*arg_ty, PhpType::Void | PhpType::Never | PhpType::Callable)

--- a/src/types/checker/method_pass.rs
+++ b/src/types/checker/method_pass.rs
@@ -64,11 +64,32 @@ impl Checker {
                     };
                     for (i, (pname, type_ann, _, _)) in method.params.iter().enumerate() {
                         let ty = if let Some(type_ann) = type_ann {
-                            self.resolve_declared_param_type_hint(
+                            let declared = self.resolve_declared_param_type_hint(
                                 type_ann,
                                 method.span,
                                 &format!("Method parameter ${}", pname),
-                            )?
+                            )?;
+                            // A generic `array` hint is sharpened to the call-site array shape
+                            // recorded on the stored signature, mirroring how free-function
+                            // `array` parameters are specialized (issue #406). Without this a
+                            // method `array` parameter stays an integer-indexed list and rejects
+                            // string-key access / mis-encodes associative arrays.
+                            if Self::is_generic_array_hint(&declared) {
+                                sig_params
+                                    .as_ref()
+                                    .and_then(|p| p.get(i))
+                                    .map(|(_, t)| t.clone())
+                                    .filter(|t| {
+                                        matches!(
+                                            t,
+                                            PhpType::Array(_) | PhpType::AssocArray { .. }
+                                        )
+                                    })
+                                    .map(|t| Self::specialize_generic_array_hint(&declared, &t))
+                                    .unwrap_or(declared)
+                            } else {
+                                declared
+                            }
                         } else {
                             sig_params
                                 .as_ref()

--- a/tests/codegen/regressions.rs
+++ b/tests/codegen/regressions.rs
@@ -25,6 +25,8 @@ mod builtins_misc;
 mod concat_buffer_args;
 #[path = "regressions/param_inference.rs"]
 mod param_inference;
+#[path = "regressions/method_array_assoc_param.rs"]
+mod method_array_assoc_param;
 #[path = "regressions/mixed_method_dispatch.rs"]
 mod mixed_method_dispatch;
 #[path = "regressions/switch_and_float_params.rs"]

--- a/tests/codegen/regressions/method_array_assoc_param.rs
+++ b/tests/codegen/regressions/method_array_assoc_param.rs
@@ -1,0 +1,103 @@
+//! Purpose:
+//! Regression tests for issue #406: an `array`-typed method parameter (instance or
+//! static) must preserve the associative shape known at the call site, exactly like
+//! a free-function `array` parameter does.
+//!
+//! Called from:
+//! - `cargo test` through Rust's test harness.
+//!
+//! Key details:
+//! - Before the fix a declared `array` method parameter was treated as an
+//!   integer-indexed list: string-key access was rejected with "Array index must be
+//!   integer" and `json_encode` emitted a JSON list with garbage values instead of a
+//!   JSON object. Free functions already specialized the generic `array` hint from the
+//!   call-site argument; methods did not.
+
+use crate::support::*;
+
+/// A static method with a declared `array` parameter, called with an associative
+/// literal, accepts string-key access on that parameter (previously rejected at
+/// compile time with "Array index must be integer").
+#[test]
+fn test_static_method_array_param_string_key_access() {
+    let out = compile_and_run(
+        r#"<?php
+class W {
+    public static function first(array $d): string {
+        return $d['a'];
+    }
+}
+echo W::first(['a' => 'hello']);
+"#,
+    );
+    assert_eq!(out, "hello");
+}
+
+/// An instance method with a declared `array` parameter, called with an associative
+/// literal, accepts string-key access on that parameter.
+#[test]
+fn test_instance_method_array_param_string_key_access() {
+    let out = compile_and_run(
+        r#"<?php
+class W {
+    public function first(array $d): string {
+        return $d['a'];
+    }
+}
+$w = new W();
+echo $w->first(['a' => 'hello']);
+"#,
+    );
+    assert_eq!(out, "hello");
+}
+
+/// `json_encode` of a static method's `array` parameter emits a JSON object (the
+/// associative shape is preserved), not a JSON list with garbage values.
+#[test]
+fn test_static_method_array_param_json_encode_object() {
+    let out = compile_and_run(
+        r#"<?php
+class W {
+    public static function enc(array $d): string {
+        return json_encode($d);
+    }
+}
+echo W::enc(['a' => 1, 'b' => 2]);
+"#,
+    );
+    assert_eq!(out, r#"{"a":1,"b":2}"#);
+}
+
+/// `json_encode` of an instance method's `array` parameter emits a JSON object.
+#[test]
+fn test_instance_method_array_param_json_encode_object() {
+    let out = compile_and_run(
+        r#"<?php
+class W {
+    public function enc(array $d): string {
+        return json_encode($d);
+    }
+}
+$w = new W();
+echo $w->enc(['a' => 1, 'b' => 2]);
+"#,
+    );
+    assert_eq!(out, r#"{"a":1,"b":2}"#);
+}
+
+/// A method `array` parameter still works as an integer-indexed list when called with
+/// a list literal: the call-site specialization must not break the plain list case.
+#[test]
+fn test_method_array_param_list_still_works() {
+    let out = compile_and_run(
+        r#"<?php
+class W {
+    public static function at(array $d): string {
+        return $d[0] . $d[1];
+    }
+}
+echo W::at(['x', 'y']);
+"#,
+    );
+    assert_eq!(out, "xy");
+}


### PR DESCRIPTION
An `array`-typed parameter of an instance or static method now keeps the
associative shape known at the call site, like a free-function `array`
parameter. Previously string-key access was rejected with "Array index must
be integer" and `json_encode()` emitted a JSON list with garbage values.

Method-call inference now sharpens a declared generic `array` parameter from
the call-site argument type (instance, static, and self::/parent:: dispatch),
and the method body check uses that sharpened shape instead of re-resolving
the raw generic hint.

Closes #406
