### PR TITLE
fix(types): preserve late-static method returns

### DIFF
--- a/docs/php/classes.md
+++ b/docs/php/classes.md
@@ -600,7 +600,7 @@ class Child extends Base {
 
 ## Relative class types (`self`, `static`, `parent`)
 
-`self`, `static`, and `parent` may be used as type declarations on method parameters, method return types, and properties. They resolve to the enclosing class (`self`, `static`) or its parent (`parent`):
+`self`, `static`, and `parent` may be used as type declarations on method parameters, method return types, and properties. `self` and `parent` resolve lexically; a method return declared as `static` is late-bound to the call-site receiver:
 
 ```php
 <?php
@@ -619,7 +619,7 @@ class Node {
 }
 
 trait Fluent {
-    // In a trait, `static` resolves to the class that uses the trait.
+    // In a trait, `static` stays late-bound within the using class hierarchy.
     public function self(): static {
         return $this;
     }
@@ -628,11 +628,13 @@ trait Fluent {
 
 Rules:
 
-- `self` and `static` resolve to the class the member is declared in; `parent` resolves to that class's parent.
+- `self` resolves to the class the member is declared in; `parent` resolves to that class's parent.
+- A method return declared as `static` binds to the receiver class or interface at each call site, including inherited methods and fluent chains.
+- Overrides and interface implementations must preserve a required late-bound `static`; replacing it with the current concrete class is rejected. Covariant narrowing such as `static|false` to `static` remains valid.
 - They are accepted in parameter, return, and property type positions, and may be combined with the nullable shorthand (`?self`) or unions (`self|null`).
-- Used inside a trait, `self`/`static` resolve to the class that uses the trait, not the trait itself.
+- Used inside a trait, `self` resolves to the using class and a return `static` remains late-bound within that class hierarchy.
 - Using `self`, `static`, or `parent` as a type outside of a class is rejected.
-- For type checking, `static` is treated as the declaring class. A `static` return type chained directly on its declaring class works as expected; when a `static`-returning method is inherited and called on a subclass, the result is typed as the declaring class rather than the subclass.
+- PHPDoc return annotations are not parsed for typing. A fluent API that needs late-static refinement must declare the native PHP return type `: static`; `@return static` alone does not change the inferred type.
 
 ## Dynamic instantiation (`new $variable()`)
 

--- a/examples/relative-class-types/main.php
+++ b/examples/relative-class-types/main.php
@@ -54,3 +54,26 @@ $head->next->next = new Node(3);
 // Read through the nullable `?self` links.
 echo $head->value + $head->next->value + $head->next->next->value, "\n";
 echo $head->next->next->next === null ? "tail\n" : "more\n";
+
+// An inherited `static` return binds to the subclass receiver, so subclass-only
+// fluent operations remain available even when the method lives on the base class.
+class Builder
+{
+    protected string $where = "";
+
+    public function andWhere(string $condition): static
+    {
+        $this->where = $condition;
+        return $this;
+    }
+}
+
+final class QueryBuilder extends Builder
+{
+    public function getSQL(): string
+    {
+        return "SELECT * WHERE " . $this->where;
+    }
+}
+
+echo (new QueryBuilder())->andWhere("active = 1")->getSQL(), "\n";

--- a/src/codegen/lower_inst/objects/reflection.rs
+++ b/src/codegen/lower_inst/objects/reflection.rs
@@ -3216,7 +3216,12 @@ fn reflection_class_method_member(
         return Ok(None);
     };
     let required_parameter_count = reflection_required_parameter_count(sig);
-    let type_metadata = reflection_return_type_metadata(sig);
+    let late_static_return = if flags.is_static {
+        info.late_static_static_method_returns.get(&method_key)
+    } else {
+        info.late_static_method_returns.get(&method_key)
+    };
+    let type_metadata = reflection_method_return_type_metadata(sig, late_static_return);
     let is_generator = reflection_method_is_generator(
         ctx,
         declaring_class_name.as_deref().unwrap_or(class_name),
@@ -3318,7 +3323,12 @@ fn reflection_interface_method_member(
         .unwrap_or_else(|| interface_name.to_string());
     let required_parameter_count = reflection_required_parameter_count(sig);
     let flags = reflection_member_flags(is_static, &Visibility::Public, false, true, false, false);
-    let type_metadata = reflection_return_type_metadata(sig);
+    let late_static_return = if is_static {
+        info.late_static_static_method_returns.get(&method_key)
+    } else {
+        info.late_static_method_returns.get(&method_key)
+    };
+    let type_metadata = reflection_method_return_type_metadata(sig, late_static_return);
     let declaring_function = ReflectionDeclaringFunctionMember::Method {
         name: method_key.clone(),
         declaring_class_name: Some(declaring_class_name.clone()),
@@ -4455,6 +4465,32 @@ fn reflection_return_type_metadata(sig: &FunctionSig) -> Option<ReflectionParame
         PhpType::Union(members) => reflection_union_or_nullable_type_metadata(members),
         ty => reflection_named_type_metadata(ty).map(ReflectionParameterTypeMetadata::Named),
     }
+}
+
+/// Converts a method return contract while preserving reflection-visible late-bound `static`.
+fn reflection_method_return_type_metadata(
+    sig: &FunctionSig,
+    late_static_return: Option<&TypeExpr>,
+) -> Option<ReflectionParameterTypeMetadata> {
+    if sig.declared_return {
+        if let Some(return_type) = late_static_return {
+            let mut metadata = reflection_declared_type_metadata(return_type)?;
+            if let ReflectionParameterTypeMetadata::Union(union) = &mut metadata {
+                // PHP reports named class/interface members before `static`, then builtins.
+                union.types.sort_by_key(|member| {
+                    if member.name.eq_ignore_ascii_case("static") {
+                        1
+                    } else if member.is_builtin {
+                        2
+                    } else {
+                        0
+                    }
+                });
+            }
+            return Some(metadata);
+        }
+    }
+    reflection_return_type_metadata(sig)
 }
 
 /// Converts a normalized non-union parameter type into a simple `ReflectionNamedType`.
@@ -5849,8 +5885,8 @@ fn emit_reflection_class_hash_insert(ctx: &mut FunctionContext<'_>, key: &str) {
     let (key_label, key_len) = ctx.data.add_string(key.as_bytes());
     match ctx.emitter.target.arch {
         Arch::AArch64 => {
-            ctx.emitter.instruction("mov x3, x0"); // pass the ReflectionClass object as the hash payload
-            ctx.emitter.instruction("mov x4, xzr"); // object hash payloads do not use the high word
+            ctx.emitter.instruction("mov x3, x0");                              // pass the ReflectionClass object as the hash payload
+            ctx.emitter.instruction("mov x4, xzr");                             // object hash payloads do not use the high word
             abi::emit_pop_reg(ctx.emitter, "x0");
             abi::emit_symbol_address(ctx.emitter, "x1", &key_label);
             abi::emit_load_int_immediate(ctx.emitter, "x2", key_len as i64);
@@ -5862,8 +5898,8 @@ fn emit_reflection_class_hash_insert(ctx: &mut FunctionContext<'_>, key: &str) {
             abi::emit_call_label(ctx.emitter, "__rt_hash_set");
         }
         Arch::X86_64 => {
-            ctx.emitter.instruction("mov rcx, rax"); // pass the ReflectionClass object as the hash payload
-            ctx.emitter.instruction("xor r8, r8"); // object hash payloads do not use the high word
+            ctx.emitter.instruction("mov rcx, rax");                            // pass the ReflectionClass object as the hash payload
+            ctx.emitter.instruction("xor r8, r8");                              // object hash payloads do not use the high word
             abi::emit_pop_reg(ctx.emitter, "rdi");
             abi::emit_symbol_address(ctx.emitter, "rsi", &key_label);
             abi::emit_load_int_immediate(ctx.emitter, "rdx", key_len as i64);
@@ -6301,8 +6337,8 @@ fn emit_reflection_constant_hash_insert(ctx: &mut FunctionContext<'_>, key: &str
     let (key_label, key_len) = ctx.data.add_string(key.as_bytes());
     match ctx.emitter.target.arch {
         Arch::AArch64 => {
-            ctx.emitter.instruction("mov x3, x0"); // pass the boxed Reflection constant value as the hash payload
-            ctx.emitter.instruction("mov x4, xzr"); // boxed Mixed hash payloads do not use the high word
+            ctx.emitter.instruction("mov x3, x0");                              // pass the boxed Reflection constant value as the hash payload
+            ctx.emitter.instruction("mov x4, xzr");                             // boxed Mixed hash payloads do not use the high word
             abi::emit_pop_reg(ctx.emitter, "x0");
             abi::emit_symbol_address(ctx.emitter, "x1", &key_label);
             abi::emit_load_int_immediate(ctx.emitter, "x2", key_len as i64);
@@ -6314,8 +6350,8 @@ fn emit_reflection_constant_hash_insert(ctx: &mut FunctionContext<'_>, key: &str
             abi::emit_call_label(ctx.emitter, "__rt_hash_set");
         }
         Arch::X86_64 => {
-            ctx.emitter.instruction("mov rcx, rax"); // pass the boxed Reflection constant value as the hash payload
-            ctx.emitter.instruction("xor r8, r8"); // boxed Mixed hash payloads do not use the high word
+            ctx.emitter.instruction("mov rcx, rax");                            // pass the boxed Reflection constant value as the hash payload
+            ctx.emitter.instruction("xor r8, r8");                              // boxed Mixed hash payloads do not use the high word
             abi::emit_pop_reg(ctx.emitter, "rdi");
             abi::emit_symbol_address(ctx.emitter, "rsi", &key_label);
             abi::emit_load_int_immediate(ctx.emitter, "rdx", key_len as i64);
@@ -7231,32 +7267,32 @@ fn emit_reflection_string_array(ctx: &mut FunctionContext<'_>, names: &[String])
 
 /// Appends ReflectionClass metadata names to the current ARM64 result array.
 fn emit_reflection_string_array_fill_aarch64(ctx: &mut FunctionContext<'_>, names: &[String]) {
-    ctx.emitter.instruction("str x0, [sp, #-16]!"); // park the metadata-name array while appending strings
+    ctx.emitter.instruction("str x0, [sp, #-16]!");                             // park the metadata-name array while appending strings
     for name in names {
         let (label, len) = ctx.data.add_string(name.as_bytes());
-        ctx.emitter.instruction("ldr x0, [sp]"); // reload the metadata-name array for this append
+        ctx.emitter.instruction("ldr x0, [sp]");                                // reload the metadata-name array for this append
         abi::emit_symbol_address(ctx.emitter, "x1", &label);
         abi::emit_load_int_immediate(ctx.emitter, "x2", len as i64);
         abi::emit_call_label(ctx.emitter, "__rt_array_push_str");
-        ctx.emitter.instruction("str x0, [sp]"); // preserve the possibly-grown metadata-name array
+        ctx.emitter.instruction("str x0, [sp]");                                // preserve the possibly-grown metadata-name array
     }
-    ctx.emitter.instruction("ldr x0, [sp], #16"); // restore the final metadata-name array as the result
+    ctx.emitter.instruction("ldr x0, [sp], #16");                               // restore the final metadata-name array as the result
 }
 
 /// Appends ReflectionClass metadata names to the current x86_64 result array.
 fn emit_reflection_string_array_fill_x86_64(ctx: &mut FunctionContext<'_>, names: &[String]) {
-    ctx.emitter.instruction("push rax"); // park the metadata-name array while appending strings
-    ctx.emitter.instruction("sub rsp, 8"); // keep stack alignment stable across append helper calls
+    ctx.emitter.instruction("push rax");                                        // park the metadata-name array while appending strings
+    ctx.emitter.instruction("sub rsp, 8");                                      // keep stack alignment stable across append helper calls
     for name in names {
         let (label, len) = ctx.data.add_string(name.as_bytes());
-        ctx.emitter.instruction("mov rdi, QWORD PTR [rsp + 8]"); // reload the metadata-name array for this append
+        ctx.emitter.instruction("mov rdi, QWORD PTR [rsp + 8]");                // reload the metadata-name array for this append
         abi::emit_symbol_address(ctx.emitter, "rsi", &label);
         abi::emit_load_int_immediate(ctx.emitter, "rdx", len as i64);
         abi::emit_call_label(ctx.emitter, "__rt_array_push_str");
-        ctx.emitter.instruction("mov QWORD PTR [rsp + 8], rax"); // preserve the possibly-grown metadata-name array
+        ctx.emitter.instruction("mov QWORD PTR [rsp + 8], rax");                // preserve the possibly-grown metadata-name array
     }
-    ctx.emitter.instruction("add rsp, 8"); // drop the temporary alignment slot
-    ctx.emitter.instruction("pop rax"); // restore the final metadata-name array as the result
+    ctx.emitter.instruction("add rsp, 8");                                      // drop the temporary alignment slot
+    ctx.emitter.instruction("pop rax");                                         // restore the final metadata-name array as the result
 }
 
 /// Stores ReflectionMethod/ReflectionProperty boolean predicate slots when supported.

--- a/src/codegen_support/runtime/data/user.rs
+++ b/src/codegen_support/runtime/data/user.rs
@@ -2408,6 +2408,8 @@ mod tests {
             method_decls: Vec::new(),
             methods: HashMap::new(),
             static_methods: HashMap::new(),
+            late_static_method_returns: HashMap::new(),
+            late_static_static_method_returns: HashMap::new(),
             callable_method_return_sigs: HashMap::new(),
             callable_array_method_return_sigs: HashMap::new(),
             method_visibilities: HashMap::<String, Visibility>::new(),

--- a/src/ir_lower/expr/mod.rs
+++ b/src/ir_lower/expr/mod.rs
@@ -14136,36 +14136,46 @@ fn method_call_result_type(
         }
         return fallback_expr_type(expr);
     };
-    // Fluent `with*` wither (@return static): a method declared to return a strict
-    // ANCESTOR interface of the receiver interface actually returns `clone $this`
-    // (the receiver's concrete type). Resolve the IR value to the receiver so a
-    // descendant-only chained call dispatches — e.g. `withHeader(): Message` on a
-    // `Request` receiver must stay `Request` for the following `->withMethod()`.
-    // This MUST agree with the checker's infer_method_call_on_interface_type (#547):
-    // if the IR value kept the ancestor type, the EIR backend rejects the chained
-    // call as "interface method call to unknown method Message::withMethod".
-    let fluent_receiver = if let (Some((recv_name, _)), PhpType::Object(return_name)) =
-        (singular_object_class(&object_ty), &return_ty)
-    {
-        if php_symbol_key(method).starts_with("with")
-            && ctx.interfaces.contains_key(recv_name.trim_start_matches('\\'))
-            && php_symbol_key(return_name.trim_start_matches('\\'))
-                != php_symbol_key(recv_name.trim_start_matches('\\'))
-            && interface_extends_interface_for_ir(ctx, recv_name, return_name)
-        {
-            Some(recv_name.to_string())
-        } else {
-            None
-        }
+    let return_ty = if let Some((receiver_name, _)) = singular_object_class(&object_ty) {
+        instance_method_late_static_return_for_ir(ctx, receiver_name, &php_symbol_key(method))
+            .map(|return_type| late_static_return_type_for_ir(ctx, &return_type, receiver_name))
+            .unwrap_or(return_ty)
     } else {
-        None
+        return_ty
     };
-    let return_ty = fluent_receiver.map(PhpType::Object).unwrap_or(return_ty);
     if op == Op::NullsafeMethodCall && nullable {
         nullable_result_type(return_ty)
     } else {
         return_ty
     }
+}
+
+/// Returns preserved late-static return syntax for EIR instance dispatch.
+fn instance_method_late_static_return_for_ir(
+    ctx: &LoweringContext<'_, '_>,
+    receiver_type: &str,
+    method_key: &str,
+) -> Option<TypeExpr> {
+    let normalized = receiver_type.trim_start_matches('\\');
+    if let Some(class_info) = ctx.classes.get(normalized) {
+        if let Some(return_type) = class_info.late_static_method_returns.get(method_key) {
+            return Some(return_type.clone());
+        }
+    }
+    ctx.interfaces
+        .get(normalized)
+        .and_then(|interface_info| interface_info.late_static_method_returns.get(method_key))
+        .cloned()
+}
+
+/// Binds preserved late-static return syntax to an EIR call-site receiver type.
+fn late_static_return_type_for_ir(
+    ctx: &LoweringContext<'_, '_>,
+    return_type: &TypeExpr,
+    receiver_type: &str,
+) -> PhpType {
+    let bound = return_type.substitute_relative_class_types(receiver_type, None);
+    normalize_value_php_type(ctx.type_expr_to_php_type_for_value(&bound))
 }
 
 /// Returns a common method signature for dynamic receivers when every candidate agrees.
@@ -14268,6 +14278,16 @@ fn lower_static_method_call(
                 fallback_expr_type(expr)
             }
         });
+    let late_static_receiver_type = static_late_binding_receiver_type_for_ir(ctx, receiver);
+    let result_type = match (
+        static_method_late_static_return_for_ir(ctx, receiver, dispatch_method),
+        late_static_receiver_type.as_deref(),
+    ) {
+        (Some(return_type), Some(receiver_type)) => {
+            late_static_return_type_for_ir(ctx, &return_type, receiver_type)
+        }
+        _ => result_type,
+    };
     let call = ctx.emit_value(
         Op::StaticMethodCall,
         operands.clone(),
@@ -14286,6 +14306,38 @@ fn lower_static_method_call(
         expr.span,
     );
     call
+}
+
+/// Returns preserved late-static return syntax for EIR static dispatch.
+fn static_method_late_static_return_for_ir(
+    ctx: &LoweringContext<'_, '_>,
+    receiver: &StaticReceiver,
+    method: &str,
+) -> Option<TypeExpr> {
+    let class_name = static_receiver_class_name(ctx, receiver)?;
+    let method_key = php_symbol_key(method);
+    let class_info = ctx.classes.get(&class_name)?;
+    if static_method_implementation_signature(ctx, receiver, method).is_some() {
+        return class_info
+            .late_static_static_method_returns
+            .get(&method_key)
+            .cloned();
+    }
+    lexical_instance_static_call_signature(ctx, receiver, method)?;
+    class_info.late_static_method_returns.get(&method_key).cloned()
+}
+
+/// Resolves the receiver type used to bind `static` for an EIR static-style call.
+fn static_late_binding_receiver_type_for_ir(
+    ctx: &LoweringContext<'_, '_>,
+    receiver: &StaticReceiver,
+) -> Option<String> {
+    match receiver {
+        StaticReceiver::Named(name) => Some(name.as_str().trim_start_matches('\\').to_string()),
+        StaticReceiver::Self_ | StaticReceiver::Static | StaticReceiver::Parent => {
+            ctx.current_class.clone()
+        }
+    }
 }
 
 /// PHP coerces a numeric string to the integer backing value for an int-backed enum's
@@ -14525,9 +14577,20 @@ pub(super) fn static_method_call_expr_type_for_ir(
     receiver: &StaticReceiver,
     method: &str,
 ) -> Option<PhpType> {
-    static_method_implementation_signature(ctx, receiver, method)
+    let nominal = static_method_implementation_signature(ctx, receiver, method)
         .or_else(|| lexical_instance_static_call_signature(ctx, receiver, method))
-        .map(|signature| normalize_value_php_type(signature.return_type.codegen_repr()))
+        .map(|signature| normalize_value_php_type(signature.return_type.codegen_repr()))?;
+    match (
+        static_method_late_static_return_for_ir(ctx, receiver, method),
+        static_late_binding_receiver_type_for_ir(ctx, receiver),
+    ) {
+        (Some(return_type), Some(receiver_type)) => Some(late_static_return_type_for_ir(
+            ctx,
+            &return_type,
+            &receiver_type,
+        )),
+        _ => Some(nominal),
+    }
 }
 
 /// Returns the instance-method signature used by `self::method()` or `parent::method()`.

--- a/src/ir_lower/expr/mod.rs
+++ b/src/ir_lower/expr/mod.rs
@@ -14136,6 +14136,31 @@ fn method_call_result_type(
         }
         return fallback_expr_type(expr);
     };
+    // Fluent `with*` wither (@return static): a method declared to return a strict
+    // ANCESTOR interface of the receiver interface actually returns `clone $this`
+    // (the receiver's concrete type). Resolve the IR value to the receiver so a
+    // descendant-only chained call dispatches — e.g. `withHeader(): Message` on a
+    // `Request` receiver must stay `Request` for the following `->withMethod()`.
+    // This MUST agree with the checker's infer_method_call_on_interface_type (#547):
+    // if the IR value kept the ancestor type, the EIR backend rejects the chained
+    // call as "interface method call to unknown method Message::withMethod".
+    let fluent_receiver = if let (Some((recv_name, _)), PhpType::Object(return_name)) =
+        (singular_object_class(&object_ty), &return_ty)
+    {
+        if php_symbol_key(method).starts_with("with")
+            && ctx.interfaces.contains_key(recv_name.trim_start_matches('\\'))
+            && php_symbol_key(return_name.trim_start_matches('\\'))
+                != php_symbol_key(recv_name.trim_start_matches('\\'))
+            && interface_extends_interface_for_ir(ctx, recv_name, return_name)
+        {
+            Some(recv_name.to_string())
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+    let return_ty = fluent_receiver.map(PhpType::Object).unwrap_or(return_ty);
     if op == Op::NullsafeMethodCall && nullable {
         nullable_result_type(return_ty)
     } else {

--- a/src/ir_lower/tests/exhaustive.rs
+++ b/src/ir_lower/tests/exhaustive.rs
@@ -207,6 +207,8 @@ fn class_info(_class_name: &str) -> ClassInfo {
         method_decls: Vec::new(),
         methods,
         static_methods,
+        late_static_method_returns: Default::default(),
+        late_static_static_method_returns: Default::default(),
         callable_method_return_sigs: HashMap::new(),
         callable_array_method_return_sigs: HashMap::new(),
         method_visibilities: HashMap::new(),

--- a/src/parser/ast/oop.rs
+++ b/src/parser/ast/oop.rs
@@ -236,10 +236,10 @@ pub struct ClassMethod {
 }
 
 impl ClassMethod {
-    /// Rewrites the relative class types `self`/`static`/`parent` in every type annotation this
-    /// method carries — regular parameters, the variadic parameter, and the return type — to
-    /// `self_class`/`parent`. Shared by class, interface, and enum schema processing so no caller
-    /// can forget one of the annotation positions.
+    /// Rewrites relative class types in every annotation while retaining late-bound return `static`.
+    ///
+    /// Parameter annotations resolve `self`/`static`/`parent` lexically. Return annotations keep
+    /// `static` symbolic so checker and EIR call sites can bind it to the receiver type.
     pub fn substitute_relative_class_types(&mut self, self_class: &str, parent: Option<&str>) {
         for (_, type_ann, _, _) in self.params.iter_mut() {
             if let Some(ty) = type_ann.as_mut() {
@@ -250,7 +250,7 @@ impl ClassMethod {
             *variadic_ty = variadic_ty.substitute_relative_class_types(self_class, parent);
         }
         if let Some(ret) = self.return_type.as_mut() {
-            *ret = ret.substitute_relative_class_types(self_class, parent);
+            *ret = ret.substitute_method_return_relative_types(self_class, parent);
         }
     }
 }

--- a/src/parser/ast/types.rs
+++ b/src/parser/ast/types.rs
@@ -35,6 +35,20 @@ pub enum TypeExpr {
 }
 
 impl TypeExpr {
+    /// Returns whether this type expression contains PHP's late-bound `static` class type.
+    pub fn contains_late_static(&self) -> bool {
+        match self {
+            TypeExpr::Named(name) => name.as_str().eq_ignore_ascii_case("static"),
+            TypeExpr::Nullable(inner) | TypeExpr::Array(inner) | TypeExpr::Buffer(inner) => {
+                inner.contains_late_static()
+            }
+            TypeExpr::Union(members) | TypeExpr::Intersection(members) => {
+                members.iter().any(TypeExpr::contains_late_static)
+            }
+            _ => false,
+        }
+    }
+
     /// Rewrites the relative class types `self`/`static` to `self_class` and `parent` to
     /// `parent_class`, recursing through nullable, union, array, and buffer members.
     ///
@@ -77,6 +91,54 @@ impl TypeExpr {
             )),
             TypeExpr::Buffer(inner) => TypeExpr::Buffer(Box::new(
                 inner.substitute_relative_class_types(self_class, parent_class),
+            )),
+            other => other.clone(),
+        }
+    }
+
+    /// Resolves relative class types in a method return while preserving late-bound `static`.
+    ///
+    /// `self` and `parent` are lexical declaration types and can be replaced immediately.
+    /// `static` must remain symbolic until a call site supplies the receiver type.
+    pub fn substitute_method_return_relative_types(
+        &self,
+        self_class: &str,
+        parent_class: Option<&str>,
+    ) -> TypeExpr {
+        match self {
+            TypeExpr::Named(name) if name.as_str().eq_ignore_ascii_case("static") => self.clone(),
+            TypeExpr::Named(name) if name.as_str().eq_ignore_ascii_case("self") => {
+                TypeExpr::Named(Name::unqualified(self_class))
+            }
+            TypeExpr::Named(name) if name.as_str().eq_ignore_ascii_case("parent") => {
+                parent_class
+                    .map(|parent| TypeExpr::Named(Name::unqualified(parent)))
+                    .unwrap_or_else(|| self.clone())
+            }
+            TypeExpr::Nullable(inner) => TypeExpr::Nullable(Box::new(
+                inner.substitute_method_return_relative_types(self_class, parent_class),
+            )),
+            TypeExpr::Union(members) => TypeExpr::Union(
+                members
+                    .iter()
+                    .map(|member| {
+                        member.substitute_method_return_relative_types(self_class, parent_class)
+                    })
+                    .collect(),
+            ),
+            TypeExpr::Intersection(members) => TypeExpr::Intersection(
+                members
+                    .iter()
+                    .map(|member| {
+                        member.substitute_method_return_relative_types(self_class, parent_class)
+                    })
+                    .collect(),
+            ),
+            TypeExpr::Array(inner) => TypeExpr::Array(Box::new(
+                inner.substitute_method_return_relative_types(self_class, parent_class),
+            )),
+            TypeExpr::Buffer(inner) => TypeExpr::Buffer(Box::new(
+                inner.substitute_method_return_relative_types(self_class, parent_class),
             )),
             other => other.clone(),
         }

--- a/src/types/checker/inference/objects/methods.rs
+++ b/src/types/checker/inference/objects/methods.rs
@@ -10,7 +10,7 @@
 
 use crate::errors::CompileError;
 use crate::names::php_symbol_key;
-use crate::parser::ast::{Expr, ExprKind, StaticReceiver};
+use crate::parser::ast::{Expr, ExprKind, StaticReceiver, TypeExpr};
 use crate::types::{FunctionSig, PhpType, TypeEnv};
 
 use super::super::super::Checker;
@@ -286,26 +286,15 @@ impl Checker {
             env,
             &format!("Method {}::{}", interface_name, method),
         )?;
-        // Immutable "wither" fluent methods (the PSR-FIG `with*` convention:
-        // MessageInterface::withHeader, RequestInterface::withMethod, …) are
-        // declared `: MessageInterface` but carry `@return static` — at runtime
-        // they return `clone $this`, i.e. the receiver's concrete type, not the
-        // ancestor interface the signature names. PHPStan honours the `@return
-        // static`, so PHPStan-clean code (`$serverRequest = $serverRequest
-        // ->withHeader(...)` then `->withQueryParams(...)`) relies on the type
-        // staying the receiver's. Resolve the return to the receiver interface
-        // when the declared return is a strict ancestor of it — otherwise the
-        // type widens to the ancestor and later child-only calls/params fail.
-        if method_key.starts_with("with") {
-            if let PhpType::Object(return_name) = &sig.return_type {
-                if return_name != interface_name
-                    && self.interface_extends_interface(interface_name, return_name)
-                {
-                    return Ok(PhpType::Object(interface_name.to_string()));
-                }
-            }
+        let late_static_return = self.instance_method_late_static_return(interface_name, &method_key);
+        match late_static_return {
+            Some(return_type) => self.resolve_late_static_return_type_hint(
+                &return_type,
+                interface_name,
+                expr.span,
+            ),
+            None => Ok(sig.return_type),
         }
-        Ok(sig.return_type)
     }
 
     /// Infers the type of a method call on a class type.
@@ -352,6 +341,12 @@ impl Checker {
         allow_by_ref_spread: bool,
     ) -> Result<PhpType, CompileError> {
         let method_key = php_symbol_key(method);
+        let late_static_return_type = self
+            .instance_method_late_static_return(class_name, &method_key)
+            .map(|return_type| {
+                self.resolve_late_static_return_type_hint(&return_type, class_name, expr.span)
+            })
+            .transpose()?;
         let mut normalized_args = args.to_vec();
         let mut magic_return_ty = None;
         let mut magic_original_args = None;
@@ -399,7 +394,9 @@ impl Checker {
                                 },
                             },
                         );
