### PR TITLE
fix(types): assign class and interface ids deterministically

### DIFF
--- a/src/types/checker/driver/mod.rs
+++ b/src/types/checker/driver/mod.rs
@@ -207,7 +207,12 @@ pub(super) fn check_types_impl(
 
     let mut next_interface_id = 0u64;
     let mut building_interfaces = HashSet::new();
-    let interface_names: Vec<String> = interface_map.keys().cloned().collect();
+    // Sorted: `interface_map` is a HashMap, whose iteration order is randomized per
+    // process. Interface ids are handed out in this order and are baked into the
+    // generated assembly, so an unsorted walk makes two compilations of the SAME
+    // source produce different output — which defeats any content-addressed cache.
+    let mut interface_names: Vec<String> = interface_map.keys().cloned().collect();
+    interface_names.sort();
     for interface_name in interface_names {
         if let Err(error) = build_interface_info_recursive(
             &interface_name,
@@ -223,7 +228,11 @@ pub(super) fn check_types_impl(
 
     let mut next_class_id = 0u64;
     let mut building = HashSet::new();
-    let class_names: Vec<String> = class_map.keys().cloned().collect();
+    // Sorted for the same reason as `interface_names` above: class ids are assigned in
+    // this walk order and end up as immediates and `.quad` values in the emitted
+    // assembly, so a HashMap-ordered walk is a reproducibility hole.
+    let mut class_names: Vec<String> = class_map.keys().cloned().collect();
+    class_names.sort();
     for class_name in class_names {
         if let Err(error) = build_class_info_recursive(
             &class_name,

--- a/tests/compiler_determinism_tests.rs
+++ b/tests/compiler_determinism_tests.rs
@@ -1,0 +1,196 @@
+//! Purpose:
+//! Locks compiler output reproducibility: compiling the same source twice must
+//! produce byte-identical assembly.
+//!
+//! Called from:
+//! - `cargo test` through Rust's test harness.
+//!
+//! Key details:
+//! - Each compilation runs in its OWN process on purpose. `HashMap` seeds its
+//!   hasher from a per-process random state, so a single in-process pair of
+//!   compilations would not exercise the ordering difference these tests exist
+//!   to catch.
+//! - `--emit-asm` stops before the assembler and the linker, so the fixtures stay
+//!   cheap while still covering every phase that can bake an ordering decision
+//!   into the output.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Returns the path to the cargo-built `elephc` binary.
+fn elephc_cli_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_elephc").unwrap_or_else(|_| {
+        let mut path = std::env::current_exe().expect("failed to resolve current test binary");
+        path.pop();
+        if path.ends_with("deps") {
+            path.pop();
+        }
+        path.join("elephc").to_string_lossy().into_owned()
+    })
+}
+
+/// Returns a process-unique suffix so parallel tests never share a directory.
+fn unique_test_id() -> usize {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Compiles `source` to assembly `runs` times, each in a fresh process, and
+/// returns the emitted assembly of every run.
+///
+/// Every run compiles the SAME file in the SAME directory: the compiler bakes the
+/// canonicalized source path into the output (`__FILE__`, `Throwable::getFile()`),
+/// so compiling copies in sibling directories would report a path difference as a
+/// reproducibility failure. Runs also share one cache root, so the runtime object
+/// is built once; the assembly under test is regenerated from scratch regardless.
+fn emit_asm_repeatedly(name: &str, source: &str, runs: usize) -> Vec<String> {
+    let dir = std::env::temp_dir().join(format!(
+        "elephc_determinism_{}_{}_{}",
+        name,
+        std::process::id(),
+        unique_test_id()
+    ));
+    fs::create_dir_all(&dir).expect("failed to create determinism fixture directory");
+    let php_path: PathBuf = dir.join("main.php");
+    fs::write(&php_path, source).expect("failed to write determinism PHP fixture");
+    let cache_root = dir.join("cache-root");
+
+    let outputs = (0..runs)
+        .map(|run| emit_asm_once(&dir, &cache_root, &php_path, run, name))
+        .collect();
+
+    let _ = fs::remove_dir_all(&dir);
+    outputs
+}
+
+/// Runs one `elephc --emit-asm` invocation and returns the assembly it wrote.
+fn emit_asm_once(
+    dir: &Path,
+    cache_root: &Path,
+    php_path: &Path,
+    run: usize,
+    name: &str,
+) -> String {
+    let compile = Command::new(elephc_cli_bin())
+        .env("XDG_CACHE_HOME", cache_root)
+        .current_dir(dir)
+        .arg("--quiet")
+        .arg("--emit-asm")
+        .arg(php_path)
+        .output()
+        .expect("failed to run elephc CLI");
+    assert!(
+        compile.status.success(),
+        "elephc failed for {name} run {run}: stderr={}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    fs::read_to_string(dir.join("main.s")).expect("failed to read emitted assembly")
+}
+
+/// Asserts every run produced the same assembly, reporting the divergence size
+/// rather than dumping megabytes of assembly into the failure output.
+fn assert_all_identical(name: &str, outputs: &[String]) {
+    let first = &outputs[0];
+    for (run, other) in outputs.iter().enumerate().skip(1) {
+        if first == other {
+            continue;
+        }
+        let differing = first
+            .lines()
+            .zip(other.lines())
+            .filter(|(a, b)| a != b)
+            .count();
+        panic!(
+            "{name}: compiling the same source twice produced different assembly \
+             (run 0 vs run {run}: {} lines differ, {} vs {} lines total). \
+             Compiler output must not depend on per-process hash ordering.",
+            differing,
+            first.lines().count(),
+            other.lines().count()
+        );
+    }
+}
+
+/// Builds a fixture with enough sibling classes that an unordered walk over the
+/// class table is astronomically unlikely to match a stable one by chance.
+fn many_classes_source() -> String {
+    let mut source = String::from("<?php\n");
+    for index in 0..12 {
+        source.push_str(&format!(
+            "class Shape{index} {{\n    private int $n = {index};\n    \
+             public function area(int $side): int {{ return $side * {}; }}\n}}\n",
+            index + 1
+        ));
+    }
+    source.push_str("$total = 0;\n");
+    for index in 0..12 {
+        source.push_str(&format!(
+            "$s{index} = new Shape{index}(); $total = $total + $s{index}->area($argc);\n"
+        ));
+    }
+    source.push_str("echo $total;\n");
+    source
+}
+
+/// Two compilations of the same class-heavy program must emit identical assembly.
+///
+/// Regression: class ids were handed out while walking a `HashMap`, whose
+/// iteration order is randomized per process. Those ids reach the output as
+/// symbol names, immediates, and `.quad` values, so two runs of an unchanged
+/// source disagreed on roughly a quarter of the emitted lines.
+#[test]
+fn class_heavy_program_emits_identical_assembly_across_processes() {
+    let outputs = emit_asm_repeatedly("classes", &many_classes_source(), 3);
+    assert_all_identical("classes", &outputs);
+}
+
+/// The same guarantee for interfaces, whose ids are assigned by a separate walk.
+#[test]
+fn interface_heavy_program_emits_identical_assembly_across_processes() {
+    let mut source = String::from("<?php\n");
+    for index in 0..10 {
+        source.push_str(&format!(
+            "interface Contract{index} {{ public function tag{index}(): int; }}\n"
+        ));
+    }
+    for index in 0..10 {
+        source.push_str(&format!(
+            "class Impl{index} implements Contract{index} {{\n    \
+             public function tag{index}(): int {{ return {index}; }}\n}}\n"
+        ));
+    }
+    source.push_str("$total = 0;\n");
+    for index in 0..10 {
+        source.push_str(&format!(
+            "$i{index} = new Impl{index}(); $total = $total + $i{index}->tag{index}();\n"
+        ));
+    }
+    source.push_str("echo $total;\n");
+
+    let outputs = emit_asm_repeatedly("interfaces", &source, 3);
+    assert_all_identical("interfaces", &outputs);
+}
+
+/// Enums share the class-id counter, so they need the same guarantee.
+#[test]
+fn enum_heavy_program_emits_identical_assembly_across_processes() {
+    let mut source = String::from("<?php\n");
+    for index in 0..8 {
+        source.push_str(&format!(
+            "enum Level{index}: int {{ case Low = {}; case High = {}; }}\n",
+            index,
+            index + 100
+        ));
+    }
+    source.push_str("$total = 0;\n");
+    for index in 0..8 {
+        source.push_str(&format!("$total = $total + Level{index}::High->value;\n"));
+    }
+    source.push_str("echo $total;\n");
+
+    let outputs = emit_asm_repeatedly("enums", &source, 3);
+    assert_all_identical("enums", &outputs);
+}


### PR DESCRIPTION
## Problem

Compiling the **same unchanged source twice** produced different assembly.

On a 30-class fixture: **105 490 differing lines out of 371 914 — about 28% of the output.**

Class and interface ids are handed out while walking `class_map` and `interface_map` (`src/types/checker/driver/mod.rs`), both `HashMap`s. `HashMap` iteration order is randomized per process, so every run assigned different ids.

Those ids are not internal bookkeeping. They reach the emitted assembly three ways:

- symbol names — `_class_propinit_<id>`, `_class_vtable_<id>`, `_class_serprop_<id>`, …
- immediates — 14 392 occurrences of `mov x10, #<id>` in that one fixture
- `.quad` values in the runtime metadata tables

## Impact

**Nothing is miscompiled.** Each binary is self-consistent, and the ids only ever have to agree with themselves.

What breaks is *reproducibility*:

- two builds of the same source cannot be compared, so "did this change alter codegen?" is not answerable by diffing
- any content-addressed caching of build artifacts is impossible — a key computed from generated assembly can never hit

The second point is what surfaced this: it blocks incremental/`--watch`-style work on the build pipeline.

## Fix

Sort both walks before assigning ids. That makes the assignment a pure function of the declared names.

## Tests

`tests/compiler_determinism_tests.rs` compiles a class-heavy, an interface-heavy and an enum-heavy fixture three times each, asserting the emitted assembly is byte-identical.

Two details that matter and are commented in the file:

- **Each compilation runs in its own process.** A single process reuses one `HashMap` seed, so an in-process pair would not exercise the difference.
- **All runs compile the same file in the same directory.** The canonicalized source path is baked into the output (`__FILE__`, `Throwable::getFile()`), so compiling sibling copies would report a path difference as a reproducibility failure. This was caught while writing the test — the first version failed on exactly one line for that reason.

Verified the tests actually catch the bug: with the sorts removed they report ~8 900 differing lines; with the fix, all three pass.

## Verification

| suite | result |
|---|---|
| `--test compiler_determinism_tests` | 3 passed |
| `--test codegen_tests instanceof` | 32 passed |
| `--test codegen_tests enum` | 78 passed |
| `--test codegen_tests classes` | 78 passed |
| `--test codegen_tests interface` | 102 passed |

Also checked by hand: three consecutive compilations of `showcases/doom` (32 files, inheritance, interfaces, enums) now emit identical assembly, where before they did not.

## Note

This does not prove the compiler is reproducible overall — it fixes the source measured here. Other unordered walks may remain in codegen or metadata emission. A repo-wide reproducibility gate would be the way to establish that, and is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)