### PR TITLE
feat: support ::class on object expressions

### DIFF
--- a/docs/internals/the-parser.md
+++ b/docs/internals/the-parser.md
@@ -98,6 +98,7 @@ Things that have a value:
 | `BufferNew { element_type, len }` | `buffer_new<int>(256)` | Compiler extension for contiguous hot-path buffers |
 | `MagicConstant(MagicConstant)` | `__DIR__`, `__CLASS__` | Parsed from case-insensitive magic-constant tokens. `__LINE__` is lowered immediately to `IntLiteral`; the remaining magic constants are lowered by `src/magic_constants.rs` before type checking. |
 | `ClassConstant { receiver }` | `MyClass::class`, `\App\C::class`, `self::class`, `parent::class`, `static::class` | The PHP `::class` reflection literal. Codegen lowers it to a string literal carrying the fully-qualified class name. `static::class` follows late static binding. |
+| `ObjectClassName { object }` | `$object::class`, `make_object()::class` | Runtime `::class` lookup for an object-valued expression. The object expression remains structural so later passes evaluate it once and read its concrete runtime class. |
 | `ScopedConstantAccess { receiver, name }` | `MyClass::LIMIT`, `self::DEFAULT_SIZE` | User-declared class constant access through `::`; later phases resolve the receiver and constant metadata. |
 
 ### Statements (`Stmt`)
@@ -391,6 +392,7 @@ Before looking for infix operators, the parser handles **prefix** constructs —
 | `new` + `$var` + `(` | Parse dynamic object instantiation → `NewDynamic` (class named by a runtime variable) |
 | `new` + `self` / `static` / `parent` + `(` | Parse scoped object instantiation → `NewScopedObject` |
 | `<receiver>::class` | Parse `MyClass::class`, `\App\C::class`, `self::class`, `parent::class`, `static::class` → `ClassConstant` |
+| `<object-expression>::class` | Parse `$object::class`, `make_object()::class` → `ObjectClassName` |
 | `$this` | Return `This` node |
 | `...` + expr | Parse spread/unpack → `Spread` |
 | `ptr_cast` + `<Type>` + `(` | Parse pointer cast syntax → `PtrCast` |

--- a/docs/php/classes.md
+++ b/docs/php/classes.md
@@ -539,7 +539,9 @@ Called with `::`, no `$this`.
 
 ## Class name reflection (`::class`)
 
-`::class` returns the fully-qualified class name as a string at compile time.
+`::class` returns a fully-qualified class name as a string. Named and scoped
+receivers are resolved without constructing an object; an object-valued receiver
+reads the concrete class from the object at runtime.
 
 ```php
 <?php
@@ -551,11 +553,18 @@ class Logger {
 }
 echo Logger::class;                  // "App\Logger"
 echo \App\Logger::class;             // "App\Logger"
+
+$logger = new Logger("audit");
+echo $logger::class;                 // "App\Logger"
 ```
 
-Supported receivers: `Class::class`, `\Vendor\Class::class`, `self::class`, `parent::class`, `static::class`.
+Supported receivers: `Class::class`, `\Vendor\Class::class`, `self::class`,
+`parent::class`, `static::class`, and statically known object-valued expressions
+such as `$object::class` or `make_object()::class`.
 
 `static::class` follows PHP late static binding and resolves to the called class.
+`$object::class` follows the object's concrete runtime class, including when its
+static type is a parent class. The receiver expression is evaluated exactly once.
 For named receivers, elephc preserves PHP's written/imported spelling for the
 `::class` string while still using case-insensitive class lookup for executable
 operations such as `new`, `instanceof`, static method calls, and static property

--- a/examples/static-classes/main.php
+++ b/examples/static-classes/main.php
@@ -31,6 +31,8 @@ echo "Default logger: " . $default->describe() . "\n";
 
 $named = new Logger("audit");
 echo "Named logger: " . $named->describe() . "\n";
+// Object receivers resolve the concrete runtime class, like get_class($named).
+echo "Named logger runtime class: " . $named::class . "\n";
 
 // Inheritance + parent::class
 class Base {

--- a/src/autoload/walk.rs
+++ b/src/autoload/walk.rs
@@ -550,7 +550,8 @@ fn collect_refs_expr(expr: &Expr, out: &mut HashSet<String>) {
             }
         }
         ExprKind::PropertyAccess { object, .. }
-        | ExprKind::NullsafePropertyAccess { object, .. } => collect_refs_expr(object, out),
+        | ExprKind::NullsafePropertyAccess { object, .. }
+        | ExprKind::ObjectClassName { object } => collect_refs_expr(object, out),
         ExprKind::MethodCall { object, args, .. }
         | ExprKind::NullsafeMethodCall { object, args, .. } => {
             collect_refs_expr(object, out);

--- a/src/codegen_support/program_usage/required_classes/collect.rs
+++ b/src/codegen_support/program_usage/required_classes/collect.rs
@@ -462,6 +462,9 @@ fn collect_required_class_names_in_expr(expr: &Expr, names: &mut HashSet<String>
                 names.insert(name.as_str().to_string());
             }
         }