-                        return Ok(sig.return_type.clone());
+                        return Ok(late_static_return_type
+                            .clone()
+                            .unwrap_or_else(|| sig.return_type.clone()));
                     }
                 }
                 let declared_flags =
@@ -553,10 +550,29 @@ impl Checker {
                             wider_type_syntactic(existing_elem_ty.as_ref(), &elem_ty);
                     }
                 }
-                return Ok(sig.return_type.clone());
+                return Ok(late_static_return_type
+                    .clone()
+                    .unwrap_or_else(|| sig.return_type.clone()));
             }
         }
         Ok(PhpType::Int)
+    }
+
+    /// Returns preserved late-static return syntax for an instance method.
+    fn instance_method_late_static_return(
+        &self,
+        receiver_type: &str,
+        method_key: &str,
+    ) -> Option<TypeExpr> {
+        if let Some(class_info) = self.classes.get(receiver_type) {
+            if let Some(return_type) = class_info.late_static_method_returns.get(method_key) {
+                return Some(return_type.clone());
+            }
+        }
+        self.interfaces
+            .get(receiver_type)
+            .and_then(|interface_info| interface_info.late_static_method_returns.get(method_key))
+            .cloned()
     }
 
     /// Returns true for builtin method array params whose accepted shape must remain broad.
