### PR TITLE
feat/persistent progress timings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to elephc, a PHP-to-native compiler written in Rust.
 Releases are listed newest first.
 
 ## [Unreleased]
-- Improved interactive compilation progress: each completed phase now remains visible with an action-oriented label, checkmark, and elapsed time while the next phase starts on a new line; `--quiet` and non-interactive output remain unchanged.
+- Improved compilation diagnostics: each completed interactive phase now remains visible with an action-oriented label, checkmark, and elapsed time while the next phase starts on a new line; `--timings` renders a bordered table with aligned friendly labels, adaptive durations, percentage shares, and a total row, using ASCII borders for non-interactive output.
 - Fixed the supported-target test matrix for managed-PCRE2 programs so eval, dynamic `instanceof`, and regex regressions are validated hermetically without relying on the removed system-library fallback.
 - Fixed managed native dependency downloads leaving temporary files behind when another process won the cache-publication race; successful fallback now cleans up the losing download.
 - Added curated native dependency management through `elephc native`: projects can declare and deterministically lock PCRE2 10.47 and zlib 1.3.2, build verified target/toolchain-specific static artifacts, reinstall them with `--locked --offline`, and link regex programs through an opaque shim without a production system-PCRE2 fallback. Uniform project/recovery diagnostics cover missing, stale, corrupt, offline, and toolchain states; `native doctor` reports cache growth and abandoned staging, while explicit locked `native prune` removes obsolete fingerprints/staging without making `remove` mutate the shared cache.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to elephc, a PHP-to-native compiler written in Rust.
 Releases are listed newest first.
 
 ## [Unreleased]
-- Improved interactive compilation progress: each completed phase now remains visible with a checkmark and its elapsed time while the next phase starts on a new line; `--quiet` and non-interactive output remain unchanged.
+- Improved interactive compilation progress: each completed phase now remains visible with an action-oriented label, checkmark, and elapsed time while the next phase starts on a new line; `--quiet` and non-interactive output remain unchanged.
 - Fixed the supported-target test matrix for managed-PCRE2 programs so eval, dynamic `instanceof`, and regex regressions are validated hermetically without relying on the removed system-library fallback.
 - Fixed managed native dependency downloads leaving temporary files behind when another process won the cache-publication race; successful fallback now cleans up the losing download.
 - Added curated native dependency management through `elephc native`: projects can declare and deterministically lock PCRE2 10.47 and zlib 1.3.2, build verified target/toolchain-specific static artifacts, reinstall them with `--locked --offline`, and link regex programs through an opaque shim without a production system-PCRE2 fallback. Uniform project/recovery diagnostics cover missing, stale, corrupt, offline, and toolchain states; `native doctor` reports cache growth and abandoned staging, while explicit locked `native prune` removes obsolete fingerprints/staging without making `remove` mutate the shared cache.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to elephc, a PHP-to-native compiler written in Rust.
 Releases are listed newest first.
 
 ## [Unreleased]
+- Improved interactive compilation progress: each completed phase now remains visible with a checkmark and its elapsed time while the next phase starts on a new line; `--quiet` and non-interactive output remain unchanged.
 - Fixed the supported-target test matrix for managed-PCRE2 programs so eval, dynamic `instanceof`, and regex regressions are validated hermetically without relying on the removed system-library fallback.
 - Fixed managed native dependency downloads leaving temporary files behind when another process won the cache-publication race; successful fallback now cleans up the losing download.
 - Added curated native dependency management through `elephc native`: projects can declare and deterministically lock PCRE2 10.47 and zlib 1.3.2, build verified target/toolchain-specific static artifacts, reinstall them with `--locked --offline`, and link regex programs through an opaque shim without a production system-PCRE2 fallback. Uniform project/recovery diagnostics cover missing, stale, corrupt, offline, and toolchain states; `native doctor` reports cache growth and abandoned staging, while explicit locked `native prune` removes obsolete fingerprints/staging without making `remove` mutate the shared cache.

--- a/docs/compiling/output-and-diagnostics.md
+++ b/docs/compiling/output-and-diagnostics.md
@@ -96,9 +96,9 @@ consumers, the second serves tools that want the richer JSON schema.
 ## Compile-time diagnostics
 
 On an interactive terminal, each compilation phase starts as a spinner. When
-the phase finishes, elephc keeps a completed line with a checkmark and elapsed
-time, then starts the next phase on a new line. Non-interactive output and
-`--quiet` keep the compact plain output without progress lines.
+the phase finishes, elephc keeps its action-oriented label with a checkmark and
+elapsed time, then starts the next phase on a new line. Non-interactive output
+and `--quiet` keep the compact plain output without progress lines.
 
 ### `--timings`
 

--- a/docs/compiling/output-and-diagnostics.md
+++ b/docs/compiling/output-and-diagnostics.md
@@ -102,12 +102,29 @@ and `--quiet` keep the compact plain output without progress lines.
 
 ### `--timings`
 
-Prints the detailed timing table with percentages to stderr in addition to the
-interactive completed-phase lines. The labels match the
-[pipeline phases](compilation-pipeline.md).
+Prints a bordered timing table to stderr in addition to the interactive
+completed-phase lines. It uses friendly phase labels, adaptive millisecond or
+second durations, percentage shares, and a total row. Interactive terminals
+use Unicode box drawing; non-interactive output and `--quiet` use ASCII borders
+without styling.
 
 ```bash
 elephc --timings hello.php
+```
+
+```text
+Compiler timings
+┌────────────────────────────────┬───────────┬────────┐
+│ Phase                          │  Duration │  Share │
+├────────────────────────────────┼───────────┼────────┤
+│ Reading source                 │   0.54 ms │   0.0% │
+│ Checking types                 │ 155.70 ms │   1.4% │
+│ ...                            │       ... │    ... │
+│ Optimizing EIR                 │    2.78 s │  25.1% │
+│ Generating native code         │    6.66 s │  60.1% │
+├────────────────────────────────┼───────────┼────────┤
+│ Total                          │   11.08 s │ 100.0% │
+└────────────────────────────────┴───────────┴────────┘
 ```
 
 ## Runtime diagnostics