+        ExprKind::ObjectClassName { object } => {
+            collect_required_class_names_in_expr(object, names);
+        }
         ExprKind::ScopedConstantAccess { receiver, .. } => {
             if let crate::parser::ast::StaticReceiver::Named(name) = receiver {
                 names.insert(name.as_str().to_string());

--- a/src/codegen_support/program_usage/required_classes/dynamic_instanceof.rs
+++ b/src/codegen_support/program_usage/required_classes/dynamic_instanceof.rs
@@ -163,7 +163,8 @@ fn expr_has_dynamic_instanceof(expr: &Expr) -> bool {
         | ExprKind::Cast { expr, .. }
         | ExprKind::PtrCast { expr, .. }
         | ExprKind::NamedArg { value: expr, .. }
-        | ExprKind::BufferNew { len: expr, .. } => expr_has_dynamic_instanceof(expr),
+        | ExprKind::BufferNew { len: expr, .. }
+        | ExprKind::ObjectClassName { object: expr } => expr_has_dynamic_instanceof(expr),
         ExprKind::NullCoalesce { value, default }
         | ExprKind::ShortTernary { value, default } => {
             expr_has_dynamic_instanceof(value) || expr_has_dynamic_instanceof(default)

--- a/src/codegen_support/runtime_features.rs
+++ b/src/codegen_support/runtime_features.rs
@@ -468,6 +468,7 @@ fn expr_has_regex_call(expr: &Expr) -> bool {
             is_regex_builtin_name(name.as_str())
         }
         ExprKind::FirstClassCallable(CallableTarget::StaticMethod { .. }) => false,
+        ExprKind::ObjectClassName { object } => expr_has_regex_call(object),
         ExprKind::StaticPropertyAccess { receiver, .. }
         | ExprKind::ClassConstant { receiver }
         | ExprKind::ScopedConstantAccess { receiver, .. } => {
@@ -794,6 +795,7 @@ fn expr_needs_descriptor_invoker(expr: &Expr) -> bool {
             expr_needs_descriptor_invoker(object)
         }
         ExprKind::FirstClassCallable(_) => false,
+        ExprKind::ObjectClassName { object } => expr_needs_descriptor_invoker(object),
         ExprKind::StaticPropertyAccess { .. }
         | ExprKind::ClassConstant { .. }
         | ExprKind::ScopedConstantAccess { .. } => false,

--- a/src/eval_aot.rs
+++ b/src/eval_aot.rs
@@ -1440,6 +1440,7 @@ fn expr_fallback_reason(expr: &Expr) -> Option<EvalAotFallbackReason> {
         | ExprKind::NullsafeMethodCall { .. }
         | ExprKind::StaticMethodCall { .. }
         | ExprKind::ClassConstant { .. }
+        | ExprKind::ObjectClassName { .. }
         | ExprKind::ScopedConstantAccess { .. }
         | ExprKind::This => Some(EvalAotFallbackReason::ObjectOrMemberAccess),
         ExprKind::ArrayLiteral(_) | ExprKind::ArrayLiteralAssoc(_) | ExprKind::Spread(_) => {
@@ -2566,6 +2567,7 @@ fn collect_expr_scope_access(expr: &Expr, access: &mut EvalScopeAccess) {
         | ExprKind::ClassConstant { .. }
         | ExprKind::ScopedConstantAccess { .. }
         | ExprKind::MagicConstant(_) => {}
+        ExprKind::ObjectClassName { object } => collect_expr_scope_access(object, access),
         ExprKind::Variable(name)
         | ExprKind::PreIncrement(name)
         | ExprKind::PostIncrement(name)

--- a/src/image_prelude/detect.rs
+++ b/src/image_prelude/detect.rs
@@ -355,6 +355,7 @@ fn expr_refs_image(expr: &Expr) -> bool {
         }
         ExprKind::ClassConstant { receiver }
         | ExprKind::ScopedConstantAccess { receiver, .. } => receiver_refs_image(receiver),
+        ExprKind::ObjectClassName { object } => expr_refs_image(object),
         ExprKind::NewScopedObject { receiver, args } => {
             receiver_refs_image(receiver) || args.iter().any(expr_refs_image)
         }

--- a/src/ir_lower/expr/mod.rs
+++ b/src/ir_lower/expr/mod.rs
@@ -166,6 +166,7 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext<'_, '_>, expr: &Expr) -> Lowe
         ExprKind::PtrCast { target_type, expr: inner } => lower_ptr_cast(ctx, target_type, inner, expr),
         ExprKind::BufferNew { element_type, len } => lower_buffer_new(ctx, element_type, len, expr),
         ExprKind::ClassConstant { receiver } => lower_class_constant(ctx, receiver, expr),
+        ExprKind::ObjectClassName { object } => lower_object_class_name(ctx, object, expr),
         ExprKind::ScopedConstantAccess { receiver, name } => {
             lower_scoped_constant(ctx, receiver, name, expr)
         }
@@ -713,7 +714,10 @@ fn expr_can_reset_concat_storage(expr: &Expr) -> bool {
         | ExprKind::NamedArg { value: inner, .. }
         | ExprKind::Spread(inner)
         | ExprKind::PtrCast { expr: inner, .. }
-        | ExprKind::BufferNew { len: inner, .. } => expr_can_reset_concat_storage(inner),
+        | ExprKind::BufferNew { len: inner, .. }
+        | ExprKind::ObjectClassName { object: inner } => {
+            expr_can_reset_concat_storage(inner)
+        }
         ExprKind::NullCoalesce { value, default }
         | ExprKind::ShortTernary { value, default } => {
             expr_can_reset_concat_storage(value) || expr_can_reset_concat_storage(default)
@@ -9421,6 +9425,7 @@ fn expr_contains_eval_call(expr: &Expr) -> bool {
         | ExprKind::Cast { expr, .. }
         | ExprKind::PtrCast { expr, .. }
         | ExprKind::BufferNew { len: expr, .. }
+        | ExprKind::ObjectClassName { object: expr }
         | ExprKind::YieldFrom(expr) => expr_contains_eval_call(expr),
         ExprKind::NullCoalesce { value, default }
         | ExprKind::ShortTernary { value, default }
@@ -14430,6 +14435,23 @@ fn lower_class_constant(ctx: &mut LoweringContext<'_, '_>, receiver: &StaticRece
         PhpType::Str,
         Op::ConstClassName.default_effects(),
         Some(expr.span),
+    )
+}
+
+/// Lowers an object-valued `::class` receiver through the runtime class-name lookup.
+fn lower_object_class_name(
+    ctx: &mut LoweringContext<'_, '_>,
+    object: &Expr,
+    expr: &Expr,
+) -> LoweredValue {
+    let object = lower_expr(ctx, object);
+    emit_builtin_call_value(
+        ctx,
+        "get_class",
+        vec![object.value],
+        PhpType::Str,
+        expr.span,
+        None,
     )
 }
 

--- a/src/ir_lower/tests/exhaustive.rs
+++ b/src/ir_lower/tests/exhaustive.rs
@@ -343,6 +343,7 @@ fn lowers_every_expr_variant_smoke() {
         expr(ExprKind::ClassConstant { receiver: StaticReceiver::Self_ }),
         expr(ExprKind::ClassConstant { receiver: StaticReceiver::Static }),
         expr(ExprKind::ClassConstant { receiver: StaticReceiver::Parent }),
+        expr(ExprKind::ObjectClassName { object: Box::new(object.clone()) }),
         expr(ExprKind::ScopedConstantAccess { receiver: StaticReceiver::Named(name("C")), name: "K".to_string() }),
         expr(ExprKind::NewScopedObject { receiver: StaticReceiver::Named(name("C")), args: Vec::new() }),
         expr(ExprKind::MagicConstant(MagicConstant::File)),

--- a/src/list_id_prelude/detect.rs
+++ b/src/list_id_prelude/detect.rs
@@ -250,6 +250,7 @@ fn expr_refs_listid(expr: &Expr) -> bool {
         ExprKind::StaticPropertyAccess { .. } => false,
         ExprKind::BufferNew { len, .. } => expr_refs_listid(len),
         ExprKind::ClassConstant { .. } | ExprKind::ScopedConstantAccess { .. } => false,
+        ExprKind::ObjectClassName { object } => expr_refs_listid(object),
         ExprKind::NewScopedObject { args, .. } => args.iter().any(expr_refs_listid),
         ExprKind::Yield { key, value } => {
             key.as_deref().is_some_and(expr_refs_listid)

--- a/src/magic_constants/walker/exprs.rs
+++ b/src/magic_constants/walker/exprs.rs
@@ -274,6 +274,9 @@ pub(super) fn walk_expr<P: Pass>(expr: Expr, pass: &mut P) -> Expr {
             len: Box::new(walk_expr(*len, pass)),
         },
         ExprKind::ClassConstant { receiver } => ExprKind::ClassConstant { receiver },
+        ExprKind::ObjectClassName { object } => ExprKind::ObjectClassName {
+            object: Box::new(walk_expr(*object, pass)),
+        },
         ExprKind::ScopedConstantAccess { receiver, name } => {
             ExprKind::ScopedConstantAccess { receiver, name }
         }

--- a/src/name_resolver/expressions.rs
+++ b/src/name_resolver/expressions.rs
@@ -264,6 +264,9 @@ pub(super) fn resolve_expr(
                 _ => receiver.clone(),
             },
         },
+        ExprKind::ObjectClassName { object } => ExprKind::ObjectClassName {
+            object: Box::new(resolve_expr(object, current_namespace, imports, symbols)),
+        },
         ExprKind::ScopedConstantAccess { receiver, name } => ExprKind::ScopedConstantAccess {
             receiver: match receiver {
                 StaticReceiver::Named(name) => StaticReceiver::Named(resolved_name(

--- a/src/optimize/control/prune/expr.rs
+++ b/src/optimize/control/prune/expr.rs
@@ -253,6 +253,9 @@ pub(crate) fn prune_expr(expr: Expr) -> Expr {
             len: Box::new(prune_expr(*len)),
         },
         ExprKind::ClassConstant { receiver } => ExprKind::ClassConstant { receiver },
+        ExprKind::ObjectClassName { object } => ExprKind::ObjectClassName {
+            object: Box::new(prune_expr(*object)),
+        },
         ExprKind::ScopedConstantAccess { receiver, name } => {
             ExprKind::ScopedConstantAccess { receiver, name }
         }

--- a/src/optimize/effects.rs
+++ b/src/optimize/effects.rs
@@ -346,6 +346,7 @@ pub(super) fn expr_effect(expr: &Expr) -> Effect {
         ExprKind::FirstClassCallable(target) => callable_target_effect(target),
         ExprKind::BufferNew { len, .. } => expr_effect(len).with_side_effects(),
         ExprKind::ClassConstant { .. } | ExprKind::ScopedConstantAccess { .. } => Effect::PURE,
+        ExprKind::ObjectClassName { object } => expr_effect(object),
         ExprKind::NewScopedObject { args, .. } => combine_effects(args.iter().map(expr_effect))
             .with_side_effects()
             .with_may_throw(),

--- a/src/optimize/fold/expr.rs
+++ b/src/optimize/fold/expr.rs
@@ -380,6 +380,9 @@ pub(in crate::optimize) fn fold_expr(expr: Expr) -> Expr {
             len: Box::new(fold_expr(*len)),
         },
         ExprKind::ClassConstant { receiver } => ExprKind::ClassConstant { receiver },
+        ExprKind::ObjectClassName { object } => ExprKind::ObjectClassName {
+            object: Box::new(fold_expr(*object)),
+        },
         ExprKind::ScopedConstantAccess { receiver, name } => {
             ExprKind::ScopedConstantAccess { receiver, name }
         }

--- a/src/optimize/propagate/expr.rs
+++ b/src/optimize/propagate/expr.rs
@@ -361,6 +361,9 @@ pub(crate) fn propagate_expr(expr: Expr, env: &ConstantEnv) -> Expr {
             len: Box::new(propagate_expr(*len, env)),
         },
         ExprKind::ClassConstant { receiver } => ExprKind::ClassConstant { receiver },
+        ExprKind::ObjectClassName { object } => ExprKind::ObjectClassName {
+            object: Box::new(propagate_expr(*object, env)),
+        },
         ExprKind::ScopedConstantAccess { receiver, name } => {
             ExprKind::ScopedConstantAccess { receiver, name }
         }

--- a/src/optimize/propagate/invalidation.rs
+++ b/src/optimize/propagate/invalidation.rs
@@ -95,6 +95,7 @@ pub(crate) fn expr_invalidation(expr: &Expr) -> Invalidation {
         | ExprKind::This
         | ExprKind::ClassConstant { .. }
         | ExprKind::ScopedConstantAccess { .. } => Invalidation::none(),
+        ExprKind::ObjectClassName { object } => expr_invalidation(object),
         // Creating a closure executes nothing, but its by-ref captures alias
         // the outer variables from this point on: any existing fact for them
         // must die here (the volatility ledger only blocks *future* facts).

--- a/src/parser/ast/expr.rs
+++ b/src/parser/ast/expr.rs
@@ -215,6 +215,12 @@ pub enum ExprKind {
     ClassConstant {
         receiver: StaticReceiver,
     },
+    /// `$object::class` or another object-valued expression followed by `::class`.
+    /// Unlike `ClassConstant`, this resolves the concrete runtime class of the
+    /// evaluated object instead of naming a compile-time static receiver.
+    ObjectClassName {
+        object: Box<Expr>,
+    },
     /// Access to a user-declared class constant: `MyClass::FOO`,
     /// `self::FOO`, `parent::FOO`, `static::FOO`. Resolved at type-check
     /// time by looking up the constant in the receiver's class info.

--- a/src/parser/expr/assignment_targets.rs
+++ b/src/parser/expr/assignment_targets.rs
@@ -350,7 +350,10 @@ fn collect_assignment_target_dependencies(expr: &Expr, dependencies: &mut HashSe
         | ExprKind::Cast { expr: value, .. }
         | ExprKind::PtrCast { expr: value, .. }
         | ExprKind::NamedArg { value, .. }
-        | ExprKind::Spread(value) => collect_assignment_target_dependencies(value, dependencies),
+        | ExprKind::Spread(value)
+        | ExprKind::ObjectClassName { object: value } => {
+            collect_assignment_target_dependencies(value, dependencies)
+        }
         ExprKind::NullCoalesce { value, default } | ExprKind::ShortTernary { value, default } => {
             collect_assignment_target_dependencies(value, dependencies);
             collect_assignment_target_dependencies(default, dependencies);
@@ -483,7 +486,10 @@ fn expr_may_write_dependency(expr: &Expr, dependencies: &HashSet<String>) -> boo
         | ExprKind::Cast { expr: value, .. }
         | ExprKind::PtrCast { expr: value, .. }
         | ExprKind::NamedArg { value, .. }
-        | ExprKind::Spread(value) => expr_may_write_dependency(value, dependencies),
+        | ExprKind::Spread(value)
+        | ExprKind::ObjectClassName { object: value } => {
+            expr_may_write_dependency(value, dependencies)
+        }
         ExprKind::NullCoalesce { value, default } | ExprKind::ShortTernary { value, default } => {
             expr_may_write_dependency(value, dependencies)
                 || expr_may_write_dependency(default, dependencies)
@@ -695,6 +701,7 @@ fn expr_contains_equivalent(expr: &Expr, needle: &Expr) -> bool {
         | ExprKind::PtrCast { expr: value, .. }
         | ExprKind::NamedArg { value, .. }
         | ExprKind::Spread(value)
+        | ExprKind::ObjectClassName { object: value }
         | ExprKind::YieldFrom(value) => expr_contains_equivalent(value, needle),
         ExprKind::NullCoalesce { value, default } | ExprKind::ShortTernary { value, default } => {
             expr_contains_equivalent(value, needle) || expr_contains_equivalent(default, needle)

--- a/src/parser/expr/pratt.rs
+++ b/src/parser/expr/pratt.rs
@@ -99,6 +99,17 @@ fn parse_expr_bp_inner(
                 // `call_user_func([$cls, $method], ...args)`, reusing the runtime dispatch path.
                 let span = tokens[*pos].1;
                 *pos += 1; // consume '::'
+                if matches!(tokens.get(*pos).map(|(token, _)| token), Some(Token::Class)) {
+                    *pos += 1;
+                    let span = crate::parser::expr::span_through_prev_token(tokens, *pos, span);
+                    lhs = Expr::new(
+                        ExprKind::ObjectClassName {
+                            object: Box::new(lhs),
+                        },
+                        span,
+                    );
+                    continue;
+                }
                 let member = match tokens.get(*pos).map(|(token, s)| (token.clone(), *s)) {
                     Some((Token::Identifier(name), name_span)) => {
                         *pos += 1;

--- a/src/parser/expr/prefix_complex.rs
+++ b/src/parser/expr/prefix_complex.rs
@@ -351,6 +351,7 @@ fn collect_arrow_expr_captures(
         | ExprKind::Spread(inner)
         | ExprKind::PtrCast { expr: inner, .. }
         | ExprKind::Cast { expr: inner, .. }
+        | ExprKind::ObjectClassName { object: inner }
         | ExprKind::YieldFrom(inner) => collect_arrow_expr_captures(inner, bound, seen, captures),
         ExprKind::NullCoalesce { value, default } | ExprKind::ShortTernary { value, default } => {
             collect_arrow_expr_captures(value, bound, seen, captures);

--- a/src/pdo_prelude/detect.rs
+++ b/src/pdo_prelude/detect.rs
@@ -287,6 +287,7 @@ fn expr_refs_pdo(expr: &Expr) -> bool {
         }
         ExprKind::ClassConstant { receiver }
         | ExprKind::ScopedConstantAccess { receiver, .. } => receiver_refs_pdo(receiver),
+        ExprKind::ObjectClassName { object } => expr_refs_pdo(object),
         ExprKind::NewScopedObject { receiver, args } => {
             receiver_refs_pdo(receiver) || args.iter().any(expr_refs_pdo)
         }

--- a/src/resolver/contains.rs
+++ b/src/resolver/contains.rs
@@ -237,6 +237,7 @@ fn expr_has_includes(expr: &Expr) -> bool {
         ExprKind::FirstClassCallable(CallableTarget::Method { object, .. }) => {
             expr_has_includes(object)
         }
+        ExprKind::ObjectClassName { object } => expr_has_includes(object),
         ExprKind::StringLiteral(_)
         | ExprKind::IntLiteral(_)
         | ExprKind::FloatLiteral(_)

--- a/src/resolver/discovery/exprs.rs
+++ b/src/resolver/discovery/exprs.rs
@@ -201,6 +201,9 @@ pub(super) fn discover_expr(
         ExprKind::FirstClassCallable(crate::parser::ast::CallableTarget::Method { object, .. }) => {
             discover_expr(object, base_dir, loaded_paths, include_chain, state, output)?;
         }
+        ExprKind::ObjectClassName { object } => {
+            discover_expr(object, base_dir, loaded_paths, include_chain, state, output)?;
+        }
         ExprKind::StringLiteral(_)
         | ExprKind::IntLiteral(_)
         | ExprKind::FloatLiteral(_)

--- a/src/strict_php/audit.rs
+++ b/src/strict_php/audit.rs
@@ -509,6 +509,7 @@ fn audit_expr(expr: &Expr, errors: &mut Vec<CompileError>) {
         | ExprKind::Print(inner)
         | ExprKind::Spread(inner)
         | ExprKind::Clone(inner)
+        | ExprKind::ObjectClassName { object: inner }
         | ExprKind::YieldFrom(inner) => audit_expr(inner, errors),
         ExprKind::NullCoalesce { value, default } => {
             audit_expr(value, errors);

--- a/src/types/checker/inference/expr/mod.rs
+++ b/src/types/checker/inference/expr/mod.rs
@@ -614,6 +614,24 @@ impl Checker {
                 self.validate_class_constant_receiver(receiver, expr.span)?;
                 Ok(PhpType::Str)
             }
+            ExprKind::ObjectClassName { object } => {
+                let object_type = self.infer_type(object, env)?;
+                let object_only = match &object_type {
+                    PhpType::Object(_) => true,
+                    PhpType::Union(members) => {
+                        !members.is_empty()
+                            && members.iter().all(|member| matches!(member, PhpType::Object(_)))
+                    }
+                    _ => false,
+                };
+                if !object_only {
+                    return Err(CompileError::new(
+                        expr.span,
+                        &format!("Cannot use \"::class\" on {}", object_type),
+                    ));
+                }
+                Ok(PhpType::Str)
+            }
             ExprKind::ScopedConstantAccess { receiver, name } => {
                 self.infer_scoped_constant_access(receiver, name, expr)
             }

--- a/src/types/checker/inference/syntactic.rs
+++ b/src/types/checker/inference/syntactic.rs
@@ -366,7 +366,9 @@ pub fn infer_expr_type_syntactic(expr: &Expr) -> PhpType {
             PhpType::Object(fallback_class.as_str().to_string())
         }
         ExprKind::NewScopedObject { .. } => PhpType::Object(String::new()),
-        ExprKind::ClassConstant { .. } | ExprKind::ScopedConstantAccess { .. } => PhpType::Str,
+        ExprKind::ClassConstant { .. }
+        | ExprKind::ObjectClassName { .. }
+        | ExprKind::ScopedConstantAccess { .. } => PhpType::Str,
         ExprKind::This => PhpType::Object(String::new()),
         ExprKind::Closure { .. } | ExprKind::FirstClassCallable(_) => PhpType::Callable,
         ExprKind::PtrCast { target_type, .. } => PhpType::Pointer(Some(target_type.clone())),

--- a/src/types/checker/schema/classes/constants.rs
+++ b/src/types/checker/schema/classes/constants.rs
@@ -303,6 +303,9 @@ fn rewrite_expr(
         ExprKind::ClassConstant { receiver } => ExprKind::ClassConstant {
             receiver: rewrite_constant_receiver(receiver, class_name, parent_name, expr.span)?,
         },
+        ExprKind::ObjectClassName { object } => ExprKind::ObjectClassName {
+            object: Box::new(rewrite_expr(object, class_name, parent_name)?),
+        },
         ExprKind::ScopedConstantAccess { receiver, name } => {
             ExprKind::ScopedConstantAccess {
                 receiver: rewrite_constant_receiver(receiver, class_name, parent_name, expr.span)?,

--- a/src/types/checker/yield_validation/validate.rs
+++ b/src/types/checker/yield_validation/validate.rs
@@ -390,6 +390,7 @@ fn visit_expr(expr: &Expr, st: &mut State) {
         }
         ExprKind::PropertyAccess { object, .. }
         | ExprKind::NullsafePropertyAccess { object, .. } => visit_expr(object, st),
+        ExprKind::ObjectClassName { object } => visit_expr(object, st),
         ExprKind::DynamicPropertyAccess { object, property }
         | ExprKind::NullsafeDynamicPropertyAccess { object, property } => {
             visit_expr(object, st);

--- a/src/types/return_alias.rs
+++ b/src/types/return_alias.rs
@@ -547,6 +547,7 @@ fn expr_alias(expr: &Expr, state: &HashMap<String, ReturnArgAlias>) -> ReturnArg
         | ExprKind::BitNot(_)
         | ExprKind::PtrCast { .. }
         | ExprKind::ClassConstant { .. }
+        | ExprKind::ObjectClassName { .. }
         | ExprKind::MagicConstant(_) => ReturnArgAlias::None,
         _ => ReturnArgAlias::Unknown,
     }
@@ -708,6 +709,7 @@ fn apply_expr_effects(expr: &Expr, state: &mut HashMap<String, ReturnArgAlias>) 
         }
         ExprKind::NamedArg { value, .. } => apply_expr_effects(value, state),
         ExprKind::BufferNew { len, .. } => apply_expr_effects(len, state),
+        ExprKind::ObjectClassName { object } => apply_expr_effects(object, state),
         ExprKind::Yield { key, value } => {
             if let Some(key) = key {
                 apply_expr_effects(key, state);

--- a/src/types/warnings/expr_reads.rs
+++ b/src/types/warnings/expr_reads.rs
@@ -204,6 +204,7 @@ pub(super) fn collect_expr_reads(
         }
         ExprKind::StaticPropertyAccess { .. } => {},
         ExprKind::BufferNew { len, .. } => collect_expr_reads(len, scope, warnings),
+        ExprKind::ObjectClassName { object } => collect_expr_reads(object, scope, warnings),
         ExprKind::ClassConstant { .. } | ExprKind::ScopedConstantAccess { .. } => {}
         ExprKind::NewScopedObject { args, .. } => {
             for arg in args {

--- a/src/tz_prelude/detect.rs
+++ b/src/tz_prelude/detect.rs
@@ -239,6 +239,7 @@ fn expr_refs_tz(expr: &Expr) -> bool {
         ExprKind::StaticPropertyAccess { .. } => false,
         ExprKind::BufferNew { len, .. } => expr_refs_tz(len),
         ExprKind::ClassConstant { .. } | ExprKind::ScopedConstantAccess { .. } => false,
+        ExprKind::ObjectClassName { object } => expr_refs_tz(object),
         ExprKind::NewScopedObject { args, .. } => args.iter().any(expr_refs_tz),
         ExprKind::Yield { key, value } => {
             key.as_deref().is_some_and(expr_refs_tz)

--- a/src/var_export_prelude/detect.rs
+++ b/src/var_export_prelude/detect.rs
@@ -231,6 +231,7 @@ fn expr_refs_ve(expr: &Expr) -> bool {
         ExprKind::StaticPropertyAccess { .. } => false,
         ExprKind::BufferNew { len, .. } => expr_refs_ve(len),
         ExprKind::ClassConstant { .. } | ExprKind::ScopedConstantAccess { .. } => false,
+        ExprKind::ObjectClassName { object } => expr_refs_ve(object),
         ExprKind::NewScopedObject { args, .. } => args.iter().any(expr_refs_ve),
         ExprKind::Yield { key, value } => {
             key.as_deref().is_some_and(expr_refs_ve)

--- a/src/web_prelude/usage.rs
+++ b/src/web_prelude/usage.rs
@@ -505,5 +505,6 @@ fn scan_expr(expr: &Expr, usage: &mut Usage) {
         | ExprKind::ClassConstant { .. }
         | ExprKind::ScopedConstantAccess { .. }
         | ExprKind::MagicConstant(_) => {}
+        ExprKind::ObjectClassName { object } => scan_expr(object, usage),
     }
 }

--- a/tests/codegen/static_class_features.rs
+++ b/tests/codegen/static_class_features.rs
@@ -65,6 +65,42 @@ fn test_class_class_concat_in_message() {
     assert_eq!(out, "From: Logger");
 }
 
+/// Verifies `$object::class` returns the object's fully-qualified runtime class name.
+#[test]
+fn test_object_class_name_returns_runtime_fqn() {
+    let out = compile_and_run(
+        "<?php namespace App; class Pluto {} $pippo = new Pluto(); echo $pippo::class;",
+    );
+    assert_eq!(out, "App\\Pluto");
+}
+
+/// Verifies `$object::class` reads the concrete subclass even when the expression is typed as its base class.
+#[test]
+fn test_object_class_name_preserves_concrete_subclass() {
+    let out = compile_and_run(
+        "<?php class Base {} class Child extends Base {} function pick(bool $base): Base { return $base ? new Base() : new Child(); } echo pick(false)::class;",
+    );
+    assert_eq!(out, "Child");
+}
+
+/// Verifies `::class` accepts object-only unions and dispatches using the selected runtime object.
+#[test]
+fn test_object_class_name_accepts_object_union() {
+    let out = compile_and_run(
+        "<?php class Left {} class Right {} function pick(bool $left): Left|Right { return $left ? new Left() : new Right(); } echo pick(false)::class;",
+    );
+    assert_eq!(out, "Right");
+}
+
+/// Verifies an object-valued expression before `::class` is evaluated exactly once.
+#[test]
+fn test_object_class_name_evaluates_receiver_once() {
+    let out = compile_and_run(
+        "<?php class Probe {} function make_probe(): Probe { echo 'once|'; return new Probe(); } echo make_probe()::class;",
+    );
+    assert_eq!(out, "once|Probe");
+}
+
 // --- new self() / new static() / new parent() ---
 
 /// Verifies `new self()` inside a static method returns an instance of the lexical (defining) class `Box` and that fields are accessible.

--- a/tests/error_tests/misc/classes.rs
+++ b/tests/error_tests/misc/classes.rs
@@ -46,6 +46,15 @@ fn test_error_undefined_method() {
     );
 }
 
+/// Verifies `::class` rejects a receiver whose static type is not an object.
+#[test]
+fn test_error_object_class_name_requires_object() {
+    expect_error(
+        "<?php $value = 1; echo $value::class;",
+        "Cannot use \"::class\" on int",
+    );
+}
+
 /// Verifies that a method call on an object union (`A|B`) is rejected when the
 /// method is absent from one of the member classes: every object member must
 /// provide the method for the runtime class-id dispatch to be sound.

--- a/tests/parser_tests/magic_constants.rs
+++ b/tests/parser_tests/magic_constants.rs
@@ -152,4 +152,32 @@ fn test_parse_class_class_parent() {
     );
 }
 
+/// Verifies that `$object::class` keeps the object expression as a dedicated runtime class-name receiver.
+#[test]
+fn test_parse_object_class_name() {
+    let stmts = parse_source("<?php echo $pippo::class;");
+    match echoed_expr(&stmts) {
+        ExprKind::ObjectClassName { object } => {
+            assert_eq!(object.kind, ExprKind::Variable("pippo".to_string()));
+        }
+        other => panic!("expected ObjectClassName, got {:?}", other),
+    }
+}
+
+/// Verifies that `::class` accepts a call expression receiver without duplicating it in the AST.
+#[test]
+fn test_parse_call_expression_object_class_name() {
+    let stmts = parse_source("<?php echo make()::class;");
+    match echoed_expr(&stmts) {
+        ExprKind::ObjectClassName { object } => match &object.kind {
+            ExprKind::FunctionCall { name, args } => {
+                assert_eq!(name.as_str(), "make");
+                assert!(args.is_empty());
+            }
+            other => panic!("expected FunctionCall receiver, got {:?}", other),
+        },
+        other => panic!("expected ObjectClassName, got {:?}", other),
+    }
+}
+
 // --- new self() / new static() / new parent() ---


### PR DESCRIPTION
## Summary

- add a dedicated ObjectClassName AST node for object-valued ::class
  receivers
- support $object::class and expression receivers such as
  make_object()::class
- lower object class-name reads through the existing runtime class metadata
  lookup
- preserve the concrete runtime class for subclasses and object-only unions
- evaluate the receiver expression exactly once
- reject statically known non-object receivers with a PHP-compatible
  diagnostic
- update the static classes example and parser/classes documentation

Named and scoped forms such as ClassName::class, self::class, parent::class,
and static::class keep their existing behavior.

## Implementation notes

The parser keeps object-valued class-name reads structurally distinct from
compile-time ClassConstant expressions. EIR lowering evaluates the receiver
once and reuses the runtime lookup used by get_class(), so a value typed as
a base class still reports its concrete subclass.

All AST walkers, optimizer passes, name resolution, usage scans, prelude
detection, eval fallback classification, and type-analysis passes now
recurse through the new node.

The existing get_class() behavior for non-object values is intentionally
unchanged and remains tracked in #568.

## Testing

- cargo test --test parser_tests object_class_name
- cargo test --test error_tests object_class_name
- cargo test --test codegen_tests object_class_name
- cargo test --lib lowers_every_expr_variant_smoke
- ELEPHC_PHP_CHECK=1 cargo test --test codegen_tests
  'static_class_features::test_object_class_name'

- cargo build
- cargo check --tests
- git diff --check

Coverage includes fully-qualified runtime names, concrete subclass dispatch,
object-only unions, single receiver evaluation, and rejection of non-object
receivers.