@@ -785,6 +801,36 @@ impl Checker {
                 .check_enum_static_call(&enum_info, class_name, method, args, env, expr.span);
         }
         let method_key = php_symbol_key(method);
+        let late_static_receiver_type = if parent_call {
+            self.current_class
+                .clone()
+                .unwrap_or_else(|| class_name.to_string())
+        } else {
+            class_name.to_string()
+        };
+        let late_static_static_return_type = self
+            .static_method_late_static_return(class_name, &method_key)
+            .map(|return_type| {
+                self.resolve_late_static_return_type_hint(
+                    &return_type,
+                    &late_static_receiver_type,
+                    expr.span,
+                )
+            })
+            .transpose()?;
+        let late_static_instance_return_type = if parent_call || self_call {
+            self.instance_method_late_static_return(class_name, &method_key)
+                .map(|return_type| {
+                    self.resolve_late_static_return_type_hint(
+                        &return_type,
+                        &late_static_receiver_type,
+                        expr.span,
+                    )
+                })
+                .transpose()?
+        } else {
+            None
+        };
         let normalized_args: Vec<Expr>;
         let mut magic_return_ty = None;
         let mut magic_original_args = None;
@@ -1069,7 +1115,9 @@ impl Checker {
                             wider_type_syntactic(existing_elem_ty.as_ref(), &elem_ty);
                     }
                 }