--- a/docs/compiling/output-and-diagnostics.md
+++ b/docs/compiling/output-and-diagnostics.md
@@ -95,9 +95,15 @@ consumers, the second serves tools that want the richer JSON schema.
 
 ## Compile-time diagnostics
 
+On an interactive terminal, each compilation phase starts as a spinner. When
+the phase finishes, elephc keeps a completed line with a checkmark and elapsed
+time, then starts the next phase on a new line. Non-interactive output and
+`--quiet` keep the compact plain output without progress lines.
+
 ### `--timings`
 
-Prints how long each compilation phase took, to stderr. The labels match the
+Prints the detailed timing table with percentages to stderr in addition to the
+interactive completed-phase lines. The labels match the
 [pipeline phases](compilation-pipeline.md).
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -114,7 +114,7 @@ Linking:
 
 Diagnostics:
   --timings               Report per-phase compile timings to stderr
-  --quiet, -q             Disable the live spinner and colorized output
+  --quiet, -q             Disable progress lines and colorized output
   --source-map            Emit a .map source map alongside the assembly
   --debug-info            Embed DWARF line info for debuggers
 
@@ -158,7 +158,7 @@ pub(crate) struct CliConfig {
     /// the API is available even when feature auto-detection would not trigger.
     /// `--with-web` is folded into `web` instead, since it aliases `--web`.
     pub(crate) with_crates: HashSet<String>,
-    /// Suppresses the live spinner and bridge-library "Linking" event lines,
+    /// Suppresses live/completed progress and bridge-library "Linking" event lines,
     /// forcing plain output regardless of whether stderr is a terminal.
     /// Errors, warnings, and the final success line are unaffected.
     pub(crate) quiet: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,7 +113,7 @@ Linking:
   --with-CRATE            Force-link a bridge crate (pdo, tls, crypto, phar, tz, image, web, eval)
 
 Diagnostics:
-  --timings               Report per-phase compile timings to stderr
+  --timings               Show a per-phase timing table on stderr
   --quiet, -q             Disable progress lines and colorized output
   --source-map            Emit a .map source map alongside the assembly
   --debug-info            Embed DWARF line info for debuggers

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -224,6 +224,7 @@ pub(crate) fn compile(config: CliConfig) {
     // would not resolve to them (see `opcache_prelude::bake_manifest` for the full argument).
     // The manifest feeds `opcache_get_status().scripts`, `opcache_is_script_cached`, and
     // `opcache_compile_file`.
+    crate::progress::phase("opcache-prelude");
     let phase_started = Instant::now();
     let opcache_manifest = opcache_prelude::collect_manifest(
         filename,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -603,7 +603,7 @@ pub(crate) fn compile(config: CliConfig) {
         }
     };
     timings.record_since("runtime-cache", phase_started);
-    timings.note(format!("runtime-cache {}", runtime_object.status.as_str()));
+    timings.note(format!("Runtime cache: {}", runtime_object.status.as_str()));
 
     crate::progress::phase("codegen");
     let phase_started = Instant::now();

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -131,7 +131,7 @@ fn format_event(verb: &str, detail: &str) -> String {
 }
 
 /// Translates stable internal phase identifiers into action-oriented CLI text.
-fn phase_label(name: &str) -> &str {
+pub(crate) fn phase_label(name: &str) -> &str {
     match name {
         "read" => "Reading source",
         "tokenize" => "Tokenizing source",
@@ -182,7 +182,7 @@ fn format_completed_phase(name: &str, elapsed: Duration) -> String {
 }
 
 /// Formats short phases in milliseconds and longer phases in seconds.
-fn format_phase_duration(elapsed: Duration) -> String {
+pub(crate) fn format_phase_duration(elapsed: Duration) -> String {
     if elapsed < Duration::from_secs(1) {
         format!("{:.2} ms", elapsed.as_secs_f64() * 1000.0)
     } else {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,7 +1,7 @@
 //! Purpose:
-//! Owns terminal progress/decoration state for the CLI: a live per-phase spinner
-//! and the single "decorated vs. plain" switch that also gates error/warning and
-//! `--timings` styling elsewhere in the compiler.
+//! Owns terminal progress/decoration state for the CLI: one live spinner per
+//! compile phase, persistent completed-phase lines, and the single "decorated
+//! vs. plain" switch used by diagnostics and `--timings`.
 //!
 //! Called from:
 //! - `crate::pipeline::compile()` at every phase boundary and terminal
@@ -13,16 +13,18 @@
 //! - State is process-global (`OnceLock`), set exactly once by `init()` at the
 //!   very start of `compile()`, mirroring the existing `codegen::set_null_repr`/
 //!   `strict_php::set_enabled` global-setup pattern in this codebase.
+//! - A phase bar is finished and left in the terminal only after its matching
+//!   `CompileTimings::record_since()` call reports successful completion.
 
 #![allow(dead_code)]
 
-use std::sync::OnceLock;
+use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::Duration;
 
 use indicatif::{ProgressBar, ProgressStyle};
 
 static DECORATED: OnceLock<bool> = OnceLock::new();
-static BAR: OnceLock<Option<ProgressBar>> = OnceLock::new();
+static BAR: OnceLock<Mutex<Option<ProgressBar>>> = OnceLock::new();
 
 /// Decides whether this run gets spinner/color/event decoration: never when
 /// `--quiet` was passed, otherwise only when stderr is an interactive terminal.
@@ -35,37 +37,57 @@ fn compute_decorated(quiet: bool, stderr_is_term: bool) -> bool {
 pub(crate) fn init(quiet: bool) {
     let decorated = compute_decorated(quiet, console::Term::stderr().is_term());
     let _ = DECORATED.set(decorated);
-    let bar = if decorated {
-        let pb = ProgressBar::new_spinner();
-        pb.set_style(
-            ProgressStyle::with_template("{spinner:.cyan} {msg}")
-                .expect("static spinner template is valid"),
-        );
-        pb.enable_steady_tick(Duration::from_millis(80));
-        Some(pb)
-    } else {
-        None
-    };
-    let _ = BAR.set(bar);
+    let _ = BAR.set(Mutex::new(None));
 }
 
-fn bar() -> Option<&'static ProgressBar> {
-    BAR.get().and_then(|b| b.as_ref())
+/// Locks the active progress-bar slot, recovering its state after a poisoned lock.
+fn bar_slot() -> MutexGuard<'static, Option<ProgressBar>> {
+    BAR.get_or_init(|| Mutex::new(None))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 /// Updates the live spinner's message to the current compile phase name.
 /// No-op when not decorated.
 pub(crate) fn phase(name: &str) {
-    if let Some(pb) = bar() {
-        pb.set_message(name.to_string());
+    if !is_decorated() {
+        return;
     }
+    let pb = ProgressBar::new_spinner();
+    pb.set_style(
+        ProgressStyle::with_template("{spinner:.cyan} {msg}")
+            .expect("static spinner template is valid"),
+    );
+    pb.set_message(name.to_string());
+    pb.enable_steady_tick(Duration::from_millis(80));
+
+    let mut slot = bar_slot();
+    if let Some(previous) = slot.replace(pb) {
+        previous.finish_and_clear();
+    }
+}
+
+/// Replaces the active spinner with a persistent completed-phase line.
+///
+/// No-op in plain mode. A missing bar is tolerated so compiler errors and
+/// nonstandard early-return paths never turn progress rendering into a
+/// compilation failure.
+pub(crate) fn finish_phase(name: &str, elapsed: Duration) {
+    if !is_decorated() {
+        return;
+    }
+    let Some(pb) = bar_slot().take() else {
+        return;
+    };
+    pb.finish_and_clear();
+    eprintln!("{}", format_completed_phase(name, elapsed));
 }
 
 /// Stops and clears the live spinner, e.g. before a fatal error is reported or
 /// before a final success line is printed, so neither interleaves with a
 /// mid-animation spinner frame. No-op when not decorated.
 pub(crate) fn clear() {
-    if let Some(pb) = bar() {
+    if let Some(pb) = bar_slot().take() {
         pb.finish_and_clear();
     }
 }
@@ -77,12 +99,21 @@ pub(crate) fn is_decorated() -> bool {
     *DECORATED.get().unwrap_or(&false)
 }
 
-/// Prints a cargo-style static line (e.g. "Linking elephc_pdo (auto-detected)")
-/// above the live spinner without corrupting its animation. No-op when not
-/// decorated (the bar is `None`, so there is nothing to print above).
+/// Prints a cargo-style event line, e.g. a bridge library discovered by the
+/// linker.
+///
+/// Uses the active progress bar when present so its animation stays intact,
+/// otherwise writes directly to stderr between two completed phases. No-op in
+/// plain mode.
 pub(crate) fn event(verb: &str, detail: &str) {
-    if let Some(pb) = bar() {
-        pb.println(format_event(verb, detail));
+    if !is_decorated() {
+        return;
+    }
+    let line = format_event(verb, detail);
+    if let Some(pb) = bar_slot().as_ref() {
+        pb.println(line);
+    } else {
+        eprintln!("{line}");
     }
 }
 
@@ -94,10 +125,31 @@ pub(crate) fn finish_ok(message: &str, elapsed: Duration) {
     println!("{}", format_success(message, elapsed, is_decorated()));
 }
 
+/// Formats a cargo-style event line with an aligned, decorated verb.
 fn format_event(verb: &str, detail: &str) -> String {
     format!("{:>12} {}", console::style(verb).bold().cyan(), detail)
 }
 
+/// Formats one successful phase with an adaptive millisecond/second duration.
+fn format_completed_phase(name: &str, elapsed: Duration) -> String {
+    format!(
+        "{} {} ({})",
+        console::style("\u{2713}").bold().green(),
+        name,
+        format_phase_duration(elapsed),
+    )
+}
+
+/// Formats short phases in milliseconds and longer phases in seconds.
+fn format_phase_duration(elapsed: Duration) -> String {
+    if elapsed < Duration::from_secs(1) {
+        format!("{:.2} ms", elapsed.as_secs_f64() * 1000.0)
+    } else {
+        format!("{:.2} s", elapsed.as_secs_f64())
+    }
+}
+
+/// Formats the terminal success message, preserving the historical plain form.
 fn format_success(message: &str, elapsed: Duration, decorated: bool) -> String {
     if decorated {
         format!(
@@ -151,5 +203,29 @@ mod tests {
         let line = format_event("Linking", "elephc_pdo (auto-detected)");
         assert!(line.contains("Linking"));
         assert!(line.contains("elephc_pdo (auto-detected)"));
+    }
+
+    /// Verifies sub-second phases remain readable instead of rounding to zero seconds.
+    #[test]
+    fn short_phase_duration_uses_milliseconds() {
+        assert_eq!(
+            format_phase_duration(Duration::from_micros(1_250)),
+            "1.25 ms"
+        );
+    }
+
+    /// Verifies longer phases use the same compact seconds scale as final success.
+    #[test]
+    fn long_phase_duration_uses_seconds() {
+        assert_eq!(format_phase_duration(Duration::from_millis(1_250)), "1.25 s");
+    }
+
+    /// Verifies completed phase lines retain the phase name and elapsed duration.
+    #[test]
+    fn completed_phase_line_contains_name_and_duration() {
+        let line = format_completed_phase("typecheck", Duration::from_millis(42));
+        assert!(line.contains('\u{2713}'));
+        assert!(line.contains("typecheck"));
+        assert!(line.contains("42.00 ms"));
     }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -58,7 +58,7 @@ pub(crate) fn phase(name: &str) {
         ProgressStyle::with_template("{spinner:.cyan} {msg}")
             .expect("static spinner template is valid"),
     );
-    pb.set_message(name.to_string());
+    pb.set_message(phase_label(name).to_string());
     pb.enable_steady_tick(Duration::from_millis(80));
 
     let mut slot = bar_slot();
@@ -130,12 +130,53 @@ fn format_event(verb: &str, detail: &str) -> String {
     format!("{:>12} {}", console::style(verb).bold().cyan(), detail)
 }
 
+/// Translates stable internal phase identifiers into action-oriented CLI text.
+fn phase_label(name: &str) -> &str {
+    match name {
+        "read" => "Reading source",
+        "tokenize" => "Tokenizing source",
+        "parse" => "Parsing program",
+        "magic-constants" => "Expanding magic constants",
+        "autoload-build" => "Building autoload index",
+        "resolve" => "Resolving includes",
+        "pdo-prelude" => "Configuring PDO support",
+        "tz-prelude" => "Configuring timezone support",
+        "list-id-prelude" => "Loading timezone identifiers",
+        "var-export-prelude" => "Configuring var_export()",
+        "opcache-prelude" => "Configuring OPcache",
+        "image-prelude" => "Configuring image support",
+        "hash-prelude" => "Configuring hash support",
+        "web-prelude" => "Configuring web runtime",
+        "version-prelude" => "Applying PHP version profile",
+        "name-resolve" => "Resolving names",
+        "autoload-run" => "Discovering autoloaded symbols",
+        "opcache-manifest-bake" => "Baking OPcache manifest",
+        "opt-fold" => "Folding constants",
+        "typecheck" => "Checking types",
+        "exports-scan" => "Discovering exports",
+        "opt-prop" => "Propagating constants",
+        "opt-post" => "Pruning constant branches",
+        "opt-norm" => "Normalizing control flow",
+        "dce" => "Eliminating dead code",
+        "ir-lower" => "Lowering program to EIR",
+        "ir-opt" => "Optimizing EIR",
+        "ir-print" => "Rendering EIR",
+        "runtime-cache" => "Preparing runtime object",
+        "codegen" => "Generating native code",
+        "write-asm" => "Writing assembly",
+        "source-map" => "Writing source map",
+        "assemble" => "Assembling object file",
+        "link" => "Linking native output",
+        _ => name,
+    }
+}
+
 /// Formats one successful phase with an adaptive millisecond/second duration.
 fn format_completed_phase(name: &str, elapsed: Duration) -> String {
     format!(
         "{} {} ({})",
         console::style("\u{2713}").bold().green(),
-        name,
+        phase_label(name),
         format_phase_duration(elapsed),
     )
 }
@@ -220,12 +261,18 @@ mod tests {
         assert_eq!(format_phase_duration(Duration::from_millis(1_250)), "1.25 s");
     }
 
-    /// Verifies completed phase lines retain the phase name and elapsed duration.
+    /// Verifies completed phase lines use the friendly label and elapsed duration.
     #[test]
     fn completed_phase_line_contains_name_and_duration() {
         let line = format_completed_phase("typecheck", Duration::from_millis(42));
         assert!(line.contains('\u{2713}'));
-        assert!(line.contains("typecheck"));
+        assert!(line.contains("Checking types"));
         assert!(line.contains("42.00 ms"));
+    }
+
+    /// Verifies unknown future phases remain visible instead of rendering blank text.
+    #[test]
+    fn unknown_phase_label_falls_back_to_internal_name() {
+        assert_eq!(phase_label("new-phase"), "new-phase");
     }
 }

--- a/src/timings.rs
+++ b/src/timings.rs
@@ -221,6 +221,7 @@ fn render_timing_table(
         chars.middle_join,
         chars.middle_right,
     ));
+    let has_phase_rows = !rows.is_empty();
     for (phase, duration, share) in rows {
         lines.push(format_table_row(
             chars,
@@ -232,15 +233,17 @@ fn render_timing_table(
             share_width,
         ));
     }
-    lines.push(format_table_rule(
-        chars,
-        phase_width,
-        duration_width,
-        share_width,
-        chars.middle_left,
-        chars.middle_join,
-        chars.middle_right,
-    ));
+    if has_phase_rows {
+        lines.push(format_table_rule(
+            chars,
+            phase_width,
+            duration_width,
+            share_width,
+            chars.middle_left,
+            chars.middle_join,
+            chars.middle_right,
+        ));
+    }
     let total_row = format_table_row(
         chars,
         "Total",
@@ -381,5 +384,15 @@ mod tests {
         );
         let widths: Vec<usize> = table.lines().map(|line| line.chars().count()).collect();
         assert!(widths.windows(2).all(|pair| pair[0] == pair[1]));
+    }
+
+    /// Verifies an empty report uses one separator between the header and total row.
+    #[test]
+    fn empty_timing_table_has_no_adjacent_separators() {
+        let table = render_timing_table(&[], Duration::ZERO, false);
+        let lines: Vec<&str> = table.lines().collect();
+        assert_eq!(lines.len(), 5);
+        assert!(lines[1].contains("Phase"));
+        assert!(lines[3].contains("Total"));
     }
 }

--- a/src/timings.rs
+++ b/src/timings.rs
@@ -21,6 +21,49 @@ pub(crate) struct CompileTimings {
     phases: Vec<(&'static str, Duration)>,
 }
 
+/// Box-drawing characters used by the interactive and plain timing tables.
+struct TableChars {
+    horizontal: char,
+    vertical: char,
+    top_left: char,
+    top_join: char,
+    top_right: char,
+    middle_left: char,
+    middle_join: char,
+    middle_right: char,
+    bottom_left: char,
+    bottom_join: char,
+    bottom_right: char,
+}
+
+const UNICODE_TABLE: TableChars = TableChars {
+    horizontal: '─',
+    vertical: '│',
+    top_left: '┌',
+    top_join: '┬',
+    top_right: '┐',
+    middle_left: '├',
+    middle_join: '┼',
+    middle_right: '┤',
+    bottom_left: '└',
+    bottom_join: '┴',
+    bottom_right: '┘',
+};
+
+const ASCII_TABLE: TableChars = TableChars {
+    horizontal: '-',
+    vertical: '|',
+    top_left: '+',
+    top_join: '+',
+    top_right: '+',
+    middle_left: '+',
+    middle_join: '+',
+    middle_right: '+',
+    bottom_left: '+',
+    bottom_join: '+',
+    bottom_right: '+',
+};
+
 impl CompileTimings {
     /// Creates a new timing collector.
     ///
@@ -52,7 +95,7 @@ impl CompileTimings {
     /// Appends an arbitrary informational note to the timing report.
     ///
     /// No-op when timing collection is disabled. The note is printed verbatim
-    /// in order at the top of the report, before any phase timings.
+    /// in order below the timing table.
     pub(crate) fn note(&mut self, note: impl Into<String>) {
         if self.enabled {
             self.notes.push(note.into());
@@ -68,12 +111,10 @@ impl CompileTimings {
 
     /// Prints the collected timing report to stderr.
     ///
-    /// Output is gated behind the `enabled` flag. The report includes all notes
-    /// in insertion order, each phase with its duration in milliseconds, and a
-    /// total elapsed time from when the collector was constructed. Decorated
-    /// runs (see `crate::progress::is_decorated`) bold the header/total row and
-    /// add a per-phase percentage-of-total column; plain runs keep today's exact
-    /// unstyled, no-percentage table — byte-identical to before this task.
+    /// Output is gated behind the `enabled` flag. The report renders friendly
+    /// phase labels, adaptive durations, percentage shares, and a total row.
+    /// Interactive runs use Unicode box drawing and bold header/total rows;
+    /// plain runs use an unstyled ASCII table suitable for logs and pipes.
     pub(crate) fn report(&self) {
         if !self.enabled {
             return;
@@ -82,15 +123,16 @@ impl CompileTimings {
         let decorated = crate::progress::is_decorated();
         let total = self.started_at.elapsed();
 
-        eprintln!("{}", style_if(decorated, "Compiler timings:"));
-        for note in &self.notes {
-            eprintln!("  {}", note);
+        eprintln!("{}", style_if(decorated, "Compiler timings"));
+        eprintln!("{}", render_timing_table(&self.phases, total, decorated));
+        if !self.notes.is_empty() {
+            eprintln!();
+            eprintln!("{}", style_if(decorated, "Notes"));
+            let bullet = if decorated { "•" } else { "-" };
+            for note in &self.notes {
+                eprintln!("  {bullet} {note}");
+            }
         }
-        for (phase, duration) in &self.phases {
-            eprintln!("{}", format_phase_line(phase, *duration, total, decorated));
-        }
-        let total_line = format!("  {:<12} {:>8.2} ms", "total", total.as_secs_f64() * 1000.0);
-        eprintln!("{}", style_if(decorated, &total_line));
     }
 }
 
@@ -113,21 +155,147 @@ fn style_if(decorated: bool, text: &str) -> String {
     }
 }
 
-/// Formats one phase's timing line. Decorated runs add a percentage-of-total
-/// column; plain runs keep today's exact two-column layout (phase + ms) with
-/// no percentage suffix, so plain-mode `--timings` output stays byte-identical
-/// to before this task.
-fn format_phase_line(phase: &str, duration: Duration, total: Duration, decorated: bool) -> String {
-    if decorated {
-        format!(
-            "  {:<12} {:>8.2} ms {:>5.1}%",
-            phase,
-            duration.as_secs_f64() * 1000.0,
-            percentage(duration, total),
-        )
+/// Renders the complete timing table using terminal-appropriate borders.
+fn render_timing_table(
+    phases: &[(&str, Duration)],
+    total: Duration,
+    decorated: bool,
+) -> String {
+    let chars = if decorated {
+        &UNICODE_TABLE
     } else {
-        format!("  {:<12} {:>8.2} ms", phase, duration.as_secs_f64() * 1000.0)
+        &ASCII_TABLE
+    };
+    let rows: Vec<(String, String, String)> = phases
+        .iter()
+        .map(|(phase, duration)| {
+            (
+                crate::progress::phase_label(phase).to_string(),
+                crate::progress::format_phase_duration(*duration),
+                format!("{:.1}%", percentage(*duration, total)),
+            )
+        })
+        .collect();
+    let total_duration = crate::progress::format_phase_duration(total);
+    let total_share = "100.0%";
+
+    let phase_width = rows
+        .iter()
+        .map(|row| row.0.chars().count())
+        .fold("Phase".len().max("Total".len()), usize::max);
+    let duration_width = rows
+        .iter()
+        .map(|row| row.1.len())
+        .fold("Duration".len().max(total_duration.len()), usize::max);
+    let share_width = rows
+        .iter()
+        .map(|row| row.2.len())
+        .fold("Share".len().max(total_share.len()), usize::max);
+
+    let mut lines = Vec::with_capacity(rows.len() + 6);
+    lines.push(format_table_rule(
+        chars,
+        phase_width,
+        duration_width,
+        share_width,
+        chars.top_left,
+        chars.top_join,
+        chars.top_right,
+    ));
+    let header = format_table_row(
+        chars,
+        "Phase",
+        "Duration",
+        "Share",
+        phase_width,
+        duration_width,
+        share_width,
+    );
+    lines.push(style_if(decorated, &header));
+    lines.push(format_table_rule(
+        chars,
+        phase_width,
+        duration_width,
+        share_width,
+        chars.middle_left,
+        chars.middle_join,
+        chars.middle_right,
+    ));
+    for (phase, duration, share) in rows {
+        lines.push(format_table_row(
+            chars,
+            &phase,
+            &duration,
+            &share,
+            phase_width,
+            duration_width,
+            share_width,
+        ));
     }
+    lines.push(format_table_rule(
+        chars,
+        phase_width,
+        duration_width,
+        share_width,
+        chars.middle_left,
+        chars.middle_join,
+        chars.middle_right,
+    ));
+    let total_row = format_table_row(
+        chars,
+        "Total",
+        &total_duration,
+        total_share,
+        phase_width,
+        duration_width,
+        share_width,
+    );
+    lines.push(style_if(decorated, &total_row));
+    lines.push(format_table_rule(
+        chars,
+        phase_width,
+        duration_width,
+        share_width,
+        chars.bottom_left,
+        chars.bottom_join,
+        chars.bottom_right,
+    ));
+    lines.join("\n")
+}
+
+/// Formats one table row with left-aligned phase text and numeric columns right-aligned.
+fn format_table_row(
+    chars: &TableChars,
+    phase: &str,
+    duration: &str,
+    share: &str,
+    phase_width: usize,
+    duration_width: usize,
+    share_width: usize,
+) -> String {
+    let phase = format!("{phase:<phase_width$}");
+    let duration = format!("{duration:>duration_width$}");
+    let share = format!("{share:>share_width$}");
+    format!(
+        "{} {phase} {} {duration} {} {share} {}",
+        chars.vertical, chars.vertical, chars.vertical, chars.vertical,
+    )
+}
+
+/// Formats a horizontal table border or separator for the computed column widths.
+fn format_table_rule(
+    chars: &TableChars,
+    phase_width: usize,
+    duration_width: usize,
+    share_width: usize,
+    left: char,
+    join: char,
+    right: char,
+) -> String {
+    let phase = chars.horizontal.to_string().repeat(phase_width + 2);
+    let duration = chars.horizontal.to_string().repeat(duration_width + 2);
+    let share = chars.horizontal.to_string().repeat(share_width + 2);
+    format!("{left}{phase}{join}{duration}{join}{share}{right}")
 }
 
 #[cfg(test)]
@@ -155,42 +323,63 @@ mod tests {
         assert!((pct - 25.0).abs() < 0.001);
     }
 
-    /// Verifies plain timing headers remain byte-identical.
+    /// Verifies plain timing titles remain unstyled.
     #[test]
     fn style_if_plain_is_unchanged() {
-        assert_eq!(style_if(false, "Compiler timings:"), "Compiler timings:");
+        assert_eq!(style_if(false, "Compiler timings"), "Compiler timings");
     }
 
     /// Verifies decorated timing headers retain their original text.
     #[test]
     fn style_if_decorated_contains_original_text() {
-        assert!(style_if(true, "Compiler timings:").contains("Compiler timings:"));
+        assert!(style_if(true, "Compiler timings").contains("Compiler timings"));
     }
 
-    /// Verifies plain phase rows omit the decorated percentage column.
+    /// Verifies plain reports use ASCII borders, friendly labels, and percentages.
     #[test]
-    fn format_phase_line_plain_has_no_percentage() {
-        let line = format_phase_line(
-            "codegen",
-            Duration::from_millis(10),
+    fn plain_timing_table_is_ascii_and_complete() {
+        let table = render_timing_table(
+            &[("read", Duration::from_millis(25))],
             Duration::from_millis(100),
             false,
         );
-        assert!(!line.contains('%'));
-        assert!(line.contains("codegen"));
-        assert!(line.contains("10.00 ms"));
+        assert!(table.starts_with('+'));
+        assert!(table.ends_with('+'));
+        assert!(table.contains("| Reading source "));
+        assert!(table.contains("25.00 ms"));
+        assert!(table.contains("25.0%"));
+        assert!(table.contains("| Total"));
+        assert!(!table.contains('┌'));
     }
 
-    /// Verifies decorated phase rows include their share of total time.
+    /// Verifies interactive reports use Unicode borders and adaptive durations.
     #[test]
-    fn format_phase_line_decorated_includes_percentage() {
-        let line = format_phase_line(
-            "codegen",
-            Duration::from_millis(10),
-            Duration::from_millis(100),
+    fn decorated_timing_table_uses_unicode_and_friendly_labels() {
+        let table = render_timing_table(
+            &[("ir-opt", Duration::from_millis(1_250))],
+            Duration::from_millis(2_500),
             true,
         );
-        assert!(line.contains('%'));
-        assert!(line.contains("10.0%"));
+        assert!(table.starts_with('┌'));
+        assert!(table.ends_with('┘'));
+        assert!(table.contains('┼'));
+        assert!(table.contains("Optimizing EIR"));
+        assert!(table.contains("1.25 s"));
+        assert!(table.contains("50.0%"));
+    }
+
+    /// Verifies every line in the plain table has the same visible width.
+    #[test]
+    fn plain_timing_table_columns_align() {
+        let table = render_timing_table(
+            &[
+                ("read", Duration::from_micros(500)),
+                ("autoload-run", Duration::from_millis(1_250)),
+            ],
+            Duration::from_millis(2_000),
+            false,
+        );
+        let widths: Vec<usize> = table.lines().map(|line| line.chars().count()).collect();
+        assert!(widths.windows(2).all(|pair| pair[0] == pair[1]));
     }
 }

--- a/src/timings.rs
+++ b/src/timings.rs
@@ -1,12 +1,15 @@
 //! Purpose:
-//! Records optional compile-phase durations and notes for CLI timing output.
-//! Keeps timing collection lightweight when the user has not requested `--timings`.
+//! Records compile-phase durations and optional notes for CLI timing output.
+//! Reports each successful phase to the interactive progress renderer while
+//! retaining the full timing table only when the user requests `--timings`.
 //!
 //! Called from:
 //! - `crate::pipeline::compile()` around each major compiler phase.
 //!
 //! Key details:
-//! - Disabled timing still accepts calls so pipeline code does not branch around every measurement.
+//! - Phase durations are always measured for interactive completed-step lines.
+//! - Disabled timing skips only table storage/reporting, so pipeline code does
+//!   not branch around every measurement.
 
 use std::time::{Duration, Instant};
 
@@ -21,9 +24,9 @@ pub(crate) struct CompileTimings {
 impl CompileTimings {
     /// Creates a new timing collector.
     ///
-    /// `enabled` controls whether timing data is actually recorded and reported.
-    /// When disabled (the common case), all methods are no-ops so callers need
-    /// not branch on the flag. The internal timer starts immediately.
+    /// `enabled` controls whether detailed timing data is retained and reported.
+    /// Phase completion still reaches the interactive progress renderer when
+    /// disabled. The internal timer starts immediately.
     pub(crate) fn new(enabled: bool) -> Self {
         Self {
             enabled,
@@ -35,11 +38,14 @@ impl CompileTimings {
 
     /// Records the elapsed time since `started_at` for the named phase.
     ///
-    /// No-op when timing collection is disabled. The duration is computed
-    /// immediately at call time via `Instant::elapsed()`.
+    /// The duration is always forwarded to the interactive progress renderer.
+    /// It is retained for the detailed timing report only when collection is
+    /// enabled.
     pub(crate) fn record_since(&mut self, phase: &'static str, started_at: Instant) {
+        let elapsed = started_at.elapsed();
+        crate::progress::finish_phase(phase, elapsed);
         if self.enabled {
-            self.phases.push((phase, started_at.elapsed()));
+            self.phases.push((phase, elapsed));
         }
     }
 
@@ -98,6 +104,7 @@ fn percentage(part: Duration, total: Duration) -> f64 {
     }
 }
 
+/// Applies bold terminal styling only for decorated interactive runs.
 fn style_if(decorated: bool, text: &str) -> String {
     if decorated {
         console::style(text).bold().to_string()
@@ -127,38 +134,62 @@ fn format_phase_line(phase: &str, duration: Duration, total: Duration, decorated
 mod tests {
     use super::*;
 
+    /// Verifies disabled detailed timings do not retain phase samples.
+    #[test]
+    fn disabled_timings_do_not_store_phases() {
+        let mut timings = CompileTimings::new(false);
+        timings.record_since("read", Instant::now());
+        assert!(timings.phases.is_empty());
+    }
+
+    /// Verifies percentage formatting avoids division by zero.
     #[test]
     fn percentage_of_zero_total_is_zero() {
         assert_eq!(percentage(Duration::from_millis(5), Duration::ZERO), 0.0);
     }
 
+    /// Verifies phase shares are computed against total elapsed time.
     #[test]
     fn percentage_computes_share_of_total() {
         let pct = percentage(Duration::from_millis(25), Duration::from_millis(100));
         assert!((pct - 25.0).abs() < 0.001);
     }
 
+    /// Verifies plain timing headers remain byte-identical.
     #[test]
     fn style_if_plain_is_unchanged() {
         assert_eq!(style_if(false, "Compiler timings:"), "Compiler timings:");
     }
 
+    /// Verifies decorated timing headers retain their original text.
     #[test]
     fn style_if_decorated_contains_original_text() {
         assert!(style_if(true, "Compiler timings:").contains("Compiler timings:"));
     }
 
+    /// Verifies plain phase rows omit the decorated percentage column.
     #[test]
     fn format_phase_line_plain_has_no_percentage() {
-        let line = format_phase_line("codegen", Duration::from_millis(10), Duration::from_millis(100), false);
+        let line = format_phase_line(
+            "codegen",
+            Duration::from_millis(10),
+            Duration::from_millis(100),
+            false,
+        );
         assert!(!line.contains('%'));
         assert!(line.contains("codegen"));
         assert!(line.contains("10.00 ms"));
     }
 
+    /// Verifies decorated phase rows include their share of total time.
     #[test]
     fn format_phase_line_decorated_includes_percentage() {
-        let line = format_phase_line("codegen", Duration::from_millis(10), Duration::from_millis(100), true);
+        let line = format_phase_line(
+            "codegen",
+            Duration::from_millis(10),
+            Duration::from_millis(100),
+            true,
+        );
         assert!(line.contains('%'));
         assert!(line.contains("10.0%"));
     }

--- a/tests/codegen/cli.rs
+++ b/tests/codegen/cli.rs
@@ -531,9 +531,8 @@ fn test_cli_timings_reports_assemble_and_link() {
     let _ = fs::remove_dir_all(&dir);
 }
 
-/// Verifies the runtime cache: the first compile produces a "runtime-cache miss"
-/// and caches a runtime .o object; the second compile with the same input hits
-/// the cache ("runtime-cache hit") without recompiling the runtime.
+/// Verifies the timing report records `Runtime cache: miss` for the first
+/// compile and `Runtime cache: hit` for the second without rebuilding it.
 #[test]
 fn test_cli_runtime_cache_reuses_runtime_object() {
     let dir = make_cli_test_dir("elephc_cli_runtime_cache");
@@ -555,7 +554,11 @@ fn test_cli_runtime_cache_reuses_runtime_object() {
     );
     let first_stderr = String::from_utf8_lossy(&first.stderr);
     assert!(
-        first_stderr.contains("runtime-cache miss"),
+        first_stderr.contains("Notes"),
+        "expected timing notes after first compile, got stderr={first_stderr}"
+    );
+    assert!(
+        first_stderr.contains("Runtime cache: miss"),
         "expected first compile to miss runtime cache, got stderr={first_stderr}"
     );
 
@@ -586,7 +589,11 @@ fn test_cli_runtime_cache_reuses_runtime_object() {
     );
     let second_stderr = String::from_utf8_lossy(&second.stderr);
     assert!(
-        second_stderr.contains("runtime-cache hit"),
+        second_stderr.contains("Notes"),
+        "expected timing notes after second compile, got stderr={second_stderr}"
+    );
+    assert!(
+        second_stderr.contains("Runtime cache: hit"),
         "expected second compile to hit runtime cache, got stderr={second_stderr}"
     );
 

--- a/tests/codegen/cli.rs
+++ b/tests/codegen/cli.rs
@@ -449,8 +449,8 @@ fn test_cli_rejects_emit_ir_output_mode_conflicts() {
     let _ = fs::remove_dir_all(&dir);
 }
 
-/// Verifies `--check --timings` reports per-phase timings for tokenize, parse,
-/// typecheck, and total — without running codegen/assemble/link phases.
+/// Verifies `--check --timings` renders the frontend phase table without
+/// reporting code generation, assembly, or linking phases.
 #[test]
 fn test_cli_timings_reports_check_phases() {
     let dir = make_cli_test_dir("elephc_cli_timings_check");
@@ -471,16 +471,28 @@ fn test_cli_timings_reports_check_phases() {
     );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("Compiler timings:"), "missing timings header: {stderr}");
-    assert!(stderr.contains("tokenize"), "missing tokenize timing: {stderr}");
-    assert!(stderr.contains("parse"), "missing parse timing: {stderr}");
-    assert!(stderr.contains("typecheck"), "missing typecheck timing: {stderr}");
-    assert!(stderr.contains("total"), "missing total timing: {stderr}");
+    assert!(stderr.contains("Compiler timings"), "missing timings header: {stderr}");
+    assert!(stderr.contains("Tokenizing source"), "missing tokenize timing: {stderr}");
+    assert!(stderr.contains("Parsing program"), "missing parse timing: {stderr}");
+    assert!(stderr.contains("Checking types"), "missing typecheck timing: {stderr}");
+    assert!(stderr.contains("Total"), "missing total timing: {stderr}");
+    assert!(
+        !stderr.contains("Generating native code"),
+        "unexpected codegen timing in --check output: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Assembling object file"),
+        "unexpected assemble timing in --check output: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Linking native output"),
+        "unexpected link timing in --check output: {stderr}"
+    );
 
     let _ = fs::remove_dir_all(&dir);
 }
 
-/// Verifies `--timings` reports codegen, assemble, link, and total durations
+/// Verifies `--timings` renders the native build phases and total duration
 /// when compiling a full binary, and that the binary is emitted.
 #[test]
 fn test_cli_timings_reports_assemble_and_link() {
@@ -501,10 +513,19 @@ fn test_cli_timings_reports_assemble_and_link() {
     );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("codegen"), "missing codegen timing: {stderr}");
-    assert!(stderr.contains("assemble"), "missing assemble timing: {stderr}");
-    assert!(stderr.contains("link"), "missing link timing: {stderr}");
-    assert!(stderr.contains("total"), "missing total timing: {stderr}");
+    assert!(
+        stderr.contains("Generating native code"),
+        "missing codegen timing: {stderr}"
+    );
+    assert!(
+        stderr.contains("Assembling object file"),
+        "missing assemble timing: {stderr}"
+    );
+    assert!(
+        stderr.contains("Linking native output"),
+        "missing link timing: {stderr}"
+    );
+    assert!(stderr.contains("Total"), "missing total timing: {stderr}");
     assert!(dir.join("main").exists(), "expected compiled binary to exist");
 
     let _ = fs::remove_dir_all(&dir);


### PR DESCRIPTION
## Summary

- Keep every successfully completed compilation phase visible in interactive terminals, with a checkmark and elapsed time, before starting the next spinner on a new line.
- Replace internal phase identifiers with action-oriented labels such as `Reading source`, `Checking types`, `Optimizing EIR`, and `Generating native code`, while keeping the stable identifiers for internal timing collection.
- Render `--timings` as an aligned table with friendly labels, adaptive millisecond/second durations, percentage shares, a total row, and a separate notes section for details such as runtime-cache status.
- Use Unicode box drawing in interactive terminals and an unstyled ASCII table with `--quiet`, pipes, and CI. Normal non-interactive output remains compact and unchanged when `--timings` is not requested.
- Update CLI help, compilation diagnostics documentation, and the changelog.

## Example

```text
Compiler timings
┌────────────────────────────────┬───────────┬────────┐
│ Phase                          │  Duration │  Share │
├────────────────────────────────┼───────────┼────────┤
│ Reading source                 │   0.54 ms │   0.0% │
│ Checking types                 │ 155.70 ms │   1.4% │
│ Optimizing EIR                 │    2.78 s │  25.1% │
│ Generating native code         │    6.66 s │  60.1% │
├────────────────────────────────┼───────────┼────────┤
│ Total                          │   11.08 s │ 100.0% │
└────────────────────────────────┴───────────┴────────┘
```

## Testing

- `cargo test --lib progress::tests`
- `cargo test --bin elephc timings::tests`
- `cargo test --bin elephc quiet`
- `cargo build`
- Manually verified persistent progress and bridge `Linking` output in a PTY with `examples/hashing/main.php`.
- Manually verified Unicode, ASCII/non-TTY, and `--quiet` timing-table rendering with `examples/hello/main.php`.

