### PR TITLE
Update test for getprotobyname and getprotobynumber for inconsistant protocol 0

### DIFF
--- a/tests/codegen/io/streams.rs
+++ b/tests/codegen/io/streams.rs
@@ -3280,10 +3280,11 @@ $name = getprotobynumber(0);
 echo $name . "|" . getprotobyname($name);
 "#,
     );
-    assert!(
-        matches!(out.as_str(), "ip|0" | "hopopt|0"),
-        "expected protocol zero to round-trip as ip or hopopt, got {out:?}"
-    );
+    let (name, number) = out
+        .split_once('|')
+        .expect("expected protocol zero output in name|number format");
+    assert!(!name.is_empty(), "expected a non-empty protocol name");
+    assert_eq!(number, "0", "expected protocol name to round-trip to zero");
 }
 
 /// Verifies compiled PHP output for getprotobynumber persists across calls.

--- a/tests/codegen/io/streams.rs
+++ b/tests/codegen/io/streams.rs
@@ -3237,11 +3237,9 @@ echo "|";
 echo getprotobyname("udp");
 echo "|";
 echo getprotobyname("icmp");
-echo "|";
-echo getprotobyname("ip");
 "#,
     );
-    assert_eq!(out, "6|17|1|0");
+    assert_eq!(out, "6|17|1");
 }
 
 /// Verifies compiled PHP output for getprotobyname alias and missing.
@@ -3267,11 +3265,25 @@ echo "|";
 echo getprotobynumber(17);
 echo "|";
 echo getprotobynumber(1);
-echo "|";
-echo getprotobynumber(0);
 "#,
     );
-    assert_eq!(out, "tcp|udp|icmp|ip");
+    assert_eq!(out, "tcp|udp|icmp");
+}
+
+/// Verifies protocol zero and its host-defined name resolve in both directions.
+#[test]
+fn test_protocol_zero_host_name_round_trip() {
+    // Protocol zero is named "ip" on some systems and "hopopt" on others.
+    let out = compile_and_run(
+        r#"<?php
+$name = getprotobynumber(0);
+echo $name . "|" . getprotobyname($name);
+"#,
+    );
+    assert!(
+        matches!(out.as_str(), "ip|0" | "hopopt|0"),
+        "expected protocol zero to round-trip as ip or hopopt, got {out:?}"
+    );
 }
 
 /// Verifies compiled PHP output for getprotobynumber persists across calls.


### PR DESCRIPTION
Depending on the system protocol 0 can be `ip` or `hopopt`. On Arch Linux it is `hopopt` while the former test here assumed it to always be `ip`

So, this test would fail if run from an Arch Linux system.

Arch gets its protocol list for /etc/protocols from 
https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xml
https://sources.archlinux.org/other/packages/iana-etc/protocol-numbers-20260310.xml

I've updated the tests here so it can still pass with `ip` or `hopopt` being protocol 0.