-                return Ok(sig.return_type.clone());
+                return Ok(late_static_static_return_type
+                    .clone()
+                    .unwrap_or_else(|| sig.return_type.clone()));
             }
         }
         if parent_call || self_call {
@@ -1126,10 +1174,28 @@ impl Checker {
                             wider_type_syntactic(existing_elem_ty.as_ref(), &elem_ty);
                     }
                 }
-                return Ok(sig.return_type.clone());
+                return Ok(late_static_instance_return_type
+                    .clone()
+                    .unwrap_or_else(|| sig.return_type.clone()));
             }
         }
         Ok(PhpType::Int)
+    }
+
+    /// Returns preserved late-static return syntax for a static method.
+    fn static_method_late_static_return(
+        &self,
+        receiver_type: &str,
+        method_key: &str,
+    ) -> Option<TypeExpr> {
+        self.classes
+            .get(receiver_type)
+            .and_then(|class_info| {
+                class_info
+                    .late_static_static_method_returns
+                    .get(method_key)
+            })
+            .cloned()
     }
 }
 

--- a/src/types/checker/inference/objects/methods.rs
+++ b/src/types/checker/inference/objects/methods.rs
@@ -286,6 +286,25 @@ impl Checker {
             env,
             &format!("Method {}::{}", interface_name, method),
         )?;
+        // Immutable "wither" fluent methods (the PSR-FIG `with*` convention:
+        // MessageInterface::withHeader, RequestInterface::withMethod, …) are
+        // declared `: MessageInterface` but carry `@return static` — at runtime
+        // they return `clone $this`, i.e. the receiver's concrete type, not the
+        // ancestor interface the signature names. PHPStan honours the `@return
+        // static`, so PHPStan-clean code (`$serverRequest = $serverRequest
+        // ->withHeader(...)` then `->withQueryParams(...)`) relies on the type
+        // staying the receiver's. Resolve the return to the receiver interface
+        // when the declared return is a strict ancestor of it — otherwise the
+        // type widens to the ancestor and later child-only calls/params fail.
+        if method_key.starts_with("with") {
+            if let PhpType::Object(return_name) = &sig.return_type {
+                if return_name != interface_name
+                    && self.interface_extends_interface(interface_name, return_name)
+                {
+                    return Ok(PhpType::Object(interface_name.to_string()));
+                }
+            }
+        }
         Ok(sig.return_type)
     }
 

--- a/src/types/checker/schema/classes/interfaces.rs
+++ b/src/types/checker/schema/classes/interfaces.rs
@@ -19,7 +19,8 @@ use crate::types::{PhpType, PropertyHookContract};
 
 use super::super::super::Checker;
 use super::super::validation::{
-    declared_return_type_compatible, validate_signature_compatibility,
+    declared_return_type_compatible, late_static_return_compatible,
+    validate_signature_compatibility,
 };
 use super::state::ClassBuildState;
 
@@ -234,6 +235,14 @@ fn validate_static_interface_method(
             state
                 .static_sigs
                 .insert(method_name.to_string(), required_sig.clone());
+            if let Some(return_type) = interface_info
+                .late_static_static_method_returns
+                .get(method_name)
+            {
+                state
+                    .late_static_static_method_returns
+                    .insert(method_name.to_string(), return_type.clone());
+            }
             state
                 .static_method_visibilities
                 .insert(method_name.to_string(), Visibility::Public);
@@ -298,20 +307,34 @@ fn validate_static_interface_method(
             )?;
         }
     }
