### PR TITLE
docs: add Cursor Cloud environment setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -573,3 +573,28 @@ When cutting a release:
 - Run the focused pre-commit verification above before committing code changes. Do not knowingly commit with relevant focused tests failing; the full suite must pass in CI.
 - Zero compiler warnings policy (`cargo build` must be clean)
 - Never run `cargo fmt` in this repo. Use targeted manual edits only; global formatting creates noisy churn here.
+
+## Cursor Cloud specific instructions
+
+The dependency-refresh update script runs `cargo build` on startup, which also
+materializes the bridge `libelephc_*.a` staticlibs that `linker.rs` links into
+compiled programs. Standard build/test/run commands are documented above and in
+`CONTRIBUTING.md`; the notes below are only the non-obvious cloud caveats.
+
+- **Rust toolchain is version-pinned.** CI pins the toolchain in
+  `.github/docker/ci.Dockerfile` (currently `1.95.0`) and the "no warnings" gate
+  greps build output, so use that exact toolchain rather than a floating
+  `stable`. The cloud VM has it installed and set as the rustup default.
+- **The compiler shells out to the host `as` + `gcc`/`ld`.** These are present.
+  On Linux, compiling a program prints benign linker warnings
+  (`gethostbyname` in statically linked apps, missing `.note.GNU-stack`,
+  executable stack). They are not errors — the produced binary runs fine.
+- **`php` is not installed.** PHP-equivalence cross-check tests
+  (`ELEPHC_PHP_CHECK=1 cargo test ...`) will not run without installing a PHP
+  interpreter first. Normal codegen tests do not need it.
+- **Docker-based Linux cross-test scripts are unavailable by default.**
+  `scripts/test-linux-x86_64.sh` / `-arm64.sh` require Docker, which is not set
+  up here. Rely on host `cargo test`/`cargo nextest` (this VM is `linux-x86_64`)
+  and CI for the full target matrix.
+- **Quick end-to-end sanity check:** `cargo run -- examples/fizzbuzz/main.php`
+  then `./examples/fizzbuzz/main`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up and verifies the Cloud Agent development environment for `elephc` (PHP-to-native compiler in Rust) and records durable, non-obvious cloud caveats in `AGENTS.md`.

## Environment setup

- Installed Rust `1.95.0` (CI-pinned in `.github/docker/ci.Dockerfile`) and set it as the rustup default (base image had `1.83.0`).
- Installed missing system libraries: `libbz2-dev`, `libssl-dev` (bridge-crate deps). `as`/`ld`/`gcc` already present.
- Installed `cargo-nextest` `0.9.140` (used by CI and referenced in AGENTS.md).
- Update script: `cargo build` — rebuilds the compiler and materializes the bridge `libelephc_*.a` staticlibs.

## Verification (end-to-end)

- Clean `cargo build` (zero warnings).
- Compiled and ran `examples/fizzbuzz/main.php` → native binary produces correct output.
- Focused test passed: `cargo test --test codegen_tests fizzbuzz`.

[elephc_env_verification.log](https://cursor.com/agents/bc-e8739dd3-214b-425c-acbb-e35e0bec18e0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Felephc_env_verification.log)

## Changes

- `AGENTS.md`: added a `## Cursor Cloud specific instructions` section (toolchain pinning, host `as`/`gcc` benign linker warnings, `php` not installed, Docker cross-test scripts unavailable, quick sanity check).

No source code changed.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8739dd3-214b-425c-acbb-e35e0bec18e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8739dd3-214b-425c-acbb-e35e0bec18e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

