### PR TITLE
feat(types): fluent wither-return covariance through descendant interfaces

### DIFF
--- a/src/ir_lower/expr/mod.rs
+++ b/src/ir_lower/expr/mod.rs
@@ -9340,6 +9340,31 @@ fn method_call_result_type(
         }
         return fallback_expr_type(expr);
     };
+    // Fluent `with*` wither (@return static): a method declared to return a strict
+    // ANCESTOR interface of the receiver interface actually returns `clone $this`
+    // (the receiver's concrete type). Resolve the IR value to the receiver so a
+    // descendant-only chained call dispatches — e.g. `withHeader(): Message` on a
+    // `Request` receiver must stay `Request` for the following `->withMethod()`.
+    // This MUST agree with the checker's infer_method_call_on_interface_type (#547):
+    // if the IR value kept the ancestor type, the EIR backend rejects the chained
+    // call as "interface method call to unknown method Message::withMethod".
+    let fluent_receiver = if let (Some((recv_name, _)), PhpType::Object(return_name)) =
+        (singular_object_class(&object_ty), &return_ty)
+    {
+        if php_symbol_key(method).starts_with("with")
+            && ctx.interfaces.contains_key(recv_name.trim_start_matches('\\'))
+            && php_symbol_key(return_name.trim_start_matches('\\'))
+                != php_symbol_key(recv_name.trim_start_matches('\\'))
+            && interface_extends_interface_for_ir(ctx, recv_name, return_name)
+        {
+            Some(recv_name.to_string())
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+    let return_ty = fluent_receiver.map(PhpType::Object).unwrap_or(return_ty);
     if op == Op::NullsafeMethodCall && nullable {
         nullable_result_type(return_ty)
     } else {

--- a/src/types/checker/inference/objects/methods.rs
+++ b/src/types/checker/inference/objects/methods.rs
@@ -235,6 +235,25 @@ impl Checker {
             env,
             &format!("Method {}::{}", interface_name, method),
         )?;
+        // Immutable "wither" fluent methods (the PSR-FIG `with*` convention:
+        // MessageInterface::withHeader, RequestInterface::withMethod, …) are
+        // declared `: MessageInterface` but carry `@return static` — at runtime
+        // they return `clone $this`, i.e. the receiver's concrete type, not the
+        // ancestor interface the signature names. PHPStan honours the `@return
+        // static`, so PHPStan-clean code (`$serverRequest = $serverRequest
+        // ->withHeader(...)` then `->withQueryParams(...)`) relies on the type
+        // staying the receiver's. Resolve the return to the receiver interface
+        // when the declared return is a strict ancestor of it — otherwise the
+        // type widens to the ancestor and later child-only calls/params fail.
+        if method_key.starts_with("with") {
+            if let PhpType::Object(return_name) = &sig.return_type {
+                if return_name != interface_name
+                    && self.interface_extends_interface(interface_name, return_name)
+                {
+                    return Ok(PhpType::Object(interface_name.to_string()));
+                }
+            }
+        }
         Ok(sig.return_type)
     }
 

--- a/src/types/checker/type_compat/unions.rs
+++ b/src/types/checker/type_compat/unions.rs
@@ -95,8 +95,13 @@ impl Checker {
                     self.type_accepts(expected_key.as_ref(), actual_key.as_ref())
                         && self.type_accepts(expected_value.as_ref(), actual_value.as_ref())
                 }
+                // A packed `Array(T)` is an int-keyed list, so it assigns into an
+                // `AssocArray` whose key is `Int` (or `Mixed`) and whose value the
+                // element satisfies — e.g. a list literal `[...]` (Array(Mixed))
+                // passed to an `array<int, mixed>` param (SubmissionContext::withBound).
+                // The two share the same run representation; no element re-typing.
                 PhpType::Array(actual_elem)
-                    if matches!(expected_key.as_ref(), PhpType::Mixed)
+                    if matches!(expected_key.as_ref(), PhpType::Mixed | PhpType::Int)
                         && self.type_accepts(expected_value.as_ref(), actual_elem.as_ref()) =>
                 {
                     true

--- a/tests/codegen/oop/interfaces.rs
+++ b/tests/codegen/oop/interfaces.rs
@@ -282,3 +282,38 @@ echo implode(',', C::previews());
     );
     assert_eq!(out, "a,b");
 }
+
+/// PSR-FIG immutable "wither" fluent methods carry `@return static` but declare
+/// the ANCESTOR interface as the return type (`MessageInterface::withHeader(): MessageInterface`).
+/// Called through a DESCENDANT-interface receiver, the result must keep the receiver's type so a
+/// subsequent descendant-only call resolves — matching PHP's runtime `clone $this` and PHPStan's
+/// `@return static`. Here `withHeader()` is declared `: Message` (an ancestor of `Request`); on a
+/// `Request` receiver the chain must stay `Request` for `->withMethod()->method()` to type-check.
+/// Byte-parity vs PHP 8.5.
+#[test]
+fn test_interface_wither_ancestor_return_stays_receiver() {
+    let out = compile_and_run(
+        r#"<?php
+interface Message {
+    public function withHeader(string $value): Message;
+    public function body(): string;
+}
+interface Request extends Message {
+    public function withMethod(string $method): Request;
+    public function method(): string;
+}
+final class Req implements Request {
+    public function __construct(private string $verb = 'GET', private string $payload = '') {}
+    public function withHeader(string $value): Message { return new Req($this->verb, $value); }
+    public function withMethod(string $method): Request { return new Req($method, $this->payload); }
+    public function body(): string { return $this->payload; }
+    public function method(): string { return $this->verb; }
+}
+function chain(Request $r): string {
+    return $r->withHeader('x-trace')->withMethod('POST')->method();
+}
+echo chain(new Req());
+"#,
+    );
+    assert_eq!(out, "POST");
+}


### PR DESCRIPTION
## What

A PSR-FIG immutable "wither" method (`withHeader(): MessageInterface`) declares an **ancestor** interface as its return type but carries `@return static`. Called through a **descendant**-interface receiver, the result must keep the receiver's type so a subsequent descendant-only call type-checks — matching PHP's runtime `clone $this` and PHPStan's `@return static`.

Previously rejected:

```php
interface Message { public function withHeader(string $v): Message; }
interface Request extends Message {
    public function withMethod(string $m): Request;
    public function method(): string;
}
function chain(Request $r): string {
    // withMethod() was unresolved: withHeader() typed as the ancestor Message
    return $r->withHeader('x')->withMethod('POST')->method();
}
```

## How

Both inference passes resolve a `with*` method whose declared return is a **strict ancestor** of the receiver interface back to the receiver:

- checker — `infer_method_call_on_interface_type`
- EIR lowering — `method_call_result_type`

Both are required: the checker fix alone leaves the EIR backend re-resolving the chained call to the ancestor and failing native codegen (`interface method call to unknown method Message::withMethod`).

Also accepts `Array(Mixed)` where an `AssocArray` parameter is declared (an untyped list literal passed to an `array<int, mixed>` param).

## Test

`test_interface_wither_ancestor_return_stays_receiver` — a `Message` / `Request extends Message` wither chain, byte-parity vs PHP 8.5 (`chain(new Req())` prints `POST`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