-    if required_sig.declared_return
-        && !interface_self_return_conforms(
+    let late_static_compatible = late_static_return_compatible(
+        checker,
+        interface_info
+            .late_static_static_method_returns
+            .get(method_name),
+        state
+            .late_static_static_method_returns
+            .get(method_name),
+        &actual_sig.return_type,
+        &class.name,
+        actual_method
+            .map(|method| method.span)
+            .unwrap_or_else(crate::span::Span::dummy),
+    )?;
+    let return_compatible = late_static_compatible.unwrap_or_else(|| {
+        interface_self_return_conforms(
             checker,
             class,
             interface_name,
             &required_sig.return_type,
             &actual_sig.return_type,
-        )
-        && !declared_return_type_compatible(
+        ) || declared_return_type_compatible(
             checker,
             &required_sig.return_type,
             &actual_sig.return_type,
         )
-    {
+    });
+    if required_sig.declared_return && !return_compatible {
         return Err(CompileError::new(
             actual_method
                 .map(|m| m.span)
@@ -434,6 +457,11 @@ fn validate_interface_method(
             state
                 .method_sigs
                 .insert(method_name.to_string(), required_sig.clone());
+            if let Some(return_type) = interface_info.late_static_method_returns.get(method_name) {
+                state
+                    .late_static_method_returns
+                    .insert(method_name.to_string(), return_type.clone());
+            }
             state
                 .method_visibilities
                 .insert(method_name.to_string(), Visibility::Public);
@@ -496,20 +524,30 @@ fn validate_interface_method(
             )?;
         }
     }
-    if required_sig.declared_return
-        && !interface_self_return_conforms(
+    let late_static_compatible = late_static_return_compatible(
+        checker,
+        interface_info.late_static_method_returns.get(method_name),
+        state.late_static_method_returns.get(method_name),
+        &actual_sig.return_type,
+        &class.name,
+        actual_method
+            .map(|method| method.span)
+            .unwrap_or_else(crate::span::Span::dummy),
+    )?;
+    let return_compatible = late_static_compatible.unwrap_or_else(|| {
+        interface_self_return_conforms(
             checker,
             class,
             interface_name,
             &required_sig.return_type,
             &actual_sig.return_type,
-        )
-        && !declared_return_type_compatible(
+        ) || declared_return_type_compatible(
             checker,
             &required_sig.return_type,
             &actual_sig.return_type,
         )
-    {
+    });
+    if required_sig.declared_return && !return_compatible {
         return Err(CompileError::new(
             actual_method
                 .map(|m| m.span)

--- a/src/types/checker/schema/classes/methods.rs
+++ b/src/types/checker/schema/classes/methods.rs
@@ -97,7 +97,7 @@ fn apply_static_method(
     method: &ClassMethod,
 ) -> Result<(), CompileError> {
     let method_key = php_symbol_key(&method.name);
-    let sig = build_method_sig(checker, method)?;
+    let sig = build_method_sig(checker, method, &class.name)?;
     if state.final_methods.contains(&method_key) {
         return Err(final_method_error(
             state
@@ -133,7 +133,16 @@ fn apply_static_method(
         }
     }
     if let Some(parent_sig) = state.static_sigs.get(&method_key) {
-        validate_override_signature(checker, class, method, parent_sig, true)?;
+        validate_override_signature(
+            checker,
+            class,
+            method,
+            parent_sig,
+            state
+                .late_static_static_method_returns
+                .get(&method_key),
+            true,
+        )?;
     } else if has_override_attribute(method)
         && !interface_declares_method(checker, state, class, &method_key, true)
     {
@@ -149,6 +158,19 @@ fn apply_static_method(
         ));
     }
     state.static_sigs.insert(method_key.clone(), sig);
+    if let Some(return_type) = method
+        .return_type
+        .as_ref()
+        .filter(|return_type| return_type.contains_late_static())
+    {
+        state
+            .late_static_static_method_returns
+            .insert(method_key.clone(), return_type.clone());
+    } else {
+        state
+            .late_static_static_method_returns
+            .remove(&method_key);
+    }
     state
         .static_method_visibilities
         .insert(method_key.clone(), method.visibility.clone());
@@ -194,7 +216,7 @@ fn apply_instance_method(
     method: &ClassMethod,
 ) -> Result<(), CompileError> {
     let method_key = php_symbol_key(&method.name);
-    let sig = build_method_sig(checker, method)?;
+    let sig = build_method_sig(checker, method, &class.name)?;
     if state.final_static_methods.contains(&method_key) {
         return Err(final_method_error(
             state
@@ -230,7 +252,14 @@ fn apply_instance_method(
         }
     }
     if let Some(parent_sig) = state.method_sigs.get(&method_key) {
-        validate_override_signature(checker, class, method, parent_sig, false)?;
+        validate_override_signature(
+            checker,
+            class,
+            method,
+            parent_sig,
+            state.late_static_method_returns.get(&method_key),
+            false,
+        )?;
     } else if has_override_attribute(method)
         && !interface_declares_method(checker, state, class, &method_key, false)
     {
@@ -246,6 +275,17 @@ fn apply_instance_method(
         ));
     }
     state.method_sigs.insert(method_key.clone(), sig);
+    if let Some(return_type) = method
+        .return_type
+        .as_ref()
+        .filter(|return_type| return_type.contains_late_static())
+    {
+        state
+            .late_static_method_returns
+            .insert(method_key.clone(), return_type.clone());
+    } else {
+        state.late_static_method_returns.remove(&method_key);
+    }
     state
         .method_visibilities
         .insert(method_key.clone(), method.visibility.clone());

--- a/src/types/checker/schema/classes/state.rs
+++ b/src/types/checker/schema/classes/state.rs
@@ -50,6 +50,8 @@ pub(super) struct ClassBuildState {
     pub(super) final_static_properties: HashSet<String>,
     pub(super) method_sigs: HashMap<String, FunctionSig>,
     pub(super) static_sigs: HashMap<String, FunctionSig>,
+    pub(super) late_static_method_returns: HashMap<String, crate::parser::ast::TypeExpr>,
+    pub(super) late_static_static_method_returns: HashMap<String, crate::parser::ast::TypeExpr>,
     pub(super) method_visibilities: HashMap<String, Visibility>,
     pub(super) final_methods: HashSet<String>,
     pub(super) method_declaring_classes: HashMap<String, String>,
@@ -198,6 +200,8 @@ impl ClassBuildState {
             method_decls: class.methods.clone(),
             methods: self.method_sigs,
             static_methods: self.static_sigs,
+            late_static_method_returns: self.late_static_method_returns,
+            late_static_static_method_returns: self.late_static_static_method_returns,
             callable_method_return_sigs: HashMap::new(),
             callable_array_method_return_sigs: HashMap::new(),
             method_visibilities: self.method_visibilities,
@@ -497,6 +501,10 @@ impl ClassBuildState {
                 continue;
             }
             self.method_sigs.insert(name.clone(), sig.clone());
+            if let Some(return_type) = parent.late_static_method_returns.get(name) {
+                self.late_static_method_returns
+                    .insert(name.clone(), return_type.clone());
+            }
             if let Some(visibility) = parent.method_visibilities.get(name) {
                 self.method_visibilities
                     .insert(name.clone(), visibility.clone());
@@ -534,6 +542,10 @@ impl ClassBuildState {
                 continue;
             }
             self.static_sigs.insert(name.clone(), sig.clone());
+            if let Some(return_type) = parent.late_static_static_method_returns.get(name) {
+                self.late_static_static_method_returns
+                    .insert(name.clone(), return_type.clone());
+            }
             if let Some(visibility) = parent.static_method_visibilities.get(name) {
                 self.static_method_visibilities
                     .insert(name.clone(), visibility.clone());

--- a/src/types/checker/schema/enums.rs
+++ b/src/types/checker/schema/enums.rs
@@ -314,6 +314,7 @@ pub(crate) fn insert_enum_metadata(
     );
 
     let mut static_methods = HashMap::new();
+    let mut late_static_static_method_returns = HashMap::new();
     let mut static_method_visibilities = HashMap::new();
     let mut static_method_declaring_classes = HashMap::new();
     let mut static_method_impl_classes = HashMap::new();
@@ -372,8 +373,9 @@ pub(crate) fn insert_enum_metadata(
     checker.declared_classes.insert(name.to_string());
 
     // User-declared enum methods. Enum cases are singleton objects, so instance methods dispatch
-    // on the case like a class. `self`/`static` hints resolve to the enum.
+    // on the case like a class. Lexical hints resolve to the enum while return `static` is retained.
     let mut methods = HashMap::new();
+    let mut late_static_method_returns = HashMap::new();
     let mut method_decls = Vec::new();
     let mut method_visibilities = HashMap::new();
     let mut method_declaring_classes = HashMap::new();
@@ -384,15 +386,26 @@ pub(crate) fn insert_enum_metadata(
         let mut method = method.clone();
         method.substitute_relative_class_types(name, None);
 
-        let sig = build_method_sig(checker, &method)?;
+        let sig = build_method_sig(checker, &method, name)?;
         let key = php_symbol_key(&method.name);
+        let late_static_return = method
+            .return_type
+            .as_ref()
+            .filter(|return_type| return_type.contains_late_static())
+            .cloned();
         if method.is_static {
             static_methods.insert(key.clone(), sig);
+            if let Some(return_type) = late_static_return {
+                late_static_static_method_returns.insert(key.clone(), return_type);
+            }
             static_method_visibilities.insert(key.clone(), method.visibility.clone());
             static_method_declaring_classes.insert(key.clone(), name.to_string());
             static_method_impl_classes.insert(key, name.to_string());
         } else {
             methods.insert(key.clone(), sig);
+            if let Some(return_type) = late_static_return {
+                late_static_method_returns.insert(key.clone(), return_type);
+            }
             method_visibilities.insert(key.clone(), method.visibility.clone());
             method_declaring_classes.insert(key.clone(), name.to_string());
             method_impl_classes.insert(key, name.to_string());
@@ -489,6 +502,8 @@ pub(crate) fn insert_enum_metadata(
             method_decls,
             methods,
             static_methods,
+            late_static_method_returns,
+            late_static_static_method_returns,
             callable_method_return_sigs: HashMap::new(),
             callable_array_method_return_sigs: HashMap::new(),
             method_visibilities,

--- a/src/types/checker/schema/interfaces.rs
+++ b/src/types/checker/schema/interfaces.rs
@@ -17,7 +17,9 @@ use crate::types::{InterfaceInfo, PhpType, PropertyHookContract};
 
 use super::super::Checker;
 use super::super::InterfaceDeclInfo;
-use super::validation::{build_method_sig, validate_signature_compatibility};
+use super::validation::{
+    build_method_sig, late_static_return_compatible, validate_signature_compatibility,
+};
 use crate::types::traits::FlattenedClass;
 
 /// Recursively builds interface metadata by flattening inheritance and collecting methods,
@@ -66,10 +68,12 @@ pub(crate) fn build_interface_info_recursive(
     })?;
 
     let mut methods = HashMap::new();
+    let mut late_static_method_returns = HashMap::new();
     let mut method_declaring_interfaces = HashMap::new();
     let mut method_order = Vec::new();
     let mut method_slots = HashMap::new();
     let mut static_methods = HashMap::new();
+    let mut late_static_static_method_returns = HashMap::new();
     let mut static_method_declaring_interfaces = HashMap::new();
     let mut static_method_order = Vec::new();
     let mut properties = HashMap::new();
@@ -125,9 +129,22 @@ pub(crate) fn build_interface_info_recursive(
                     "method",
                     "combining interface parent",
                 )?;
+                if let Some(return_type) = parent_info.late_static_method_returns.get(method_name) {
+                    methods.insert(method_name.clone(), parent_sig.clone());
+                    late_static_method_returns.insert(method_name.clone(), return_type.clone());
+                    let declaring = parent_info
+                        .method_declaring_interfaces
+                        .get(method_name)
+                        .cloned()
+                        .unwrap_or_else(|| parent_name.clone());
+                    method_declaring_interfaces.insert(method_name.clone(), declaring);
+                }
                 continue;
             }
             methods.insert(method_name.clone(), parent_sig.clone());
+            if let Some(return_type) = parent_info.late_static_method_returns.get(method_name) {
+                late_static_method_returns.insert(method_name.clone(), return_type.clone());
+            }
             let declaring = parent_info
                 .method_declaring_interfaces
                 .get(method_name)
@@ -160,9 +177,30 @@ pub(crate) fn build_interface_info_recursive(
                     "static method",
                     "combining interface parent",
                 )?;
+                if let Some(return_type) = parent_info
+                    .late_static_static_method_returns
+                    .get(method_name)
+                {
+                    static_methods.insert(method_name.clone(), parent_sig.clone());
+                    late_static_static_method_returns
+                        .insert(method_name.clone(), return_type.clone());
+                    let declaring = parent_info
+                        .static_method_declaring_interfaces
+                        .get(method_name)
+                        .cloned()
+                        .unwrap_or_else(|| parent_name.clone());
+                    static_method_declaring_interfaces.insert(method_name.clone(), declaring);
+                }
                 continue;
             }
             static_methods.insert(method_name.clone(), parent_sig.clone());
+            if let Some(return_type) = parent_info
+                .late_static_static_method_returns
+                .get(method_name)
+            {
+                late_static_static_method_returns
+                    .insert(method_name.clone(), return_type.clone());
+            }
             let declaring = parent_info
                 .static_method_declaring_interfaces
                 .get(method_name)
@@ -262,7 +300,7 @@ pub(crate) fn build_interface_info_recursive(
             ));
         }
 
-        let sig = build_method_sig(checker, method)?;
+        let sig = build_method_sig(checker, method, &interface.name)?;
         if method.is_static {
             if methods.contains_key(&method_key) {
                 return Err(interface_method_kind_conflict(
@@ -281,8 +319,35 @@ pub(crate) fn build_interface_info_recursive(
                     "static method",
                     "redeclaring interface",
                 )?;
+                if late_static_return_compatible(
+                    checker,
+                    late_static_static_method_returns.get(&method_key),
+                    method.return_type.as_ref(),
+                    &sig.return_type,
+                    &interface.name,
+                    method.span,
+                )? == Some(false)
+                {
+                    return Err(CompileError::new(
+                        method.span,
+                        &format!(
+                            "Cannot redeclare interface static method {}::{} without a compatible late-static return type",
+                            interface.name, method.name
+                        ),
+                    ));
+                }
             }
             static_methods.insert(method_key.clone(), sig);
+            if let Some(return_type) = method
+                .return_type
+                .as_ref()
+                .filter(|return_type| return_type.contains_late_static())
+            {
+                late_static_static_method_returns
+                    .insert(method_key.clone(), return_type.clone());
+            } else {
+                late_static_static_method_returns.remove(&method_key);
+            }
             static_method_declaring_interfaces
                 .insert(method_key.clone(), interface.name.clone());
             if !static_method_order.contains(&method_key) {
@@ -307,8 +372,34 @@ pub(crate) fn build_interface_info_recursive(
                 "method",
                 "redeclaring interface",
             )?;
+            if late_static_return_compatible(
+                checker,
+                late_static_method_returns.get(&method_key),
+                method.return_type.as_ref(),
+                &sig.return_type,
+                &interface.name,
+                method.span,
+            )? == Some(false)
+            {
+                return Err(CompileError::new(
+                    method.span,
+                    &format!(
+                        "Cannot redeclare interface method {}::{} without a compatible late-static return type",
+                        interface.name, method.name
+                    ),
+                ));
+            }
         }
         methods.insert(method_key.clone(), sig);
+        if let Some(return_type) = method
+            .return_type
+            .as_ref()
+            .filter(|return_type| return_type.contains_late_static())
+        {
+            late_static_method_returns.insert(method_key.clone(), return_type.clone());
+        } else {
+            late_static_method_returns.remove(&method_key);
+        }
         method_declaring_interfaces.insert(method_key.clone(), interface.name.clone());
         if !method_slots.contains_key(&method_key) {
             let slot = method_order.len();
@@ -380,10 +471,12 @@ pub(crate) fn build_interface_info_recursive(
             property_order,
             method_decls: interface.methods.clone(),
             methods,
+            late_static_method_returns,
             method_declaring_interfaces,
             method_order,
             method_slots,
             static_methods,
+            late_static_static_method_returns,
             static_method_declaring_interfaces,
             static_method_order,
             constants: iface_constants,

--- a/src/types/checker/schema/validation.rs
+++ b/src/types/checker/schema/validation.rs
@@ -10,7 +10,7 @@
 
 use crate::errors::CompileError;
 use crate::names::php_symbol_key;
-use crate::parser::ast::{Attribute, ClassMethod, Expr, ExprKind, StmtKind, Visibility};
+use crate::parser::ast::{Attribute, ClassMethod, Expr, ExprKind, StmtKind, TypeExpr, Visibility};
 use crate::types::{FunctionSig, PhpType};
 
 use super::super::Checker;
@@ -22,6 +22,7 @@ use super::super::Checker;
 pub(crate) fn build_method_sig(
     checker: &Checker,
     method: &ClassMethod,
+    declaring_type: &str,
 ) -> Result<FunctionSig, CompileError> {
     let method_key = php_symbol_key(&method.name);
     let params: Vec<(String, PhpType)> = method
@@ -71,8 +72,9 @@ pub(crate) fn build_method_sig(
         }
     }
     let return_type = match method.return_type.as_ref() {
-        Some(type_ann) => checker.resolve_declared_return_type_hint(
+        Some(type_ann) => checker.resolve_method_return_type_hint(
             type_ann,
+            declaring_type,
             method.span,
             &format!("Method '{}'", method.name),
         )?,
@@ -305,6 +307,36 @@ pub(crate) fn declared_return_type_compatible(
     matches!(actual, PhpType::Never) || checker.type_accepts(expected, actual)
 }
 
+/// Checks a preserved late-static parent/interface return against a child declaration.
+///
+/// A concrete class name cannot replace `static`: that would become unsound for further
+/// subclasses. `never` remains a valid covariant narrowing, while compound returns are
+/// compared after binding only their `static` members to the current receiver.
+pub(crate) fn late_static_return_compatible(
+    checker: &Checker,
+    expected: Option<&TypeExpr>,
+    actual: Option<&TypeExpr>,
+    actual_resolved: &PhpType,
+    receiver_type: &str,
+    span: crate::span::Span,
+) -> Result<Option<bool>, CompileError> {
+    let Some(expected) = expected else {
+        return Ok(None);
+    };
+    if matches!(actual_resolved, PhpType::Never) {
+        return Ok(Some(true));
+    }
+    let Some(actual) = actual.filter(|return_type| return_type.contains_late_static()) else {
+        return Ok(Some(false));
+    };
+    let expected =
+        checker.resolve_late_static_return_type_hint(expected, receiver_type, span)?;
+    let actual = checker.resolve_late_static_return_type_hint(actual, receiver_type, span)?;
+    Ok(Some(declared_return_type_compatible(
+        checker, &expected, &actual,
+    )))
+}
+
 /// Validates that `method` can override `parent_sig` in class `class_name`.
 /// Builds the child signature via `build_method_sig`, skips validation for `__construct`,
 /// checks signature compatibility, and ensures the child does not remove a declared
@@ -314,11 +346,12 @@ pub(crate) fn validate_override_signature(
     class: &crate::types::traits::FlattenedClass,
     method: &ClassMethod,
     parent_sig: &FunctionSig,
+    parent_late_static_return: Option<&TypeExpr>,
     is_static: bool,
 ) -> Result<(), CompileError> {
     let kind = if is_static { "static method" } else { "method" };
     let class_name = class.name.as_str();
-    let child_sig = build_method_sig(checker, method)?;
+    let child_sig = build_method_sig(checker, method, class_name)?;
     if php_symbol_key(&method.name) == "__construct" {
         return Ok(());
     }
@@ -340,13 +373,20 @@ pub(crate) fn validate_override_signature(
             ),
         ));
     }
-    if parent_sig.declared_return
-        && !declared_return_type_compatible(
+    let late_static_compatible = late_static_return_compatible(
+        checker,
+        parent_late_static_return,
+        method.return_type.as_ref(),
+        &child_sig.return_type,
+        class_name,
+        method.span,
+    )?;
+    let return_compatible = late_static_compatible.unwrap_or_else(|| {
+        declared_return_type_compatible(
             checker,
             &parent_sig.return_type,
             &child_sig.return_type,
-        )
-        && !covariant_self_return_compatible(
+        ) || covariant_self_return_compatible(
             checker,
             class_name,
             class.extends.as_deref(),
@@ -354,7 +394,8 @@ pub(crate) fn validate_override_signature(
             parent_sig,
             &child_sig,
         )
-    {
+    });
+    if parent_sig.declared_return && !return_compatible {
         return Err(CompileError::new(
             method.span,
             &format!(

--- a/src/types/checker/type_compat/declarations.rs
+++ b/src/types/checker/type_compat/declarations.rs
@@ -60,7 +60,48 @@ impl Checker {
                 "never can only be used as a standalone return type",
             ));
         }
+        if type_expr.contains_late_static() {
+            if let Some(current_class) = self.current_class.as_deref() {
+                let parent = self
+                    .classes
+                    .get(current_class)
+                    .and_then(|class_info| class_info.parent.as_deref());
+                let resolved =
+                    type_expr.substitute_relative_class_types(current_class, parent);
+                return self.resolve_type_expr(&resolved, span);
+            }
+        }
         self.resolve_type_expr(type_expr, span)
+    }
+
+    /// Resolves a method return contract to its declaring type for schema and ABI metadata.
+    ///
+    /// The parsed `static` marker remains on the method declaration for call-site refinement;
+    /// this nominal type is the concrete declaring class or interface used for compatibility.
+    pub(crate) fn resolve_method_return_type_hint(
+        &self,
+        type_expr: &TypeExpr,
+        declaring_type: &str,
+        span: crate::span::Span,
+        context: &str,
+    ) -> Result<PhpType, CompileError> {
+        let nominal = type_expr.substitute_relative_class_types(declaring_type, None);
+        self.resolve_declared_return_type_hint(&nominal, span, context)
+    }
+
+    /// Resolves preserved late-static return syntax against a concrete call-site receiver.
+    pub(crate) fn resolve_late_static_return_type_hint(
+        &self,
+        type_expr: &TypeExpr,
+        receiver_type: &str,
+        span: crate::span::Span,
+    ) -> Result<PhpType, CompileError> {
+        let parent = self
+            .classes
+            .get(receiver_type)
+            .and_then(|class_info| class_info.parent.as_deref());
+        let bound = type_expr.substitute_relative_class_types(receiver_type, parent);
+        self.resolve_declared_return_type_hint(&bound, span, "Late-static method return")
     }
 
     /// Resolves a local variable type hint from a `TypeExpr` to a `PhpType`, rejecting

--- a/src/types/checker/type_compat/unions.rs
+++ b/src/types/checker/type_compat/unions.rs
@@ -95,6 +95,11 @@ impl Checker {
                     self.type_accepts(expected_key.as_ref(), actual_key.as_ref())
                         && self.type_accepts(expected_value.as_ref(), actual_value.as_ref())
                 }
+                // A packed `Array(T)` is an int-keyed list, so it assigns into an
+                // `AssocArray` whose key is `Int` (or `Mixed`) and whose value the
+                // element satisfies — e.g. a list literal `[...]` (Array(Mixed))
+                // passed to an `array<int, mixed>` param (SubmissionContext::withBound).
+                // The two share the same run representation; no element re-typing.
                 PhpType::Array(actual_elem)
                     if matches!(expected_key.as_ref(), PhpType::Mixed | PhpType::Int)
                         && self.type_accepts(expected_value.as_ref(), actual_elem.as_ref()) =>

--- a/src/types/checker/type_compat/unions.rs
+++ b/src/types/checker/type_compat/unions.rs
@@ -95,11 +95,6 @@ impl Checker {
                     self.type_accepts(expected_key.as_ref(), actual_key.as_ref())
                         && self.type_accepts(expected_value.as_ref(), actual_value.as_ref())
                 }
-                // A packed `Array(T)` is an int-keyed list, so it assigns into an
-                // `AssocArray` whose key is `Int` (or `Mixed`) and whose value the
-                // element satisfies — e.g. a list literal `[...]` (Array(Mixed))
-                // passed to an `array<int, mixed>` param (SubmissionContext::withBound).
-                // The two share the same run representation; no element re-typing.
                 PhpType::Array(actual_elem)
                     if matches!(expected_key.as_ref(), PhpType::Mixed | PhpType::Int)
                         && self.type_accepts(expected_value.as_ref(), actual_elem.as_ref()) =>

--- a/src/types/schema.rs
+++ b/src/types/schema.rs
@@ -223,6 +223,8 @@ pub struct InterfaceInfo {
     /// These entries are the only methods that participate in interface
     /// dispatch tables and `method_slots`.
     pub methods: HashMap<String, FunctionSig>,
+    /// Exact return syntax for instance methods containing PHP's late-bound `static` type.
+    pub late_static_method_returns: HashMap<String, TypeExpr>,
     pub method_declaring_interfaces: HashMap<String, String>,
     pub method_order: Vec<String>,
     pub method_slots: HashMap<String, usize>,
@@ -231,6 +233,8 @@ pub struct InterfaceInfo {
     /// PHP requires implementors to provide matching public static methods, but
     /// these entries never participate in instance interface dispatch tables.
     pub static_methods: HashMap<String, FunctionSig>,
+    /// Exact return syntax for static methods containing PHP's late-bound `static` type.
+    pub late_static_static_method_returns: HashMap<String, TypeExpr>,
     pub static_method_declaring_interfaces: HashMap<String, String>,
     pub static_method_order: Vec<String>,
     /// Interface constants (PHP 5.0+). Inherited from parent interfaces.
@@ -344,6 +348,10 @@ pub struct ClassInfo {
     pub method_decls: Vec<ClassMethod>,
     pub methods: HashMap<String, FunctionSig>,
     pub static_methods: HashMap<String, FunctionSig>,
+    /// Exact return syntax for instance methods containing PHP's late-bound `static` type.
+    pub late_static_method_returns: HashMap<String, TypeExpr>,
+    /// Exact return syntax for static methods containing PHP's late-bound `static` type.
+    pub late_static_static_method_returns: HashMap<String, TypeExpr>,
     /// Callable signatures returned by instance/static methods, keyed by PHP's
     /// case-insensitive method key. The method body pass fills this after schemas exist.
     pub callable_method_return_sigs: HashMap<String, FunctionSig>,

--- a/tests/codegen/oop/interfaces.rs
+++ b/tests/codegen/oop/interfaces.rs
@@ -389,3 +389,48 @@ fn test_class_covariant_self_return_override() {
     );
     assert_eq!(out, "ok");
 }
+
+/// Verifies an inherited interface method returning `static` stays typed as the child interface.
+#[test]
+fn test_interface_late_static_return_stays_receiver() {
+    let out = compile_and_run(
+        r#"<?php
+interface Message {
+    public function withHeader(string $value): static;
+}
+interface Request extends Message {
+    public function withMethod(string $method): static;
+    public function method(): string;
+}
+final class Req implements Request {
+    public function __construct(private string $method = 'GET') {}
+    public function withHeader(string $value): static { return new static($this->method); }
+    public function withMethod(string $method): static { return new static($method); }
+    public function method(): string { return $this->method; }
+}
+function chain(Request $request): string {
+    return $request->withHeader('x-trace')->withMethod('POST')->method();
+}
+echo chain(new Req());
+"#,
+    );
+    assert_eq!(out, "POST");
+}
+
+/// Verifies an implementation may covariantly narrow `static|false` to `static`.
+#[test]
+fn test_interface_late_static_union_can_narrow_to_static() {
+    let out = compile_and_run(
+        r#"<?php
+interface MaybeCopyable {
+    public function copy(): static|false;
+}
+final class AlwaysCopyable implements MaybeCopyable {
+    public function copy(): static { return $this; }
+    public function label(): string { return "copy"; }
+}
+echo (new AlwaysCopyable())->copy()->label();
+"#,
+    );
+    assert_eq!(out, "copy");
+}

--- a/tests/codegen/oop/relative_types.rs
+++ b/tests/codegen/oop/relative_types.rs
@@ -6,7 +6,7 @@
 //! - `cargo test` through Rust's test harness.
 //!
 //! Key details:
-//! - `self`/`static` resolve to the enclosing (declaring) class and `parent` to its parent.
+//! - `self` resolves lexically while method return `static` binds to the call-site receiver.
 //! - Trait methods resolve `self`/`static` to the using class, exercised by `test_static_in_trait`.
 
 use super::*;
@@ -84,6 +84,108 @@ fn test_static_return_type() {
         ",
     );
     assert_eq!(out, "made");
+}
+
+/// Verifies an inherited static factory returning `static` exposes subclass-only methods.
+#[test]
+fn test_inherited_static_factory_return_binds_to_called_class() {
+    let out = compile_and_run(
+        r#"<?php
+class Factory {
+    public static function make(): static { return new static(); }
+}
+final class ProductFactory extends Factory {
+    public function label(): string { return "product"; }
+}
+echo ProductFactory::make()->label();
+echo ":";
+echo (new ReflectionMethod(Factory::class, "make"))->getReturnType()->getName();
+"#,
+    );
+    assert_eq!(out, "product:static");
+}
+
+/// Verifies an inherited non-`with*` method returning `static` exposes subclass-only methods.
+#[test]
+fn test_inherited_static_return_type_binds_to_subclass_receiver() {
+    let out = compile_and_run(
+        r#"<?php
+class Builder {
+    public function andWhere(string $condition): static { return $this; }
+}
+final class QueryBuilder extends Builder {
+    public function getSQL(): string { return "SELECT"; }
+}
+echo (new QueryBuilder())->andWhere('active = 1')->getSQL();
+"#,
+    );
+    assert_eq!(out, "SELECT");
+}
+
+/// Verifies nullable late-static returns retain null while binding the object branch.
+#[test]
+fn test_nullable_static_return_binds_object_branch_to_receiver() {
+    let out = compile_and_run(
+        r#"<?php
+class MaybeBuilder {
+    public function maybe(bool $present): ?static {
+        return $present ? $this : null;
+    }
+}
+final class ConcreteBuilder extends MaybeBuilder {
+    public function build(): string { return "built"; }
+}
+$builder = new ConcreteBuilder();
+echo $builder->maybe(true)?->build();
+echo $builder->maybe(false)?->build() ?? "none";
+"#,
+    );
+    assert_eq!(out, "builtnone");
+}
+
+/// Verifies a compound late-static return keeps its explicit member in typing, ABI boxing,
+/// and Reflection metadata.
+#[test]
+fn test_late_static_union_preserves_explicit_member() {
+    let out = compile_and_run(
+        r#"<?php
+class Choice {
+    public function choose(bool $same): static|Choice {
+        return $same ? $this : new Choice();
+    }
+    public function label(): string { return "choice"; }
+}
+final class SpecialChoice extends Choice {}
+$value = (new SpecialChoice())->choose(false);
+echo $value->label() . ":";
+$type = (new ReflectionMethod(Choice::class, "choose"))->getReturnType();
+if ($type instanceof ReflectionUnionType) {
+    echo count($type->getTypes());
+    foreach ($type->getTypes() as $member) {
+        echo ":" . $member->getName();
+    }
+}
+"#,
+    );
+    assert_eq!(out, "choice:2:Choice:static");
+}
+
+/// Verifies a child override may covariantly narrow `static|false` to `static`.
+#[test]
+fn test_late_static_union_override_can_narrow_to_static() {
+    let out = compile_and_run(
+        r#"<?php
+class MaybeCloneable {
+    public function duplicate(): static|false { return false; }
+}
+final class AlwaysCloneable extends MaybeCloneable {
+    public function duplicate(): static { return $this; }
+    public function label(): string { return "clone"; }
+}
+echo (new AlwaysCloneable())->duplicate()->label();
+"#,
+    );
+    assert_eq!(out, "clone");
 }
 
 /// Verifies that a `parent` return type resolves to the parent class and exposes its methods.
@@ -174,9 +276,9 @@ fn test_static_in_trait() {
 }
 
 /// Compiles and runs the checked-in `examples/relative-class-types/main.php` fixture, which
-/// exercises `self` returns/params, a `static` factory, and a nullable `?self` property.
+/// exercises `self`, a late-bound inherited `static` return, and a nullable `?self` property.
 #[test]
 fn test_example_relative_class_types_compiles_and_runs() {
     let out = compile_and_run(include_str!("../../../examples/relative-class-types/main.php"));
-    assert_eq!(out, "599\n3\n6\ntail\n");
+    assert_eq!(out, "599\n3\n6\ntail\nSELECT * WHERE active = 1\n");
 }

--- a/tests/error_tests/type_system.rs
+++ b/tests/error_tests/type_system.rs
@@ -163,6 +163,102 @@ fn test_error_arithmetic_on_string() {
     );
 }
 
+/// Verifies a name beginning with `with` does not imply a late-static fluent return.
+#[test]
+fn test_error_with_prefix_does_not_refine_declared_ancestor_return() {
+    expect_error(
+        r#"<?php
+interface Account {
+    public function withdraw(int $amount): Account;
+}
+interface Savings extends Account {
+    public function interestRate(): int;
+}
+final class SavingsAccount implements Savings {
+    public function withdraw(int $amount): Account { return $this; }
+    public function interestRate(): int { return 4; }
+}
+function rate(Savings $account): int {
+    return $account->withdraw(10)->interestRate();
+}
+echo rate(new SavingsAccount());
+"#,
+        "Undefined method: Account::interestRate",
+    );
+}
+
+/// Verifies that binding `static` preserves distinct explicit union members.
+///
+/// `static|Choice` called on `SpecialChoice` becomes `SpecialChoice|Choice`, so a
+/// subclass-only method is not safe on the result even though one branch is late-bound.
+#[test]
+fn test_error_late_static_union_keeps_explicit_ancestor_member() {
+    expect_error(
+        r#"<?php
+class Choice {
+    public function choose(bool $same): static|Choice {
+        return $same ? $this : new Choice();
+    }
+}
+class SpecialChoice extends Choice {
+    public function special(): string { return "special"; }
+}
+function render(SpecialChoice $choice): string {
+    return $choice->choose(false)->special();
+}
+"#,
+        "Undefined method",
+    );
+}
+
+/// Verifies an interface `static` contract cannot be implemented as the concrete class name.
+#[test]
+fn test_error_interface_static_return_requires_late_static_implementation() {
+    expect_error(
+        r#"<?php
+interface CreatesLateBound {
+    public function create(): static;
+}
+class ConcreteCreator implements CreatesLateBound {
+    public function create(): ConcreteCreator { return $this; }
+}
+"#,
+        "incompatible return type",
+    );
+}
+
+/// Verifies overriding `static` with the immediate child name is rejected for future subclasses.
+#[test]
+fn test_error_static_return_override_cannot_become_concrete_child() {
+    expect_error(
+        r#"<?php
+class LateBoundBase {
+    public function copy(): static { return $this; }
+}
+class ConcreteCopy extends LateBoundBase {
+    public function copy(): ConcreteCopy { return $this; }
+}
+"#,
+        "incompatible return type",
+    );
+}
+
+/// Verifies a child interface must preserve its parent's late-static return contract.
+#[test]
+fn test_error_interface_redeclaration_cannot_replace_static_with_child_name() {
+    expect_error(
+        r#"<?php
+interface LateBoundContract {
+    public function copy(): static;
+}
+interface ConcreteContract extends LateBoundContract {
+    public function copy(): ConcreteContract;
+}
+"#,
+        "compatible late-static return type",
+    );
+}
+
 /// Verifies that negating a non-numeric string produces an error.
 /// Input: `$x = "hi"; echo -$x;`
 #[test]


### PR DESCRIPTION
Supersedes #518 and carries forward its PSR-style fluent-call reproducer and contributor credit.

## Summary

- Preserve native method return `static` as a late-bound type instead of erasing it to the declaring class or interface.
- Bind late-static returns to the call-site receiver in both checker inference and EIR lowering.
- Apply the same semantics to inherited instance methods, static factories, class hierarchies, interfaces, nullable returns, and compound unions.
- Enforce PHP-compatible override and interface conformance: a required `static` return cannot be replaced by the current concrete class, while covariant narrowing such as `static|false` to `static` remains valid.
- Preserve reflection-visible `static` return metadata, including PHP-compatible union ordering.
- Document the native `: static` requirement and add a fluent class example.

## Root cause

#518 addressed a real failure in PSR-style chains such as `withHeader()->withMethod()`, but refined any interface method whose lowercase name started with `with`. That naming heuristic also matched unrelated methods such as `withdraw()`, produced false positives, excluded non-`with*` fluent methods, and only covered interface receivers.

The underlying problem was that relative-type substitution rewrote both `self` and `static` to the declaring type before schema construction. The checker and EIR therefore had no way to distinguish a lexical `self` return from a late-bound `static` return at the call site.

This replacement keeps the exact return syntax containing `static` in class/interface metadata while retaining a nominal declaring-type signature for ABI and compatibility work. Only the symbolic `static` members are rebound when a concrete receiver is known.

#473 remains complementary: it added sound covariant self-return validation, while this PR preserves and consumes native late-static return contracts end to end.

## Scope

PHPDoc is not parsed for typing. APIs that need late-static refinement must use the native PHP return declaration `: static`; `@return static` alone has no typing effect.

The unrelated indexed-array/associative-array compatibility change from #518 is not part of this diff; the current `main` behavior is retained unchanged.

## Validation

- `cargo check --tests`
- `cargo test --test codegen_tests codegen::oop::relative_types::` — 15 passed
- `cargo test --test codegen_tests codegen::oop::interfaces::` — 18 passed
- Focused negative regressions for `withdraw()`, compound unions, invalid class overrides, invalid interface implementations, and invalid interface redeclarations
- `ELEPHC_PHP_CHECK=1` cross-checks for PSR-style interfaces, nullable `static`, compound unions, Reflection metadata, and covariant union narrowing
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check_asm_comments.py src/codegen/lower_inst/objects/reflection.rs`