### PR TITLE
perf(ir): eliminate transient boxing for integer-only checked arithmetic

### DIFF
--- a/.plans/issue-623-int-sink-checked-arithmetic.md
+++ b/.plans/issue-623-int-sink-checked-arithmetic.md
@@ -1,0 +1,146 @@
+# Issue 623: Non-Boxing Checked Integer Arithmetic for Int Sinks
+
+## Task Checklist
+
+- [x] Add scalar checked-to-int EIR operations with PHP-preserving overflow semantics.
+- [x] Add target-aware AArch64 and x86_64 lowering without Mixed allocation.
+- [x] Add an EIR pass that specializes checked arithmetic only when every consumer is an int sink or ownership cleanup.
+- [x] Classify scalar loads from provably immutable local slots so CSE can canonicalize them and LICM can hoist them.
+- [x] Register the pass before constant folding, CSE, and LICM.
+- [x] Add unit tests for accepted and rejected consumer graphs.
+- [x] Add structural CSE and LICM integration regressions.
+- [x] Pin optimized/unoptimized overflow parity and mixed-observer behavior.
+- [x] Prove per-iteration Mixed allocations disappear under heap debug.
+- [x] Correct the buffer documentation's overly literal single-instruction claim.
+- [x] Run focused macOS, Linux x86_64, and Linux AArch64 validation plus hygiene checks.
+
+## Semantic Contract
+
+Non-constant integer `+`, `-`, and `*` lower to `ICheckedAdd`, `ICheckedSub`,
+and `ICheckedMul` when PHP overflow promotion can make the result a float. The
+existing operations return an owned boxed `Mixed`, which correctly preserves the
+dynamic result for mixed-observing consumers but prevents CSE and LICM.
+
+The optimization must not replace these operations with wrapping `IAdd`, `ISub`,
+or `IMul`. Current `main` implements PHP 8.4 float-to-int conversion through
+`__rt_php_float_to_int`, including modulo-2^64 conversion for finite out-of-range
+doubles. Optimized and `--no-ir-opt` programs must remain behaviorally identical.
+
+Introduce `ICheckedAddToInt`, `ICheckedSubToInt`, and `ICheckedMulToInt`. Each
+operation returns `I64` / `PhpType::Int` / `Ownership::NonHeap`, has pure semantic
+effects, and computes the same value as:
+
+1. the corresponding boxed checked arithmetic operation;
+2. followed by PHP's integer cast of that dynamic result.
+
+The in-range fast path returns the native integer result directly. The overflow
+path converts the original operands to double, performs the floating-point
+operation, and routes the result through `__rt_php_float_to_int`. No Mixed cell is
+allocated in either path.
+
+## Pass Design
+
+Add a dedicated `CheckedIntSink` EIR pass after `Peephole` and before
+`ConstFold`, CSE, and LICM. This is a whole-function use analysis rather than a
+local box/unbox peephole.
+
+For each checked add/sub/mul result, collect every instruction and terminator use.
+The candidate is eligible only when every path observes the value as an integer:
+
+- `Cast` with `Immediate::CastTarget(IrType::I64)` is an int sink. Its result is
+  redirected to the specialized scalar producer and the cast is neutralized.
+- `StoreLocal`, `StoreStaticLocal`, or `InitStaticLocal` is an int sink only when
+  its referenced local slot has integer storage.
+- `StoreRefCell` is an int sink only when its carried alias target type is Int.
+- A normal, unmarked `Acquire` is transparent ownership scaffolding only when
+  every use of its result recursively reaches an accepted int sink or cleanup.
+  Its result is redirected to the scalar producer and the acquire is neutralized.
+- `Release` of the checked or transparent acquired result is cleanup and is
+  neutralized after specialization.
+- Lifetime-pin acquires, terminator uses, mixed stores, output, calls,
+  comparisons, and every unknown consumer reject the candidate conservatively.
+
+The commit phase updates both instruction and value metadata, applies dominance-
+safe use replacement with the shared rewrite helpers, and neutralizes the now
+dead casts and ownership operations. The fixed-point driver handles cleanup
+exposed in later sweeps.
+
+Current-main baseline EIR also exposes a second gate that was not visible in the
+original issue description: repeated expressions reload their scalar operands
+through distinct `LoadLocal` values, and an invariant `$argc` load is emitted
+inside the loop body. Add a conservative `ImmutableLocalLoads` analysis pass:
+
+- consider only `I64` locals with concrete PHP `Int` storage;
+- reject slots named by ref-cell, alias, unset, cleanup, or any other indirect
+  mutation operation;
+- accept zero explicit stores only for initialized function/main inputs, and
+  accept one `StoreLocal` in the predecessor-free entry block only when it
+  dominates every load by instruction order;
+- mark only the proven loads pure.
+
+CSE's existing constant-operand canonicalization can then key equivalent pure
+nullary loads by `(LoadLocal, type, slot immediate)`. LICM may treat a proven-pure
+`LoadLocal` as the one permitted nullary hoist candidate, moving the load and its
+dependent checked-to-int operation together. All mutable and address-taken slots
+retain `READS_LOCAL` and remain ineligible.
+
+## Backend Design
+
+Lower the new operations through a cohesive target-aware leaf under
+`src/codegen/lower_inst/`:
+
+- AArch64 uses `adds`/`subs` or `mul`+`smulh` for overflow detection.
+- x86_64 uses the arithmetic overflow flag from `add`, `sub`, or `imul`.
+- Both targets preserve the original operands for the overflow slow path,
+  reproduce the existing int-to-double arithmetic, and call the shared PHP
+  float-to-int helper.
+- The operations stay outside the volatile-safe allowlist because the overflow
+  path may call a helper, even though their semantic effects are pure.
+- Every emitted instruction carries an aligned explanatory assembly comment.
+
+## Test Plan
+
+Unit tests build EIR directly and validate the function after every rewrite:
+
+- add/sub/mul specialization through an integer cast;
+- integer local and ref-cell stores, including current acquire/release scaffolding;
+- multiple integer sinks for one producer;
+- rejection for output, mixed store, function return, unknown consumer, and
+  lifetime-pin acquire;
+- pass idempotence and exact result metadata.
+
+Integration tests use runtime-unknown operands so AST folding cannot erase the
+targeted EIR:
+
+- repeated buffer index arithmetic becomes one scalar checked-to-int operation
+  under CSE while `--no-ir-opt` keeps two boxed checked operations;
+- loop-invariant buffer index arithmetic moves from the loop body to its
+  preheader under LICM;
+- a hot loop compiled with heap debug no longer allocates one Mixed cell per
+  integer-only arithmetic evaluation;
+- optimized and unoptimized overflow casts agree for `MAX + 1`, `MIN - 1`, and
+  `MAX * 3`;
+- `echo PHP_INT_MAX + 1` remains a mixed-observing checked operation and keeps
+  PHP float promotion.
+
+The existing CSE fixture `($n + 1) * ($n + 1)` remains a negative case: its
+outer arithmetic observes the operands dynamically, so its two checked adds must
+not be specialized.
+
+## Validation
+
+Run only focused checks:
+
+```bash
+cargo build
+cargo test --lib checked_int_sink
+cargo test --test codegen_tests checked_int_sink
+./scripts/check_asm_comments.py <touched-codegen-files>
+./scripts/test-linux-x86_64.sh checked_int_sink
+./scripts/test-linux-arm64.sh checked_int_sink
+git diff --check
+```
+
+Finally inspect optimized and unoptimized `--emit-ir`, generated assembly, and a
+release build of the issue benchmark to confirm the structural and performance
+outcomes.

--- a/docs/beyond-php/buffers.md
+++ b/docs/beyond-php/buffers.md
@@ -11,7 +11,10 @@ sidebar:
 
 ## Why not PHP arrays?
 
-PHP arrays are hash tables. Every access goes through hashing, linear probing, entry comparison. `buffer<T>` compiles to a single `ldr` instruction: `base + 16 + index * stride`.
+PHP arrays are hash tables. Every access goes through hashing, probing, and entry
+comparison. `buffer<T>` instead uses a bounds-checked direct address calculation:
+`base + 16 + index * stride`, followed by a native load or store. Repeated immutable
+integer index arithmetic can be shared or moved out of loops by the EIR optimizer.
 
 ## Creating buffers
 

--- a/docs/internals/the-ir.md
+++ b/docs/internals/the-ir.md
@@ -884,7 +884,8 @@ Textual syntax requirements:
 
 Validation has two modes:
 
-- **Structural mode:** cheap, runs after builder operations and after every pass.
+- **Structural mode:** cheap, runs after builder operations and every pass that
+  declares itself applicable to the current function.
 - **Full mode:** structural + dominance + ownership + effects, runs before
   printing for tests and before EIR backend codegen.
 
@@ -961,10 +962,12 @@ A pass implements the `IrPass` trait: a stable `name()` and a
 reports whether it changed anything. The `DataPool` is the module's shared
 literal pool, threaded through so passes that materialize new constants (the
 peephole string-literal fold interns the joined string) can do so; passes that
-need no new literals ignore it. The driver runs the registered passes over each
-function-like body (functions, methods, closures, trampolines, invokers)
-repeatedly until a full sweep reports no change, capped at a fixed iteration
-budget.
+need no new literals ignore it. The driver runs the applicable registered passes
+over each function-like body (functions, methods, closures, trampolines,
+invokers) repeatedly until a full sweep reports no change, capped at a fixed
+iteration budget. Candidate-driven passes can cheaply declare themselves
+inapplicable to a function; skipped passes perform neither analysis nor the
+debug-build post-pass validation.
 
 The whole pipeline runs to a **module-level fixed point**: `optimize_module`
 interleaves the cross-function [small-function inliner](#small-function-inlining)
@@ -976,8 +979,9 @@ candidates. The first round reproduces the prior "inline once, then optimize"
 behavior, so later rounds only optimize further and never change semantics.
 
 In debug and test builds (`debug_assertions`), the driver re-validates the
-function with `validate_function` after every pass and panics — naming the
-offending pass — if any pass produced malformed IR. The same builds panic if a
+function with `validate_function` after every pass that runs and panics — naming
+the offending pass — if it produced malformed IR. A pass skipped by its
+applicability predicate cannot mutate the function. The same builds panic if a
 pass set fails to converge within the cap, which only happens for a
 non-converging pass bug. Both guards compile out of `--release`, where hitting
 the cap simply stops and proceeds with the current IR.
@@ -1043,9 +1047,57 @@ phase commits them, sharing `replace_all_uses`, `resolve_chains`, and
   `persistent` so cleanup never frees the literal. Nested concats converge across
   driver sweeps.
 
+### Immutable Integer-Local Loads
+
+The third registered transform (`src/ir_passes/immutable_local_loads.rs`) refines
+the effect of a concrete integer `load_local` from a frame read to `pure` only
+when the slot cannot change for the lifetime of the function. It accepts two
+closed-world cases:
+
+- an unwritten, non-reference, non-variadic integer parameter, or the top-level
+  `$argc` slot; and
+- a concrete integer PHP local with exactly one store in the entry block, where
+  that store dominates every load and the entry block has no predecessor.
+
+Hidden temporaries, Mixed storage, reference cells, static locals, multiple or
+non-entry stores, and any alias or otherwise unknown local-slot operation fail
+closed. The pass changes only the load's effect metadata; its result value,
+storage type, and ownership are unchanged. This gives CSE and LICM a sound way
+to reuse or hoist integer reads that lowering represents through frame slots.
+
+The analysis starts from effectful integer loads that could actually be refined.
+Already-pure loads and functions without eligible loads return before dominance
+analysis. The default issue-623 pipeline schedules this pass only for functions
+that also contain boxed checked integer arithmetic, keeping unrelated functions
+out of both the analysis and its debug-build validation.
+
+### Checked Integer Sink Specialization
+
+The fourth registered transform (`src/ir_passes/checked_int_sink.rs`) removes the
+transient Mixed allocation from checked integer add, subtract, and multiply when
+the producer's complete use graph observes only a PHP integer. It rewrites
+`ichecked_add`/`ichecked_sub`/`ichecked_mul` to the corresponding
+`ichecked_*_to_int` operation, changes the result to non-owning `I64`, redirects
+integer casts to that value, and removes the now-redundant acquire/release
+scaffolding.
+
+The proof accepts explicit integer casts, stores into concrete integer locals or
+integer ref cells, and unpinned acquire/release chains. A terminator use, output,
+call, comparison, Mixed store, lifetime pin, or unknown opcode rejects the whole
+candidate, preserving the original boxed result whenever overflow promotion can
+still be observed. Before running the full use-graph proof, the driver requires
+an integer cast/store whose value traces through transparent acquires to checked
+arithmetic. The pass also returns before building its use graph when a function
+contains no checked-arithmetic candidate.
+
+Codegen keeps the in-range path in scalar registers. On signed overflow it
+recomputes the operation as a double and applies the shared PHP float-to-int
+conversion, so removing the box does not change PHP's overflow semantics. The
+typed opcode is implemented for macOS AArch64, Linux AArch64, and Linux x86_64.
+
 ### Constant Folding
 
-The third registered transform (`src/ir_passes/const_fold.rs`) folds operations
+The fifth registered transform (`src/ir_passes/const_fold.rs`) folds operations
 whose operands are all compile-time constants into a single `const_*`
 instruction, rewriting the instruction in place and keeping its result value id
 (no use-rewrite needed). A single forward scan over the instruction table tracks
@@ -1074,7 +1126,7 @@ instruction elimination.
 
 ### Common Subexpression Elimination
 
-The fourth registered transform (`src/ir_passes/cse.rs`) removes a pure
+The sixth registered transform (`src/ir_passes/cse.rs`) removes a pure
 computation whose identical predecessor already dominates it, redirecting the
 redundant result to the earlier value (RAUW) and neutralizing it to `nop`. It
 covers per-block and cross-block redundancy in one dominator-tree value-numbering
@@ -1104,7 +1156,7 @@ redirect unsound — the same restriction branch simplification uses. CSE uses t
 
 ### Loop-Invariant Code Motion
 
-The fifth registered transform (`src/ir_passes/licm.rs`) moves a pure computation
+The seventh registered transform (`src/ir_passes/licm.rs`) moves a pure computation
 whose operands do not change across a loop out of the loop body into the loop
 preheader, so it runs once instead of per iteration. It builds the
 [loop forest](#loop-analysis) on the [dominator tree](#dominance-analysis), then
@@ -1130,7 +1182,7 @@ pass's reach grows as more values flow as SSA across loops.)
 
 ### Dead Instruction Elimination
 
-The sixth registered transform (`src/ir_passes/dead_inst.rs`) removes
+The eighth registered transform (`src/ir_passes/dead_inst.rs`) removes
 result-producing instructions whose values are not live over the CFG and whose
 effect metadata says they are pure. It computes liveness with successor live-in
 sets, initializes each block's backward walk with those live-out values plus
@@ -1146,7 +1198,7 @@ through the fixed-point pass driver after liveness is recomputed.
 
 ### Dead Store Elimination
 
-The seventh registered transform (`src/ir_passes/dead_store.rs`) removes
+The ninth registered transform (`src/ir_passes/dead_store.rs`) removes
 `store_local` instructions whose stored value is never read on any path before
 the slot is overwritten or the function exits. Unlike dead instruction
 elimination, which works at SSA-value granularity, this pass reasons about local
@@ -1191,7 +1243,7 @@ instruction elimination on a later driver sweep.
 
 ### Branch Simplification
 
-The eighth registered transform (`src/ir_passes/branch_simplify.rs`) prunes the
+The tenth registered transform (`src/ir_passes/branch_simplify.rs`) prunes the
 CFG in three ways:
 
 - **Constant-condition folding** — a `cond_br` whose condition resolves to a

--- a/docs/internals/the-optimizer.md
+++ b/docs/internals/the-optimizer.md
@@ -469,7 +469,11 @@ fixed-point pass driver (`src/ir_passes/driver.rs`) after lowering, starting wit
 identity arithmetic folding (`x + 0`, `x * 1`, `x ^ x`, …) and local peephole
 patterns (box/unbox cancellation, scalar load/store forwarding, paired
 acquire/release cancellation, string-literal concat folding, redundant
-`move`/`borrow` cleanup), then per-block constant folding that collapses
+`move`/`borrow` cleanup), then immutable integer-local classification and
+integer-sink specialization for checked add/subtract/multiply. Those passes make
+proven-stable local loads pure and replace transient boxed Mixed arithmetic with
+allocation-free `ichecked_*_to_int` operations only when every use observes an
+integer. Per-block constant folding then collapses
 operations whose operands are all compile-time constants (`5 * 5` → `25`,
 `0 < 5` → `true`) into a single constant — which, composed with the peephole's
 scalar load/store forwarding, propagates constants through EIR value ids and

--- a/src/codegen/lower_inst.rs
+++ b/src/codegen/lower_inst.rs
@@ -36,6 +36,7 @@ use super::{CodegenIrError, Result};
 mod arithmetic;
 mod arrays;
 mod buffers;
+mod checked_int_to_int;
 mod runtime_functions;
 pub(crate) mod builtins;
 mod callables;
@@ -176,6 +177,21 @@ pub(super) fn lower_instruction(ctx: &mut FunctionContext<'_>, inst_id: InstId) 
         Op::ICheckedAdd => arithmetic::lower_int_checked_binop(ctx, &inst, "__rt_int_add_checked"),
         Op::ICheckedSub => arithmetic::lower_int_checked_binop(ctx, &inst, "__rt_int_sub_checked"),
         Op::ICheckedMul => arithmetic::lower_int_checked_binop(ctx, &inst, "__rt_int_mul_checked"),
+        Op::ICheckedAddToInt => checked_int_to_int::lower_checked_int_to_int(
+            ctx,
+            &inst,
+            checked_int_to_int::CheckedIntOp::Add,
+        ),
+        Op::ICheckedSubToInt => checked_int_to_int::lower_checked_int_to_int(
+            ctx,
+            &inst,
+            checked_int_to_int::CheckedIntOp::Sub,
+        ),
+        Op::ICheckedMulToInt => checked_int_to_int::lower_checked_int_to_int(
+            ctx,
+            &inst,
+            checked_int_to_int::CheckedIntOp::Mul,
+        ),
         Op::ICheckedPow => arithmetic::lower_int_checked_binop(ctx, &inst, "__rt_int_pow_checked"),
         Op::IDiv => arithmetic::lower_int_div_to_float(ctx, &inst),
         Op::ISMod => arithmetic::lower_int_mod(ctx, &inst),

--- a/src/codegen/lower_inst/arithmetic.rs
+++ b/src/codegen/lower_inst/arithmetic.rs
@@ -297,7 +297,7 @@ pub(super) fn lower_int_shift(
 }
 
 /// Loads an integer arithmetic operand, coercing PHP null to integer zero.
-fn load_integer_operand(
+pub(super) fn load_integer_operand(
     ctx: &mut FunctionContext<'_>,
     value: ValueId,
     reg: &str,

--- a/src/codegen/lower_inst/checked_int_to_int.rs
+++ b/src/codegen/lower_inst/checked_int_to_int.rs
@@ -94,6 +94,7 @@ fn emit_aarch64_checked(
     overflow_label: &str,
     done_label: &str,
 ) {
+    // -- compute the scalar result and detect signed overflow --
     ctx.emitter.instruction(&format!("mov {}, {}", saved_lhs_reg, result_reg)); // preserve the original left operand for overflow promotion
     match op {
         CheckedIntOp::Add => {
@@ -125,6 +126,7 @@ fn emit_x86_64_checked(
     overflow_label: &str,
     done_label: &str,
 ) {
+    // -- compute the scalar result and detect signed overflow --
     ctx.emitter.instruction(&format!("mov {}, {}", saved_lhs_reg, result_reg)); // preserve the original left operand for overflow promotion
     let mnemonic = match op {
         CheckedIntOp::Add => "add",
@@ -144,6 +146,7 @@ fn emit_overflow_conversion(
     rhs_reg: &str,
 ) {
     let mnemonic = op.float_mnemonic(ctx.emitter.target.arch);
+    // -- reproduce PHP's overflow promotion in floating-point registers --
     match ctx.emitter.target.arch {
         Arch::AArch64 => {
             ctx.emitter.instruction(&format!("scvtf d0, {}", lhs_reg));         // promote the original left integer operand to double

--- a/src/codegen/lower_inst/checked_int_to_int.rs
+++ b/src/codegen/lower_inst/checked_int_to_int.rs
@@ -1,0 +1,159 @@
+//! Purpose:
+//! Lowers checked integer arithmetic whose only observable result is a PHP `int`.
+//! Keeps the in-range path scalar and reproduces PHP overflow-to-float-to-int semantics.
+//!
+//! Called from:
+//! - `crate::codegen::lower_inst::lower_instruction()` for `IChecked*ToInt` opcodes.
+//!
+//! Key details:
+//! - The overflow path performs the same double arithmetic as boxed checked operators,
+//!   then uses the shared exact PHP float-to-int conversion on every supported target.
+//! - The helper call preserves the original arithmetic operands and allocates no Mixed cell.
+
+use crate::codegen::abi;
+use crate::codegen::platform::Arch;
+use crate::codegen::Result;
+use crate::ir::Instruction;
+
+use super::super::context::FunctionContext;
+use super::{arithmetic::load_integer_operand, expect_operand, store_if_result};
+
+/// Checked arithmetic operation selected by the typed EIR opcode.
+#[derive(Clone, Copy)]
+pub(super) enum CheckedIntOp {
+    Add,
+    Sub,
+    Mul,
+}
+
+impl CheckedIntOp {
+    /// Returns the target mnemonic for the overflow-to-double slow path.
+    fn float_mnemonic(self, arch: Arch) -> &'static str {
+        match (self, arch) {
+            (Self::Add, Arch::AArch64) => "fadd",
+            (Self::Sub, Arch::AArch64) => "fsub",
+            (Self::Mul, Arch::AArch64) => "fmul",
+            (Self::Add, Arch::X86_64) => "addsd",
+            (Self::Sub, Arch::X86_64) => "subsd",
+            (Self::Mul, Arch::X86_64) => "mulsd",
+        }
+    }
+}
+
+/// Lowers checked add/sub/mul directly to the PHP integer observed by the sink.
+pub(super) fn lower_checked_int_to_int(
+    ctx: &mut FunctionContext<'_>,
+    inst: &Instruction,
+    op: CheckedIntOp,
+) -> Result<()> {
+    let lhs = expect_operand(inst, 0)?;
+    let rhs = expect_operand(inst, 1)?;
+    let result_reg = abi::int_result_reg(ctx.emitter);
+    let rhs_reg = abi::secondary_scratch_reg(ctx.emitter);
+    let saved_lhs_reg = abi::tertiary_scratch_reg(ctx.emitter);
+    load_integer_operand(ctx, lhs, result_reg, inst)?;
+    load_integer_operand(ctx, rhs, rhs_reg, inst)?;
+    let overflow_label = ctx.next_label("checked_int_to_int_overflow");
+    let done_label = ctx.next_label("checked_int_to_int_done");
+
+    match ctx.emitter.target.arch {
+        Arch::AArch64 => emit_aarch64_checked(
+            ctx,
+            op,
+            result_reg,
+            rhs_reg,
+            saved_lhs_reg,
+            &overflow_label,
+            &done_label,
+        ),
+        Arch::X86_64 => emit_x86_64_checked(
+            ctx,
+            op,
+            result_reg,
+            rhs_reg,
+            saved_lhs_reg,
+            &overflow_label,
+            &done_label,
+        ),
+    }
+
+    ctx.emitter.label(&overflow_label);
+    emit_overflow_conversion(ctx, op, saved_lhs_reg, rhs_reg);
+    abi::emit_php_float_to_int(ctx.emitter, result_reg);
+    ctx.emitter.label(&done_label);
+    store_if_result(ctx, inst)
+}
+
+/// Emits the AArch64 scalar fast path and branches to the shared overflow path.
+fn emit_aarch64_checked(
+    ctx: &mut FunctionContext<'_>,
+    op: CheckedIntOp,
+    result_reg: &str,
+    rhs_reg: &str,
+    saved_lhs_reg: &str,
+    overflow_label: &str,
+    done_label: &str,
+) {
+    ctx.emitter.instruction(&format!("mov {}, {}", saved_lhs_reg, result_reg)); // preserve the original left operand for overflow promotion
+    match op {
+        CheckedIntOp::Add => {
+            ctx.emitter.instruction(&format!("adds {}, {}, {}", result_reg, result_reg, rhs_reg)); // compute addition and set the signed-overflow flag
+            ctx.emitter.instruction(&format!("b.vs {}", overflow_label));       // convert the promoted double only when signed addition overflowed
+        }
+        CheckedIntOp::Sub => {
+            ctx.emitter.instruction(&format!("subs {}, {}, {}", result_reg, result_reg, rhs_reg)); // compute subtraction and set the signed-overflow flag
+            ctx.emitter.instruction(&format!("b.vs {}", overflow_label));       // convert the promoted double only when signed subtraction overflowed
+        }
+        CheckedIntOp::Mul => {
+            let high_reg = abi::symbol_scratch_reg(ctx.emitter);
+            ctx.emitter.instruction(&format!("smulh {}, {}, {}", high_reg, result_reg, rhs_reg)); // compute the signed high product for overflow detection
+            ctx.emitter.instruction(&format!("mul {}, {}, {}", result_reg, result_reg, rhs_reg)); // compute the low 64 bits of the signed product
+            ctx.emitter.instruction(&format!("cmp {}, {}, asr #63", high_reg, result_reg)); // compare the high product with the low half's sign extension
+            ctx.emitter.instruction(&format!("b.ne {}", overflow_label));       // convert the promoted double when the product does not fit in I64
+        }
+    }
+    ctx.emitter.instruction(&format!("b {}", done_label));                      // keep the in-range scalar result and skip overflow conversion
+}
+
+/// Emits the x86_64 scalar fast path and branches to the shared overflow path.
+fn emit_x86_64_checked(
+    ctx: &mut FunctionContext<'_>,
+    op: CheckedIntOp,
+    result_reg: &str,
+    rhs_reg: &str,
+    saved_lhs_reg: &str,
+    overflow_label: &str,
+    done_label: &str,
+) {
+    ctx.emitter.instruction(&format!("mov {}, {}", saved_lhs_reg, result_reg)); // preserve the original left operand for overflow promotion
+    let mnemonic = match op {
+        CheckedIntOp::Add => "add",
+        CheckedIntOp::Sub => "sub",
+        CheckedIntOp::Mul => "imul",
+    };
+    ctx.emitter.instruction(&format!("{} {}, {}", mnemonic, result_reg, rhs_reg)); // compute the scalar result and set the signed-overflow flag
+    ctx.emitter.instruction(&format!("jo {}", overflow_label));                 // convert the promoted double only when the operation overflowed
+    ctx.emitter.instruction(&format!("jmp {}", done_label));                    // keep the in-range scalar result and skip overflow conversion
+}
+
+/// Recomputes an overflowing operation as double, matching PHP's promotion path.
+fn emit_overflow_conversion(
+    ctx: &mut FunctionContext<'_>,
+    op: CheckedIntOp,
+    lhs_reg: &str,
+    rhs_reg: &str,
+) {
+    let mnemonic = op.float_mnemonic(ctx.emitter.target.arch);
+    match ctx.emitter.target.arch {
+        Arch::AArch64 => {
+            ctx.emitter.instruction(&format!("scvtf d0, {}", lhs_reg));         // promote the original left integer operand to double
+            ctx.emitter.instruction(&format!("scvtf d1, {}", rhs_reg));         // promote the original right integer operand to double
+            ctx.emitter.instruction(&format!("{} d0, d0, d1", mnemonic));       // reproduce PHP's overflow-promoted double arithmetic
+        }
+        Arch::X86_64 => {
+            ctx.emitter.instruction(&format!("cvtsi2sd xmm0, {}", lhs_reg));    // promote the original left integer operand to double
+            ctx.emitter.instruction(&format!("cvtsi2sd xmm1, {}", rhs_reg));    // promote the original right integer operand to double
+            ctx.emitter.instruction(&format!("{} xmm0, xmm1", mnemonic));       // reproduce PHP's overflow-promoted double arithmetic
+        }
+    }
+}

--- a/src/ir/instr.rs
+++ b/src/ir/instr.rs
@@ -274,6 +274,15 @@ pub enum Op {
     ICheckedAdd,
     ICheckedSub,
     ICheckedMul,
+    /// Adds two integers with PHP overflow promotion, then applies PHP's integer cast
+    /// without materializing the intermediate boxed `Mixed` value.
+    ICheckedAddToInt,
+    /// Subtracts two integers with PHP overflow promotion, then applies PHP's integer
+    /// cast without materializing the intermediate boxed `Mixed` value.
+    ICheckedSubToInt,
+    /// Multiplies two integers with PHP overflow promotion, then applies PHP's integer
+    /// cast without materializing the intermediate boxed `Mixed` value.
+    ICheckedMulToInt,
     ICheckedPow,
     IDiv,
     ISDiv,
@@ -560,6 +569,9 @@ impl Op {
             | IAdd
             | ISub
             | IMul
+            | ICheckedAddToInt
+            | ICheckedSubToInt
+            | ICheckedMulToInt
             | IPow
             | INeg
             | IBitAnd
@@ -836,6 +848,9 @@ impl Op {
             ICheckedAdd => "ichecked_add",
             ICheckedSub => "ichecked_sub",
             ICheckedMul => "ichecked_mul",
+            ICheckedAddToInt => "ichecked_add_to_int",
+            ICheckedSubToInt => "ichecked_sub_to_int",
+            ICheckedMulToInt => "ichecked_mul_to_int",
             ICheckedPow => "ichecked_pow",
             IDiv => "idiv",
             ISDiv => "isdiv",

--- a/src/ir/validator.rs
+++ b/src/ir/validator.rs
@@ -421,7 +421,8 @@ fn validate_opcode_rules(
         EvalStaticMethodCall => Ok(()),
         IAdd | ISub | IMul | IDiv | ISDiv | ISMod | IPow | IBitAnd | IBitOr | IBitXor
         | IShl | IShrA => check_binary(function, inst_id, inst, IrType::I64, "I64"),
-        ICheckedAdd | ICheckedSub | ICheckedMul | ICheckedPow => {
+        ICheckedAdd | ICheckedSub | ICheckedMul | ICheckedAddToInt | ICheckedSubToInt
+        | ICheckedMulToInt | ICheckedPow => {
             check_binary(function, inst_id, inst, IrType::I64, "I64")
         }
         FAdd | FSub | FMul | FDiv | FPow => check_binary(function, inst_id, inst, IrType::F64, "F64"),

--- a/src/ir/validator.rs
+++ b/src/ir/validator.rs
@@ -272,12 +272,18 @@ fn validate_instruction_result(
 }
 
 /// Validates that non-refinable opcodes carry their canonical effect set.
+/// `load_local` additionally admits exactly `PURE`, which is attached only after
+/// the immutable-local pass proves that the named scalar slot cannot change.
 fn validate_instruction_effects(
     inst_id: InstId,
     inst: &Instruction,
 ) -> Result<(), ValidationError> {
     let expected = inst.op.default_effects();
-    if !inst.op.allows_effect_refinement() && inst.effects != expected {
+    let immutable_local_refinement = inst.op == Op::LoadLocal && inst.effects.is_pure();
+    if !inst.op.allows_effect_refinement()
+        && !immutable_local_refinement
+        && inst.effects != expected
+    {
         return Err(ValidationError::EffectMismatch {
             inst: inst_id,
             expected,

--- a/src/ir_passes/checked_int_sink.rs
+++ b/src/ir_passes/checked_int_sink.rs
@@ -1,0 +1,230 @@
+//! Purpose:
+//! Specializes boxed checked integer add/sub/mul when every observation narrows to `int`.
+//! Removes the transient Mixed allocation without changing PHP overflow semantics.
+//!
+//! Called from:
+//! - The fixed-point pass driver after peephole and immutable-local classification.
+//!
+//! Key details:
+//! - The accepted use graph contains only integer casts/stores plus ordinary acquire/release
+//!   scaffolding. Returns, output, calls, comparisons, Mixed stores, terminators, lifetime pins,
+//!   and unknown/future opcodes reject the candidate.
+//! - Rewritten producers yield non-owning I64 values through `IChecked*ToInt`; removable casts
+//!   and ownership instructions are neutralized only after every use has been proven safe.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::ir::{
+    DataPool, Function, Immediate, InstId, IrType, LocalSlotId, Op, Ownership, ValueId,
+};
+use crate::types::PhpType;
+
+use super::driver::IrPass;
+use super::rewrite::{neutralize_to_nop, replace_all_uses, resolve_chains};
+
+/// Rewrites checked arithmetic whose complete use graph observes only a PHP integer.
+pub struct CheckedIntSink;
+
+impl IrPass for CheckedIntSink {
+    /// Returns the stable pass name used in driver diagnostics.
+    fn name(&self) -> &'static str {
+        "checked_int_sink"
+    }
+
+    /// Specializes every independently proven checked-arithmetic producer in the function.
+    fn run(&self, function: &mut Function, _data: &mut DataPool) -> bool {
+        let uses = instruction_uses(function);
+        let terminator_uses = terminator_used_values(function);
+        let candidates: Vec<InstId> = function
+            .instructions
+            .iter()
+            .enumerate()
+            .filter_map(|(raw, inst)| checked_to_int_op(inst.op).map(|_| InstId::from_raw(raw as u32)))
+            .collect();
+        let mut changed = false;
+
+        for candidate in candidates {
+            let Some(inst) = function.instruction(candidate) else {
+                continue;
+            };
+            let Some(result) = inst.result else {
+                continue;
+            };
+            let mut rewrite = SinkRewrite::default();
+            if !analyze_sink_graph(
+                function,
+                result,
+                &uses,
+                &terminator_uses,
+                &mut HashSet::new(),
+                &mut rewrite,
+            ) || !rewrite.saw_integer_sink
+            {
+                continue;
+            }
+
+            apply_specialization(function, candidate, result, rewrite);
+            changed = true;
+        }
+        changed
+    }
+}
+
+/// Deferred mutations collected while proving one candidate's entire use graph.
+#[derive(Default)]
+struct SinkRewrite {
+    replacements: HashMap<ValueId, ValueId>,
+    neutralize: HashSet<InstId>,
+    saw_integer_sink: bool,
+}
+
+/// Builds the instruction-use adjacency list for every SSA value.
+fn instruction_uses(function: &Function) -> HashMap<ValueId, Vec<InstId>> {
+    let mut uses: HashMap<ValueId, Vec<InstId>> = HashMap::new();
+    for (raw, inst) in function.instructions.iter().enumerate() {
+        let inst_id = InstId::from_raw(raw as u32);
+        for operand in &inst.operands {
+            uses.entry(*operand).or_default().push(inst_id);
+        }
+    }
+    uses
+}
+
+/// Returns every SSA value read by a terminator, which is never an integer-only sink here.
+fn terminator_used_values(function: &Function) -> HashSet<ValueId> {
+    function
+        .blocks
+        .iter()
+        .filter_map(|block| block.terminator.as_ref())
+        .flat_map(super::liveness::terminator_uses)
+        .collect()
+}
+
+/// Proves that every use of `value` is an accepted integer sink or removable scaffold.
+fn analyze_sink_graph(
+    function: &Function,
+    value: ValueId,
+    uses: &HashMap<ValueId, Vec<InstId>>,
+    terminator_uses: &HashSet<ValueId>,
+    visited: &mut HashSet<ValueId>,
+    rewrite: &mut SinkRewrite,
+) -> bool {
+    if !visited.insert(value) {
+        return true;
+    }
+    if terminator_uses.contains(&value) {
+        return false;
+    }
+    let Some(value_uses) = uses.get(&value) else {
+        return false;
+    };
+    for use_id in value_uses {
+        let Some(user) = function.instruction(*use_id) else {
+            return false;
+        };
+        match user.op {
+            Op::Cast if matches!(user.immediate, Some(Immediate::CastTarget(IrType::I64))) => {
+                let Some(cast_result) = user.result else {
+                    return false;
+                };
+                rewrite.replacements.insert(cast_result, value);
+                rewrite.neutralize.insert(*use_id);
+                rewrite.saw_integer_sink = true;
+            }
+            Op::StoreLocal | Op::StoreStaticLocal | Op::InitStaticLocal
+                if local_store_is_integer(function, user.immediate.as_ref()) =>
+            {
+                rewrite.saw_integer_sink = true;
+            }
+            Op::StoreRefCell
+                if matches!(user.result_php_type.codegen_repr(), PhpType::Int) =>
+            {
+                rewrite.saw_integer_sink = true;
+            }
+            Op::Acquire if user.immediate.is_none() => {
+                let Some(acquired) = user.result else {
+                    return false;
+                };
+                if !analyze_sink_graph(
+                    function,
+                    acquired,
+                    uses,
+                    terminator_uses,
+                    visited,
+                    rewrite,
+                ) {
+                    return false;
+                }
+                rewrite.replacements.insert(acquired, value);
+                rewrite.neutralize.insert(*use_id);
+            }
+            Op::Release => {
+                rewrite.neutralize.insert(*use_id);
+            }
+            _ => return false,
+        }
+    }
+    true
+}
+
+/// Returns true when a local-slot immediate names concrete integer storage.
+fn local_store_is_integer(function: &Function, immediate: Option<&Immediate>) -> bool {
+    let Some(Immediate::LocalSlot(slot)) = immediate else {
+        return false;
+    };
+    integer_local(function, *slot)
+}
+
+/// Checks that a local slot uses the concrete I64/PHP-int frame representation.
+fn integer_local(function: &Function, slot: LocalSlotId) -> bool {
+    function
+        .locals
+        .get(slot.as_raw() as usize)
+        .is_some_and(|local| {
+            local.ir_type == IrType::I64
+                && matches!(local.php_type.codegen_repr(), PhpType::Int)
+        })
+}
+
+/// Maps one boxed checked opcode to its allocation-free int-observing counterpart.
+fn checked_to_int_op(op: Op) -> Option<Op> {
+    match op {
+        Op::ICheckedAdd => Some(Op::ICheckedAddToInt),
+        Op::ICheckedSub => Some(Op::ICheckedSubToInt),
+        Op::ICheckedMul => Some(Op::ICheckedMulToInt),
+        _ => None,
+    }
+}
+
+/// Commits a proven specialization, redirects scalar uses, and erases old scaffolding.
+fn apply_specialization(
+    function: &mut Function,
+    candidate: InstId,
+    result: ValueId,
+    rewrite: SinkRewrite,
+) {
+    let replacements = resolve_chains(&rewrite.replacements);
+    replace_all_uses(function, &replacements);
+    for inst_id in rewrite.neutralize {
+        if let Some(inst) = function.instruction_mut(inst_id) {
+            neutralize_to_nop(inst);
+        }
+    }
+
+    let replacement_op = function
+        .instruction(candidate)
+        .and_then(|inst| checked_to_int_op(inst.op))
+        .expect("checked-int sink candidate retained its opcode until commit");
+    if let Some(inst) = function.instruction_mut(candidate) {
+        inst.op = replacement_op;
+        inst.result_type = IrType::I64;
+        inst.result_php_type = PhpType::Int;
+        inst.result_ownership = Ownership::NonHeap;
+        inst.effects = replacement_op.default_effects();
+    }
+    if let Some(value) = function.value_mut(result) {
+        value.ir_type = IrType::I64;
+        value.php_type = PhpType::Int;
+        value.ownership = Ownership::NonHeap;
+    }
+}

--- a/src/ir_passes/checked_int_sink.rs
+++ b/src/ir_passes/checked_int_sink.rs
@@ -31,16 +31,25 @@ impl IrPass for CheckedIntSink {
         "checked_int_sink"
     }
 
+    /// Skips functions without an integer sink reachable from checked arithmetic.
+    fn is_applicable(&self, function: &Function) -> bool {
+        has_potential_integer_sink(function)
+    }
+
     /// Specializes every independently proven checked-arithmetic producer in the function.
     fn run(&self, function: &mut Function, _data: &mut DataPool) -> bool {
-        let uses = instruction_uses(function);
-        let terminator_uses = terminator_used_values(function);
         let candidates: Vec<InstId> = function
             .instructions
             .iter()
             .enumerate()
             .filter_map(|(raw, inst)| checked_to_int_op(inst.op).map(|_| InstId::from_raw(raw as u32)))
             .collect();
+        if candidates.is_empty() {
+            return false;
+        }
+
+        let uses = instruction_uses(function);
+        let terminator_uses = terminator_used_values(function);
         let mut changed = false;
 
         for candidate in candidates {
@@ -98,6 +107,51 @@ fn terminator_used_values(function: &Function) -> HashSet<ValueId> {
         .filter_map(|block| block.terminator.as_ref())
         .flat_map(super::liveness::terminator_uses)
         .collect()
+}
+
+/// Returns whether an accepted integer sink is fed by checked arithmetic through acquires.
+fn has_potential_integer_sink(function: &Function) -> bool {
+    function.instructions.iter().any(|user| {
+        let accepts_integer = match user.op {
+            Op::Cast => matches!(user.immediate, Some(Immediate::CastTarget(IrType::I64))),
+            Op::StoreLocal | Op::StoreStaticLocal | Op::InitStaticLocal => {
+                local_store_is_integer(function, user.immediate.as_ref())
+            }
+            Op::StoreRefCell => matches!(user.result_php_type.codegen_repr(), PhpType::Int),
+            _ => false,
+        };
+        accepts_integer
+            && user
+                .operands
+                .iter()
+                .any(|operand| value_originates_from_checked(function, *operand))
+    })
+}
+
+/// Follows transparent acquire definitions back to a boxed checked-arithmetic producer.
+fn value_originates_from_checked(function: &Function, mut value: ValueId) -> bool {
+    for _ in 0..function.values.len() {
+        let Some(value_ref) = function.values.get(value.as_raw() as usize) else {
+            return false;
+        };
+        let crate::ir::ValueDef::Instruction { inst, .. } = value_ref.def else {
+            return false;
+        };
+        let Some(definition) = function.instruction(inst) else {
+            return false;
+        };
+        if checked_to_int_op(definition.op).is_some() {
+            return true;
+        }
+        if definition.op != Op::Acquire || definition.immediate.is_some() {
+            return false;
+        }
+        let Some(operand) = definition.operands.first() else {
+            return false;
+        };
+        value = *operand;
+    }
+    false
 }
 
 /// Proves that every use of `value` is an accepted integer sink or removable scaffold.

--- a/src/ir_passes/dead_store.rs
+++ b/src/ir_passes/dead_store.rs
@@ -204,7 +204,9 @@ fn op_is_value_only_consumer(op: Op) -> bool {
     matches!(
         op,
         // Integer/float arithmetic and bitwise operators.
-        IAdd | ISub | IMul | ICheckedAdd | ICheckedSub | ICheckedMul | ICheckedPow | IDiv | ISDiv | ISMod | IPow | INeg | IBitAnd | IBitOr | IBitXor
+        IAdd | ISub | IMul | ICheckedAdd | ICheckedSub | ICheckedMul | ICheckedAddToInt
+            | ICheckedSubToInt | ICheckedMulToInt | ICheckedPow | IDiv | ISDiv | ISMod
+            | IPow | INeg | IBitAnd | IBitOr | IBitXor
             | IBitNot | IShl | IShrA | FAdd | FSub | FMul | FDiv | FPow | FNeg | MixedNumericBinop
             // Comparisons.
             | ICmp | FCmp | StrEq | StrCmp | StrLooseEq | StrictEq | StrictNotEq | LooseEq

--- a/src/ir_passes/driver.rs
+++ b/src/ir_passes/driver.rs
@@ -25,11 +25,13 @@
 use crate::ir::{DataPool, Function, Module};
 
 use super::branch_simplify::BranchSimplify;
+use super::checked_int_sink::CheckedIntSink;
 use super::const_fold::ConstFold;
 use super::cse::Cse;
 use super::dead_inst::DeadInst;
 use super::dead_store::DeadStore;
 use super::identity_arith::IdentityArith;
+use super::immutable_local_loads::ImmutableLocalLoads;
 use super::licm::Licm;
 use super::peephole::Peephole;
 
@@ -61,26 +63,27 @@ pub trait IrPass {
 }
 
 /// Builds the ordered set of transformation passes run on every function:
-/// identity arithmetic folding, peephole rewrites, constant folding,
-/// common-subexpression elimination, loop-invariant code motion, dead
-/// instruction elimination, dead store elimination, and branch simplification.
+/// identity arithmetic folding, peephole rewrites, immutable-local discovery,
+/// checked-arithmetic int-sink specialization, constant folding, common-subexpression
+/// elimination, loop-invariant code motion, dead instruction elimination, dead store
+/// elimination, and branch simplification.
 /// The cross-function small-function inliner is not a member here; it runs as a
 /// module-level phase in `optimize_module`, interleaved with these passes.
 ///
-/// Constant folding runs after peephole so the scalar load/store forwarding has
-/// already moved constants stored to local slots onto their `load_local` uses,
-/// exposing constant-operand operations for it to fold. CSE then runs after
-/// folding so it deduplicates pure computations over the already-canonicalized
-/// constants (the constants themselves are left for the backend to
-/// rematerialize). LICM then hoists loop-invariant pure computations into loop
+/// Constant folding runs after peephole and the two issue-623 passes: immutable
+/// scalar local loads become pure operands, and checked operations observed only
+/// through integer sinks become allocation-free `IChecked*ToInt` computations.
+/// CSE can then deduplicate those computations using canonical immutable loads,
+/// while LICM can move both the loads and their dependent arithmetic into loop
 /// preheaders. The redundant or relocated instructions these leave behind are
 /// cleaned up by dead instruction elimination, and any folded branch condition is
-/// collapsed by branch simplification — all converging through the fixed-point
-/// loop.
+/// collapsed by branch simplification — all converging through the fixed-point loop.
 fn default_passes() -> Vec<Box<dyn IrPass>> {
     vec![
         Box::new(IdentityArith),
         Box::new(Peephole),
+        Box::new(ImmutableLocalLoads),
+        Box::new(CheckedIntSink),
         Box::new(ConstFold),
         Box::new(Cse),
         Box::new(Licm),

--- a/src/ir_passes/driver.rs
+++ b/src/ir_passes/driver.rs
@@ -1,7 +1,7 @@
 //! Purpose:
 //! Fixed-point driver for mutating EIR transformation passes. Runs the
-//! registered passes over each function repeatedly until none reports a change,
-//! re-validating the function after every pass in debug/test builds.
+//! applicable registered passes over each function repeatedly until none reports
+//! a change, re-validating the function after every pass that runs in debug/test builds.
 //!
 //! Called from:
 //! - `crate::pipeline::compile()` via `optimize_module`, after AST-to-EIR
@@ -17,10 +17,10 @@
 //!   (or expose calls) so the next round can inline more. The first round
 //!   reproduces the previous "inline once, then optimize" behavior; later rounds
 //!   only add optimization, never change semantics.
-//! - Validation after each pass and the per-function non-convergence panic are
-//!   gated on `debug_assertions`, so they are active in `cargo build`/`cargo test`
-//!   and compile out of `--release`. In release, hitting either iteration cap
-//!   simply stops and proceeds with the current IR.
+//! - Validation after each applicable pass and the per-function non-convergence
+//!   panic are gated on `debug_assertions`, so they are active in `cargo build`/
+//!   `cargo test` and compile out of `--release`. In release, hitting either
+//!   iteration cap simply stops and proceeds with the current IR.
 
 use crate::ir::{DataPool, Function, Module};
 
@@ -54,6 +54,14 @@ pub trait IrPass {
     /// dead in `--release` where those guards compile out.
     #[cfg_attr(not(debug_assertions), allow(dead_code))]
     fn name(&self) -> &'static str;
+
+    /// Returns whether this pass can possibly transform the current function.
+    /// The default keeps existing passes unconditional; candidate-driven passes
+    /// override it to avoid both their analysis and post-pass validation when no
+    /// relevant opcode or storage shape exists.
+    fn is_applicable(&self, _function: &Function) -> bool {
+        true
+    }
 
     /// Runs the pass over one function, returning true if it changed the IR.
     /// `data` is the module's shared literal pool, used by passes that materialize
@@ -159,9 +167,9 @@ pub fn optimize_module(module: &mut Module) {
 
 /// Runs the given passes over one function to a fixed point, returning whether the
 /// function was modified at all (so the module-level loop can detect convergence).
-/// After each pass, in debug/test builds, the function is re-validated and any
-/// malformed IR panics naming the offending pass. Non-convergence within the cap
-/// panics in debug and stops (keeping current IR) in release.
+/// After each pass that runs, in debug/test builds, the function is re-validated
+/// and any malformed IR panics naming the offending pass. Non-convergence within
+/// the cap panics in debug and stops (keeping current IR) in release.
 pub fn run_function_passes(
     function: &mut Function,
     passes: &[Box<dyn IrPass>],
@@ -171,6 +179,9 @@ pub fn run_function_passes(
     for _ in 0..MAX_PASS_ITERATIONS {
         let mut changed = false;
         for pass in passes {
+            if !pass.is_applicable(function) {
+                continue;
+            }
             let pass_changed = pass.run(function, data);
             #[cfg(debug_assertions)]
             if let Err(error) = crate::ir::validate_function(function) {

--- a/src/ir_passes/immutable_local_loads.rs
+++ b/src/ir_passes/immutable_local_loads.rs
@@ -14,7 +14,9 @@
 
 use std::collections::HashSet;
 
-use crate::ir::{DataPool, Effects, Function, Immediate, InstId, IrType, LocalKind, LocalSlotId, Op};
+use crate::ir::{
+    DataPool, Effects, Function, Immediate, InstId, Instruction, IrType, LocalKind, LocalSlotId, Op,
+};
 use crate::types::PhpType;
 
 use super::cfg::predecessors;
@@ -30,9 +32,24 @@ impl IrPass for ImmutableLocalLoads {
         "immutable_local_loads"
     }
 
+    /// Skips functions without an effectful concrete integer local load to refine.
+    fn is_applicable(&self, function: &Function) -> bool {
+        function.instructions.iter().any(|inst| {
+            matches!(inst.op, Op::ICheckedAdd | Op::ICheckedSub | Op::ICheckedMul)
+        }) && function
+            .instructions
+            .iter()
+            .any(|inst| actionable_integer_load_slot(function, inst).is_some())
+    }
+
     /// Refines effects for every load whose local slot satisfies the immutable contract.
     fn run(&self, function: &mut Function, _data: &mut DataPool) -> bool {
-        let eligible = immutable_integer_slots(function);
+        let candidates = actionable_integer_load_slots(function);
+        if candidates.is_empty() {
+            return false;
+        }
+
+        let eligible = immutable_integer_slots(function, &candidates);
         if eligible.is_empty() {
             return false;
         }
@@ -54,21 +71,43 @@ impl IrPass for ImmutableLocalLoads {
     }
 }
 
-/// Returns integer PHP-local slots whose contents are immutable for the whole function.
-fn immutable_integer_slots(function: &Function) -> HashSet<LocalSlotId> {
-    let mut eligible: HashSet<LocalSlotId> = function
-        .locals
+/// Returns concrete integer slots that still have at least one effectful load to refine.
+fn actionable_integer_load_slots(function: &Function) -> HashSet<LocalSlotId> {
+    function
+        .instructions
         .iter()
+        .filter_map(|inst| actionable_integer_load_slot(function, inst))
+        .collect()
+}
+
+/// Returns the concrete integer slot for an effectful load that this pass may refine.
+fn actionable_integer_load_slot(
+    function: &Function,
+    inst: &Instruction,
+) -> Option<LocalSlotId> {
+    if inst.op != Op::LoadLocal || inst.effects.is_pure() {
+        return None;
+    }
+    let Some(Immediate::LocalSlot(slot)) = inst.immediate else {
+        return None;
+    };
+    function
+        .locals
+        .get(slot.as_raw() as usize)
         .filter(|local| {
             local.kind == LocalKind::PhpLocal
                 && local.ir_type == IrType::I64
                 && matches!(local.php_type.codegen_repr(), PhpType::Int)
         })
-        .map(|local| local.id)
-        .collect();
-    if eligible.is_empty() {
-        return eligible;
-    }
+        .map(|_| slot)
+}
+
+/// Returns integer PHP-local slots whose contents are immutable for the whole function.
+fn immutable_integer_slots(
+    function: &Function,
+    candidates: &HashSet<LocalSlotId>,
+) -> HashSet<LocalSlotId> {
+    let mut eligible = candidates.clone();
 
     let mut loads: Vec<Vec<InstId>> = vec![Vec::new(); function.locals.len()];
     let mut stores: Vec<Vec<InstId>> = vec![Vec::new(); function.locals.len()];
@@ -90,25 +129,41 @@ fn immutable_integer_slots(function: &Function) -> HashSet<LocalSlotId> {
         }
     }
 
-    let dominance = compute_dominance(function);
-    let locations = instruction_locations(function);
+    let mut immutable = HashSet::new();
+    let mut single_store = Vec::new();
+    for slot in eligible {
+        let slot_loads = &loads[slot.as_raw() as usize];
+        if slot_loads.is_empty() {
+            continue;
+        }
+        match stores[slot.as_raw() as usize].as_slice() {
+            [] if slot_is_read_only_input(function, slot) => {
+                immutable.insert(slot);
+            }
+            [store] => single_store.push((slot, *store)),
+            _ => {}
+        }
+    }
+    if single_store.is_empty() {
+        return immutable;
+    }
+
     let entry_has_no_predecessor = predecessors(function)
         .get(function.entry.as_raw() as usize)
         .is_some_and(Vec::is_empty);
-    eligible.retain(|slot| {
+    if !entry_has_no_predecessor {
+        return immutable;
+    }
+
+    let dominance = compute_dominance(function);
+    let locations = instruction_locations(function);
+    for (slot, store) in single_store {
         let slot_loads = &loads[slot.as_raw() as usize];
-        if slot_loads.is_empty() {
-            return false;
+        if store_dominates_loads(function, store, slot_loads, &locations, &dominance) {
+            immutable.insert(slot);
         }
-        match stores[slot.as_raw() as usize].as_slice() {
-            [] => slot_is_read_only_input(function, *slot),
-            [store] if entry_has_no_predecessor => {
-                store_dominates_loads(function, *store, slot_loads, &locations, &dominance)
-            }
-            _ => false,
-        }
-    });
-    eligible
+    }
+    immutable
 }
 
 /// Maps every instruction table id to its current block and in-block position.

--- a/src/ir_passes/immutable_local_loads.rs
+++ b/src/ir_passes/immutable_local_loads.rs
@@ -1,0 +1,164 @@
+//! Purpose:
+//! Classifies integer `load_local` instructions whose slot value cannot change.
+//! Makes those reads pure so CSE and LICM can reason about local-backed arithmetic.
+//!
+//! Called from:
+//! - The fixed-point pass driver before checked-int specialization, CSE, and LICM.
+//!
+//! Key details:
+//! - Only concrete integer PHP locals are considered; aliases, ref cells, statics,
+//!   hidden temporaries, mixed storage, and any slot named by an unknown operation fail closed.
+//! - A slot is immutable when it is a read-only incoming parameter/main `$argc`, or has
+//!   exactly one entry-block store that dominates every load. The entry must have no
+//!   predecessor, proving that the store executes once rather than once per loop iteration.
+
+use std::collections::HashSet;
+
+use crate::ir::{DataPool, Effects, Function, Immediate, InstId, IrType, LocalKind, LocalSlotId, Op};
+use crate::types::PhpType;
+
+use super::cfg::predecessors;
+use super::dominance::compute_dominance;
+use super::driver::IrPass;
+
+/// Marks loads from proven-immutable scalar integer locals as pure.
+pub struct ImmutableLocalLoads;
+
+impl IrPass for ImmutableLocalLoads {
+    /// Returns the stable pass name used in driver diagnostics.
+    fn name(&self) -> &'static str {
+        "immutable_local_loads"
+    }
+
+    /// Refines effects for every load whose local slot satisfies the immutable contract.
+    fn run(&self, function: &mut Function, _data: &mut DataPool) -> bool {
+        let eligible = immutable_integer_slots(function);
+        if eligible.is_empty() {
+            return false;
+        }
+
+        let mut changed = false;
+        for inst in &mut function.instructions {
+            if inst.op != Op::LoadLocal || inst.effects.is_pure() {
+                continue;
+            }
+            let Some(Immediate::LocalSlot(slot)) = inst.immediate else {
+                continue;
+            };
+            if eligible.contains(&slot) {
+                inst.effects = Effects::PURE;
+                changed = true;
+            }
+        }
+        changed
+    }
+}
+
+/// Returns integer PHP-local slots whose contents are immutable for the whole function.
+fn immutable_integer_slots(function: &Function) -> HashSet<LocalSlotId> {
+    let mut eligible: HashSet<LocalSlotId> = function
+        .locals
+        .iter()
+        .filter(|local| {
+            local.kind == LocalKind::PhpLocal
+                && local.ir_type == IrType::I64
+                && matches!(local.php_type.codegen_repr(), PhpType::Int)
+        })
+        .map(|local| local.id)
+        .collect();
+    if eligible.is_empty() {
+        return eligible;
+    }
+
+    let mut loads: Vec<Vec<InstId>> = vec![Vec::new(); function.locals.len()];
+    let mut stores: Vec<Vec<InstId>> = vec![Vec::new(); function.locals.len()];
+    for (raw, inst) in function.instructions.iter().enumerate() {
+        let inst_id = InstId::from_raw(raw as u32);
+        match inst.immediate.as_ref() {
+            Some(Immediate::LocalSlot(slot)) if eligible.contains(slot) => match inst.op {
+                Op::LoadLocal => loads[slot.as_raw() as usize].push(inst_id),
+                Op::StoreLocal => stores[slot.as_raw() as usize].push(inst_id),
+                _ => {
+                    eligible.remove(slot);
+                }
+            },
+            Some(Immediate::LocalSlotPair { first, second }) => {
+                eligible.remove(first);
+                eligible.remove(second);
+            }
+            _ => {}
+        }
+    }
+
+    let dominance = compute_dominance(function);
+    let locations = instruction_locations(function);
+    let entry_has_no_predecessor = predecessors(function)
+        .get(function.entry.as_raw() as usize)
+        .is_some_and(Vec::is_empty);
+    eligible.retain(|slot| {
+        let slot_loads = &loads[slot.as_raw() as usize];
+        if slot_loads.is_empty() {
+            return false;
+        }
+        match stores[slot.as_raw() as usize].as_slice() {
+            [] => slot_is_read_only_input(function, *slot),
+            [store] if entry_has_no_predecessor => {
+                store_dominates_loads(function, *store, slot_loads, &locations, &dominance)
+            }
+            _ => false,
+        }
+    });
+    eligible
+}
+
+/// Maps every instruction table id to its current block and in-block position.
+fn instruction_locations(function: &Function) -> Vec<Option<(crate::ir::BlockId, usize)>> {
+    let mut locations = vec![None; function.instructions.len()];
+    for block in &function.blocks {
+        for (position, inst) in block.instructions.iter().copied().enumerate() {
+            locations[inst.as_raw() as usize] = Some((block.id, position));
+        }
+    }
+    locations
+}
+
+/// Returns true for an unwritten incoming integer parameter or top-level `$argc` slot.
+fn slot_is_read_only_input(function: &Function, slot: LocalSlotId) -> bool {
+    let Some(name) = function.locals[slot.as_raw() as usize].name.as_deref() else {
+        return false;
+    };
+    (function.flags.is_main && name == "argc")
+        || function.params.iter().any(|param| {
+            param.name == name
+                && !param.by_ref
+                && !param.variadic
+                && param.ir_type == IrType::I64
+                && matches!(param.php_type.codegen_repr(), PhpType::Int)
+        })
+}
+
+/// Proves that the sole store is in the entry and occurs before every local load.
+fn store_dominates_loads(
+    function: &Function,
+    store: InstId,
+    loads: &[InstId],
+    locations: &[Option<(crate::ir::BlockId, usize)>],
+    dominance: &super::dominance::DominanceInfo,
+) -> bool {
+    let Some((store_block, store_position)) = locations[store.as_raw() as usize] else {
+        return false;
+    };
+    if store_block != function.entry {
+        return false;
+    }
+    loads.iter().all(|load| {
+        let Some((load_block, load_position)) = locations[load.as_raw() as usize] else {
+            return false;
+        };
+        if load_block == store_block {
+            store_position < load_position
+        } else {
+            dominance.dominates(store_block, load_block)
+        }
+    })
+}

--- a/src/ir_passes/licm.rs
+++ b/src/ir_passes/licm.rs
@@ -13,14 +13,16 @@
 //!   defined by another instruction being hoisted from the same loop or has a
 //!   definition that dominates the preheader (so it is available there). This is
 //!   a fixed point: hoisting one instruction can make a dependent one invariant.
-//! - Only **pure** (`Effects::PURE`) instructions with at least one operand and a
-//!   `NonHeap`/`Persistent` result are eligible. Purity means the result depends
-//!   only on the operands and the op neither reads mutable state nor faults, so
-//!   evaluating it once in the preheader — unconditionally, even if the original
-//!   site was only reached on some iterations — is safe (no speculation hazard).
-//!   The ownership bound keeps the move refcount-neutral. Nullary constant/address
-//!   materializations are not hoisted: they are cheaper to rematerialize than to
-//!   keep live across the loop (the same policy CSE uses).
+//! - Only **pure** (`Effects::PURE`) instructions with a `NonHeap`/`Persistent`
+//!   result are eligible. Purity means the result depends only on immutable inputs
+//!   and the op neither reads mutable state nor faults, so evaluating it once in the
+//!   preheader — unconditionally, even if the original site was only reached on some
+//!   iterations — is safe (no speculation hazard). The ownership bound keeps the move
+//!   refcount-neutral. Nullary constant/address materializations are moved only when
+//!   they are operands of a computation being hoisted; standalone materializations
+//!   remain in place. A `load_local` proven immutable by the dedicated analysis is also
+//!   eligible: moving that load is what makes local-backed invariant arithmetic
+//!   available in the preheader.
 //! - Hoisting needs a preheader to move into. The loop analysis detects an
 //!   existing one (PHP loops lower to slot-based CFGs whose init block is a
 //!   natural preheader); loops without a detected preheader are skipped rather
@@ -125,11 +127,21 @@ fn find_hoistable(
                 if !is_hoist_eligible(inst) {
                     continue;
                 }
-                let ready = inst
-                    .operands
-                    .iter()
-                    .all(|&op| operand_available(function, op, preheader, dominance, def_block, &hoistable));
+                let mut materializations = HashSet::new();
+                let ready = inst.operands.iter().all(|&op| {
+                    operand_available(
+                        function,
+                        op,
+                        loop_ref,
+                        preheader,
+                        dominance,
+                        def_block,
+                        &hoistable,
+                        &mut materializations,
+                    )
+                });
                 if ready {
+                    hoistable.extend(materializations);
                     hoistable.insert(inst_id);
                     added = true;
                 }
@@ -150,13 +162,26 @@ fn find_hoistable(
 fn operand_available(
     function: &Function,
     op: ValueId,
+    loop_ref: &NaturalLoop,
     preheader: BlockId,
     dominance: &DominanceInfo,
     def_block: &HashMap<ValueId, BlockId>,
     hoistable: &HashSet<InstId>,
+    materializations: &mut HashSet<InstId>,
 ) -> bool {
     if let Some(inst) = defining_inst(function, op) {
         if hoistable.contains(&inst) {
+            return true;
+        }
+        let defined_inside_loop = def_block
+            .get(&op)
+            .is_some_and(|block| loop_ref.blocks.contains(block));
+        if defined_inside_loop
+            && function
+                .instruction(inst)
+                .is_some_and(is_rematerializable_dependency)
+        {
+            materializations.insert(inst);
             return true;
         }
     }
@@ -166,15 +191,25 @@ fn operand_available(
     }
 }
 
+/// Returns true for a pure nullary value that may move only with a dependent computation.
+fn is_rematerializable_dependency(inst: &crate::ir::Instruction) -> bool {
+    inst.result.is_some()
+        && inst.op != Op::Nop
+        && inst.op != Op::LoadLocal
+        && inst.effects.is_pure()
+        && inst.operands.is_empty()
+        && matches!(inst.result_ownership, Ownership::NonHeap | Ownership::Persistent)
+}
+
 /// Returns true when an instruction may be hoisted: it produces a value, is not a
-/// `nop`, is pure (no side effects, no fault, no mutable-state read), has at
-/// least one operand (so it is a computation, not a rematerializable constant),
-/// and its result carries no owned-heap cleanup.
+/// `nop`, is pure (no side effects, no fault, no mutable-state read), is either a
+/// computation or a proven-immutable `load_local`, and its result carries no
+/// owned-heap cleanup.
 fn is_hoist_eligible(inst: &crate::ir::Instruction) -> bool {
     inst.result.is_some()
         && inst.op != Op::Nop
         && inst.effects.is_pure()
-        && !inst.operands.is_empty()
+        && (!inst.operands.is_empty() || inst.op == Op::LoadLocal)
         && matches!(inst.result_ownership, Ownership::NonHeap | Ownership::Persistent)
 }
 

--- a/src/ir_passes/mod.rs
+++ b/src/ir_passes/mod.rs
@@ -14,6 +14,7 @@
 
 mod allocation;
 mod branch_simplify;
+mod checked_int_sink;
 mod cfg;
 mod clobber;
 mod const_fold;
@@ -24,6 +25,7 @@ mod dominance;
 mod driver;
 mod identity_arith;
 mod inline;
+mod immutable_local_loads;
 mod intervals;
 mod licm;
 mod liveness;

--- a/src/ir_passes/tests/checked_int_sink_test.rs
+++ b/src/ir_passes/tests/checked_int_sink_test.rs
@@ -1,0 +1,393 @@
+//! Purpose:
+//! Regression tests for checked integer arithmetic specialization at integer-only sinks.
+//!
+//! Called from:
+//! - `cargo test` through Rust's test harness.
+//!
+//! Key details:
+//! - Hand-built EIR covers casts, typed stores, ref cells, acquire/release scaffolding,
+//!   checked opcodes, and conservative rejection of Mixed, terminator, and pinned uses.
+
+use crate::ir::{
+    validate_function, Builder, DataPool, Function, Immediate, IrHeapKind, IrType, LocalKind,
+    Op, Ownership, Terminator, ValueId,
+};
+use crate::ir_passes::checked_int_sink::CheckedIntSink;
+use crate::ir_passes::driver::IrPass;
+use crate::types::PhpType;
+
+/// Runs checked-int sink specialization once with an unused literal pool.
+fn specialize(function: &mut Function) -> bool {
+    CheckedIntSink.run(function, &mut DataPool::default())
+}
+
+/// Emits one boxed checked binary operation with the canonical Mixed metadata.
+fn emit_checked(
+    builder: &mut Builder<'_>,
+    op: Op,
+    lhs: ValueId,
+    rhs: ValueId,
+) -> ValueId {
+    builder
+        .emit(
+            op,
+            vec![lhs, rhs],
+            None,
+            IrType::Heap(IrHeapKind::Mixed),
+            PhpType::Mixed,
+            Ownership::Owned,
+        )
+        .expect("checked arithmetic result")
+}
+
+/// Emits an explicit PHP integer cast of a boxed Mixed value.
+fn emit_int_cast(builder: &mut Builder<'_>, value: ValueId) -> ValueId {
+    builder
+        .emit(
+            Op::Cast,
+            vec![value],
+            Some(Immediate::CastTarget(IrType::I64)),
+            IrType::I64,
+            PhpType::Int,
+            Ownership::NonHeap,
+        )
+        .expect("integer cast result")
+}
+
+/// Checked add/sub/mul followed only by an integer cast become scalar ToInt ops.
+#[test]
+fn specializes_all_checked_integer_opcodes_at_cast_sinks() {
+    for (source_op, specialized_op) in [
+        (Op::ICheckedAdd, Op::ICheckedAddToInt),
+        (Op::ICheckedSub, Op::ICheckedSubToInt),
+        (Op::ICheckedMul, Op::ICheckedMulToInt),
+    ] {
+        let mut function = Function::new("cast_sink".to_string(), IrType::I64, PhpType::Int);
+        {
+            let mut builder = Builder::new(&mut function);
+            let entry = builder.create_named_block("entry", vec![]);
+            builder.set_entry(entry);
+            builder.position_at_end(entry);
+            let lhs = builder.emit_const_i64(7);
+            let rhs = builder.emit_const_i64(2);
+            let checked = emit_checked(&mut builder, source_op, lhs, rhs);
+            let cast = emit_int_cast(&mut builder, checked);
+            let _ = builder.emit(
+                Op::Release,
+                vec![checked],
+                None,
+                IrType::Void,
+                PhpType::Void,
+                Ownership::NonHeap,
+            );
+            builder.terminate(Terminator::Return { value: Some(cast) });
+        }
+
+        assert!(specialize(&mut function), "{source_op:?} should specialize");
+        assert_eq!(function.instructions[2].op, specialized_op);
+        assert_eq!(function.instructions[2].result_type, IrType::I64);
+        assert_eq!(function.instructions[2].result_php_type, PhpType::Int);
+        assert_eq!(function.instructions[2].result_ownership, Ownership::NonHeap);
+        assert!(function.instructions[2].effects.is_pure());
+        assert_eq!(function.instructions[3].op, Op::Nop, "cast is removed");
+        assert_eq!(function.instructions[4].op, Op::Nop, "release is removed");
+        assert!(
+            validate_function(&function).is_ok(),
+            "specialized IR invalid: {:?}",
+            validate_function(&function)
+        );
+        assert!(!specialize(&mut function), "the rewrite is idempotent");
+    }
+}
+
+/// Acquire/release scaffolding around a checked value is removed before an integer store.
+#[test]
+fn specializes_typed_local_store_through_acquire_release() {
+    let mut function = Function::new("store_sink".to_string(), IrType::Void, PhpType::Void);
+    let (checked, acquired);
+    {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+        let slot = builder.add_local(
+            Some("result".to_string()),
+            IrType::I64,
+            PhpType::Int,
+            LocalKind::PhpLocal,
+        );
+        let lhs = builder.emit_const_i64(7);
+        let rhs = builder.emit_const_i64(2);
+        checked = emit_checked(&mut builder, Op::ICheckedAdd, lhs, rhs);
+        acquired = builder
+            .emit(
+                Op::Acquire,
+                vec![checked],
+                None,
+                IrType::Heap(IrHeapKind::Mixed),
+                PhpType::Mixed,
+                Ownership::Owned,
+            )
+            .expect("acquired result");
+        builder.emit_store_local(slot, acquired);
+        let _ = builder.emit(
+            Op::Release,
+            vec![checked],
+            None,
+            IrType::Void,
+            PhpType::Void,
+            Ownership::NonHeap,
+        );
+        builder.terminate(Terminator::Return { value: None });
+    }
+
+    assert!(specialize(&mut function));
+    assert_eq!(function.instructions[2].op, Op::ICheckedAddToInt);
+    assert_eq!(function.instructions[3].op, Op::Nop, "acquire is removed");
+    assert_eq!(function.instructions[4].operands, vec![checked]);
+    assert_eq!(function.instructions[5].op, Op::Nop, "release is removed");
+    assert_ne!(checked, acquired, "fixture exercised a real acquire result");
+    assert!(
+        validate_function(&function).is_ok(),
+        "specialized store IR invalid: {:?}",
+        validate_function(&function)
+    );
+}
+
+/// A ref-cell store whose carried alias type is Int is an integer-only sink.
+#[test]
+fn specializes_integer_ref_cell_store() {
+    let mut function = Function::new("ref_cell_sink".to_string(), IrType::Void, PhpType::Void);
+    {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+        let slot = builder.add_local(
+            Some("result".to_string()),
+            IrType::I64,
+            PhpType::Int,
+            LocalKind::PhpLocal,
+        );
+        let lhs = builder.emit_const_i64(7);
+        let rhs = builder.emit_const_i64(2);
+        let checked = emit_checked(&mut builder, Op::ICheckedAdd, lhs, rhs);
+        let _ = builder.emit(
+            Op::StoreRefCell,
+            vec![checked],
+            Some(Immediate::LocalSlot(slot)),
+            IrType::Void,
+            PhpType::Int,
+            Ownership::NonHeap,
+        );
+        builder.terminate(Terminator::Return { value: None });
+    }
+
+    assert!(specialize(&mut function));
+    assert_eq!(function.instructions[2].op, Op::ICheckedAddToInt);
+    assert!(
+        validate_function(&function).is_ok(),
+        "specialized ref-cell IR invalid: {:?}",
+        validate_function(&function)
+    );
+}
+
+/// Several explicit integer casts may safely share one specialized producer.
+#[test]
+fn specializes_one_producer_with_multiple_integer_sinks() {
+    let mut function = Function::new("multiple_sinks".to_string(), IrType::Void, PhpType::Void);
+    let (checked, first_slot, second_slot);
+    {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+        first_slot = builder.add_local(
+            Some("first".to_string()),
+            IrType::I64,
+            PhpType::Int,
+            LocalKind::PhpLocal,
+        );
+        second_slot = builder.add_local(
+            Some("second".to_string()),
+            IrType::I64,
+            PhpType::Int,
+            LocalKind::PhpLocal,
+        );
+        let lhs = builder.emit_const_i64(7);
+        let rhs = builder.emit_const_i64(2);
+        checked = emit_checked(&mut builder, Op::ICheckedAdd, lhs, rhs);
+        let first = emit_int_cast(&mut builder, checked);
+        let second = emit_int_cast(&mut builder, checked);
+        builder.emit_store_local(first_slot, first);
+        builder.emit_store_local(second_slot, second);
+        let _ = builder.emit(
+            Op::Release,
+            vec![checked],
+            None,
+            IrType::Void,
+            PhpType::Void,
+            Ownership::NonHeap,
+        );
+        builder.terminate(Terminator::Return { value: None });
+    }
+
+    assert!(specialize(&mut function));
+    assert_eq!(function.instructions[2].op, Op::ICheckedAddToInt);
+    assert_eq!(function.instructions[3].op, Op::Nop);
+    assert_eq!(function.instructions[4].op, Op::Nop);
+    assert_eq!(function.instructions[5].operands, vec![checked]);
+    assert_eq!(function.instructions[6].operands, vec![checked]);
+    assert_eq!(function.instructions[7].op, Op::Nop);
+    assert!(
+        validate_function(&function).is_ok(),
+        "multiple-sink IR invalid: {:?}",
+        validate_function(&function)
+    );
+}
+
+/// Direct output observes the overflow-promoted Mixed type and therefore keeps boxing.
+#[test]
+fn rejects_mixed_output_observer() {
+    let mut function = Function::new("mixed_output".to_string(), IrType::Void, PhpType::Void);
+    {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+        let lhs = builder.emit_const_i64(7);
+        let rhs = builder.emit_const_i64(2);
+        let checked = emit_checked(&mut builder, Op::ICheckedAdd, lhs, rhs);
+        let _ = builder.emit(
+            Op::EchoValue,
+            vec![checked],
+            None,
+            IrType::Void,
+            PhpType::Void,
+            Ownership::NonHeap,
+        );
+        let _ = builder.emit(
+            Op::Release,
+            vec![checked],
+            None,
+            IrType::Void,
+            PhpType::Void,
+            Ownership::NonHeap,
+        );
+        builder.terminate(Terminator::Return { value: None });
+    }
+
+    assert!(!specialize(&mut function));
+    assert_eq!(function.instructions[2].op, Op::ICheckedAdd);
+    assert!(
+        validate_function(&function).is_ok(),
+        "mixed output fixture invalid: {:?}",
+        validate_function(&function)
+    );
+}
+
+/// A store into Mixed frame storage keeps the checked box even through an acquire.
+#[test]
+fn rejects_mixed_local_store() {
+    let mut function = Function::new("mixed_store".to_string(), IrType::Void, PhpType::Void);
+    {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+        let slot = builder.add_local(
+            Some("result".to_string()),
+            IrType::Heap(IrHeapKind::Mixed),
+            PhpType::Mixed,
+            LocalKind::PhpLocal,
+        );
+        let lhs = builder.emit_const_i64(7);
+        let rhs = builder.emit_const_i64(2);
+        let checked = emit_checked(&mut builder, Op::ICheckedAdd, lhs, rhs);
+        let acquired = builder
+            .emit(
+                Op::Acquire,
+                vec![checked],
+                None,
+                IrType::Heap(IrHeapKind::Mixed),
+                PhpType::Mixed,
+                Ownership::Owned,
+            )
+            .expect("acquired result");
+        builder.emit_store_local(slot, acquired);
+        builder.terminate(Terminator::Return { value: None });
+    }
+
+    assert!(!specialize(&mut function));
+    assert_eq!(function.instructions[2].op, Op::ICheckedAdd);
+    assert_eq!(function.instructions[3].op, Op::Acquire);
+    assert!(
+        validate_function(&function).is_ok(),
+        "mixed store fixture invalid: {:?}",
+        validate_function(&function)
+    );
+}
+
+/// Returning the dynamic result can expose overflow promotion and therefore rejects the rewrite.
+#[test]
+fn rejects_checked_value_used_by_terminator() {
+    let mut function = Function::new(
+        "mixed_return".to_string(),
+        IrType::Heap(IrHeapKind::Mixed),
+        PhpType::Mixed,
+    );
+    {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+        let lhs = builder.emit_const_i64(7);
+        let rhs = builder.emit_const_i64(2);
+        let checked = emit_checked(&mut builder, Op::ICheckedAdd, lhs, rhs);
+        builder.terminate(Terminator::Return {
+            value: Some(checked),
+        });
+    }
+
+    assert!(!specialize(&mut function));
+    assert_eq!(function.instructions[2].op, Op::ICheckedAdd);
+    assert!(
+        validate_function(&function).is_ok(),
+        "mixed return fixture invalid: {:?}",
+        validate_function(&function)
+    );
+}
+
+/// An acquire carrying lifetime-pin metadata is never erased by sink specialization.
+#[test]
+fn rejects_lifetime_pinned_acquire() {
+    let mut function = Function::new("pinned".to_string(), IrType::Void, PhpType::Void);
+    {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+        let lhs = builder.emit_const_i64(7);
+        let rhs = builder.emit_const_i64(2);
+        let checked = emit_checked(&mut builder, Op::ICheckedAdd, lhs, rhs);
+        let _ = builder.emit(
+            Op::Acquire,
+            vec![checked],
+            Some(Immediate::Bool(true)),
+            IrType::Heap(IrHeapKind::Mixed),
+            PhpType::Mixed,
+            Ownership::Owned,
+        );
+        let _ = emit_int_cast(&mut builder, checked);
+        builder.terminate(Terminator::Return { value: None });
+    }
+
+    assert!(!specialize(&mut function));
+    assert_eq!(function.instructions[2].op, Op::ICheckedAdd);
+    assert_eq!(function.instructions[3].op, Op::Acquire);
+    assert!(
+        validate_function(&function).is_ok(),
+        "lifetime-pin fixture invalid: {:?}",
+        validate_function(&function)
+    );
+}

--- a/src/ir_passes/tests/checked_int_sink_test.rs
+++ b/src/ir_passes/tests/checked_int_sink_test.rs
@@ -83,6 +83,10 @@ fn specializes_all_checked_integer_opcodes_at_cast_sinks() {
             builder.terminate(Terminator::Return { value: Some(cast) });
         }
 
+        assert!(
+            CheckedIntSink.is_applicable(&function),
+            "{source_op:?} should reach an integer sink"
+        );
         assert!(specialize(&mut function), "{source_op:?} should specialize");
         assert_eq!(function.instructions[2].op, specialized_op);
         assert_eq!(function.instructions[2].result_type, IrType::I64);
@@ -277,6 +281,10 @@ fn rejects_mixed_output_observer() {
         builder.terminate(Terminator::Return { value: None });
     }
 
+    assert!(
+        !CheckedIntSink.is_applicable(&function),
+        "a mixed-only observer should skip the sink pass"
+    );
     assert!(!specialize(&mut function));
     assert_eq!(function.instructions[2].op, Op::ICheckedAdd);
     assert!(

--- a/src/ir_passes/tests/driver_test.rs
+++ b/src/ir_passes/tests/driver_test.rs
@@ -49,6 +49,23 @@ impl IrPass for NoopPass {
     }
 }
 
+/// A pass whose cheap applicability predicate rejects the sample function.
+struct InapplicablePass;
+impl IrPass for InapplicablePass {
+    /// Returns the synthetic pass name used if the applicability gate regresses.
+    fn name(&self) -> &'static str {
+        "inapplicable"
+    }
+    /// Declares that this pass has no relevant shape to inspect in the function.
+    fn is_applicable(&self, _function: &Function) -> bool {
+        false
+    }
+    /// Panics if the driver runs a pass after its applicability predicate rejected it.
+    fn run(&self, _function: &mut Function, _data: &mut DataPool) -> bool {
+        panic!("inapplicable pass must not run")
+    }
+}
+
 /// A pass that mutates once (appends `!` to the name) then reports stable.
 struct AppendBangPass;
 impl IrPass for AppendBangPass {
@@ -102,6 +119,15 @@ impl IrPass for DropTerminatorPass {
 fn noop_pass_converges_without_change() {
     let mut function = sample_function();
     let passes: Vec<Box<dyn IrPass>> = vec![Box::new(NoopPass)];
+    drive(&mut function, &passes);
+    assert_eq!(function.name, "sample");
+}
+
+/// A rejected applicability predicate skips both pass execution and validation.
+#[test]
+fn inapplicable_pass_is_skipped() {
+    let mut function = sample_function();
+    let passes: Vec<Box<dyn IrPass>> = vec![Box::new(InapplicablePass)];
     drive(&mut function, &passes);
     assert_eq!(function.name, "sample");
 }

--- a/src/ir_passes/tests/immutable_local_loads_test.rs
+++ b/src/ir_passes/tests/immutable_local_loads_test.rs
@@ -1,0 +1,198 @@
+//! Purpose:
+//! Regression tests for conservative immutable integer-local load classification.
+//!
+//! Called from:
+//! - `cargo test` through Rust's test harness.
+//!
+//! Key details:
+//! - Covers read-only `$argc`, one dominating entry store, multiple writes,
+//!   non-entry stores, by-reference parameters, and alias metadata that reject purity.
+
+use crate::ir::{
+    validate_function, Builder, DataPool, Function, FunctionParam, Immediate, IrType, LocalKind,
+    Op, Ownership, Terminator,
+};
+use crate::ir_passes::driver::IrPass;
+use crate::ir_passes::immutable_local_loads::ImmutableLocalLoads;
+use crate::types::PhpType;
+
+/// Runs immutable-local classification once with an unused literal pool.
+fn classify(function: &mut Function) -> bool {
+    ImmutableLocalLoads.run(function, &mut DataPool::default())
+}
+
+/// A read-only top-level `$argc` load is pure and validates with the refined effect.
+#[test]
+fn classifies_main_argc_as_immutable() {
+    let mut function = Function::new("main".to_string(), IrType::I64, PhpType::Int);
+    function.flags.is_main = true;
+    {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+        let argc = builder.add_local(
+            Some("argc".to_string()),
+            IrType::I64,
+            PhpType::Int,
+            LocalKind::PhpLocal,
+        );
+        let value = builder.emit_load_local(argc, IrType::I64, PhpType::Int);
+        builder.terminate(Terminator::Return { value: Some(value) });
+    }
+
+    assert!(classify(&mut function));
+    assert!(function.instructions[0].effects.is_pure());
+    assert!(validate_function(&function).is_ok());
+    assert!(!classify(&mut function), "effect refinement is idempotent");
+}
+
+/// A by-reference integer parameter may change through its alias and is never read-only.
+#[test]
+fn rejects_by_reference_integer_parameter() {
+    let mut function = Function::new("by_ref_param".to_string(), IrType::I64, PhpType::Int);
+    function.params.push(FunctionParam {
+        name: "value".to_string(),
+        ir_type: IrType::I64,
+        php_type: PhpType::Int,
+        by_ref: true,
+        variadic: false,
+    });
+    {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+        let slot = builder.add_local(
+            Some("value".to_string()),
+            IrType::I64,
+            PhpType::Int,
+            LocalKind::PhpLocal,
+        );
+        let value = builder.emit_load_local(slot, IrType::I64, PhpType::Int);
+        builder.terminate(Terminator::Return { value: Some(value) });
+    }
+
+    assert!(!classify(&mut function));
+    assert_eq!(function.instructions[0].effects, Op::LoadLocal.default_effects());
+}
+
+/// One entry-block store before every load makes a concrete integer local immutable.
+#[test]
+fn classifies_single_dominating_entry_store() {
+    let mut function = Function::new("single_store".to_string(), IrType::I64, PhpType::Int);
+    {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+        let slot = builder.add_local(
+            Some("value".to_string()),
+            IrType::I64,
+            PhpType::Int,
+            LocalKind::PhpLocal,
+        );
+        let seed = builder.emit_const_i64(7);
+        builder.emit_store_local(slot, seed);
+        let value = builder.emit_load_local(slot, IrType::I64, PhpType::Int);
+        builder.terminate(Terminator::Return { value: Some(value) });
+    }
+
+    assert!(classify(&mut function));
+    assert!(function.instructions[2].effects.is_pure());
+    assert!(validate_function(&function).is_ok());
+}
+
+/// Two stores make the slot mutable even when both occur in the entry block.
+#[test]
+fn rejects_multiple_stores() {
+    let mut function = Function::new("multiple_stores".to_string(), IrType::I64, PhpType::Int);
+    {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+        let slot = builder.add_local(
+            Some("value".to_string()),
+            IrType::I64,
+            PhpType::Int,
+            LocalKind::PhpLocal,
+        );
+        let first = builder.emit_const_i64(1);
+        let second = builder.emit_const_i64(2);
+        builder.emit_store_local(slot, first);
+        builder.emit_store_local(slot, second);
+        let value = builder.emit_load_local(slot, IrType::I64, PhpType::Int);
+        builder.terminate(Terminator::Return { value: Some(value) });
+    }
+
+    assert!(!classify(&mut function));
+    assert_eq!(function.instructions[4].effects, Op::LoadLocal.default_effects());
+}
+
+/// A sole store outside the entry may execute repeatedly and is conservatively rejected.
+#[test]
+fn rejects_non_entry_store() {
+    let mut function = Function::new("late_store".to_string(), IrType::I64, PhpType::Int);
+    {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        let body = builder.create_named_block("body", vec![]);
+        builder.set_entry(entry);
+        let slot = builder.add_local(
+            Some("value".to_string()),
+            IrType::I64,
+            PhpType::Int,
+            LocalKind::PhpLocal,
+        );
+        builder.position_at_end(entry);
+        builder.terminate(Terminator::Br { target: body, args: vec![] });
+        builder.position_at_end(body);
+        let seed = builder.emit_const_i64(7);
+        builder.emit_store_local(slot, seed);
+        let value = builder.emit_load_local(slot, IrType::I64, PhpType::Int);
+        builder.terminate(Terminator::Return { value: Some(value) });
+    }
+
+    assert!(!classify(&mut function));
+    assert_eq!(function.instructions[2].effects, Op::LoadLocal.default_effects());
+}
+
+/// Any local-slot pair metadata represents aliasing and invalidates an otherwise immutable slot.
+#[test]
+fn rejects_reference_alias_metadata() {
+    let mut function = Function::new("aliased".to_string(), IrType::I64, PhpType::Int);
+    {
+        let mut builder = Builder::new(&mut function);
+        let entry = builder.create_named_block("entry", vec![]);
+        builder.set_entry(entry);
+        builder.position_at_end(entry);
+        let slot = builder.add_local(
+            Some("value".to_string()),
+            IrType::I64,
+            PhpType::Int,
+            LocalKind::PhpLocal,
+        );
+        let cell = builder.add_local(
+            Some("value#ref".to_string()),
+            IrType::I64,
+            PhpType::Int,
+            LocalKind::RefCell,
+        );
+        let seed = builder.emit_const_i64(7);
+        builder.emit_store_local(slot, seed);
+        let _ = builder.emit(
+            Op::AliasLocalRefCell,
+            vec![],
+            Some(Immediate::LocalSlotPair { first: slot, second: cell }),
+            IrType::Void,
+            PhpType::Void,
+            Ownership::NonHeap,
+        );
+        let value = builder.emit_load_local(slot, IrType::I64, PhpType::Int);
+        builder.terminate(Terminator::Return { value: Some(value) });
+    }
+
+    assert!(!classify(&mut function));
+    assert_eq!(function.instructions[3].effects, Op::LoadLocal.default_effects());
+}

--- a/src/ir_passes/tests/mod.rs
+++ b/src/ir_passes/tests/mod.rs
@@ -9,6 +9,7 @@
 //!   real IR data model without going through AST lowering.
 
 mod branch_simplify_test;
+mod checked_int_sink_test;
 mod const_fold_test;
 mod cse_test;
 mod dead_inst_test;
@@ -17,6 +18,7 @@ mod dominance_test;
 mod driver_test;
 mod identity_arith_test;
 mod inline_test;
+mod immutable_local_loads_test;
 mod intervals_test;
 mod licm_test;
 mod liveness_test;

--- a/tests/codegen/eval.rs
+++ b/tests/codegen/eval.rs
@@ -9311,33 +9311,49 @@ fn test_eval_parse_error_reports_eval_parse_diagnostic() {
     );
 }
 
-/// Verifies eval failure classes map to distinct stable user-facing diagnostics.
+/// Compiles one eval fixture that must fail with the requested diagnostic fragment.
+fn assert_eval_failure_contains(source: &str, expected: &str) -> String {
+    let stderr = compile_and_run_expect_failure(source);
+    assert!(
+        stderr.contains(expected),
+        "stderr did not contain expected eval diagnostic {expected:?}: {stderr}"
+    );
+    stderr
+}
+
+/// Verifies eval parse failures retain their stable user-facing diagnostic.
 #[test]
-fn test_eval_error_contract_distinguishes_parse_unsupported_runtime_and_warning() {
-    let parse_err = compile_and_run_expect_failure("<?php eval('if (');");
-    assert!(
-        parse_err.contains("Parse error: eval() fragment is invalid"),
-        "stderr did not contain eval parse-error diagnostic: {parse_err}"
+fn test_eval_error_contract_reports_parse_failure() {
+    let stderr = assert_eval_failure_contains(
+        "<?php eval('if (');",
+        "Parse error: eval() fragment is invalid",
     );
-    assert_no_rust_panic_leaked(&parse_err);
+    assert_no_rust_panic_leaked(&stderr);
+}
 
-    let unsupported_err = compile_and_run_expect_failure(
+/// Verifies unsupported eval syntax retains its stable user-facing diagnostic.
+#[test]
+fn test_eval_error_contract_reports_unsupported_construct() {
+    let stderr = assert_eval_failure_contains(
         "<?php eval('function eval_bad_static_return(): static {}');",
+        "Fatal error: eval() fragment uses an unsupported construct",
     );
-    assert!(
-        unsupported_err.contains("Fatal error: eval() fragment uses an unsupported construct"),
-        "stderr did not contain eval unsupported-construct diagnostic: {unsupported_err}"
-    );
-    assert_no_rust_panic_leaked(&unsupported_err);
+    assert_no_rust_panic_leaked(&stderr);
+}
 
-    let runtime_err =
-        compile_and_run_expect_failure("<?php eval('return MissingEvalContractConst;');");
-    assert!(
-        runtime_err.contains("Fatal error: eval() runtime failed"),
-        "stderr did not contain eval runtime-fatal diagnostic: {runtime_err}"
+/// Verifies eval runtime failures retain their stable user-facing diagnostic.
+#[test]
+fn test_eval_error_contract_reports_runtime_failure() {
+    let stderr = assert_eval_failure_contains(
+        "<?php eval('return MissingEvalContractConst;');",
+        "Fatal error: eval() runtime failed",
     );
-    assert_no_rust_panic_leaked(&runtime_err);
+    assert_no_rust_panic_leaked(&stderr);
+}
 
+/// Verifies eval warnings remain non-fatal and are written to stderr.
+#[test]
+fn test_eval_error_contract_reports_non_fatal_warning() {
     let warning = compile_and_run_capture(
         r#"<?php
 eval('define("EvalErrorContractConst", 1);');
@@ -14815,9 +14831,9 @@ echo count($implements) . ":" . $implements["EvalDynNamedReader"] . ":" . $imple
     );
 }
 
-/// Verifies eval-declared method overrides enforce covariant return types.
+/// Verifies eval-declared method overrides accept covariant return types.
 #[test]
-fn test_eval_declared_method_return_type_override_contracts() {
+fn test_eval_declared_method_return_type_override_accepts_covariance() {
     let out = compile_and_run_capture(
         r#"<?php
 eval('class EvalReturnBase {
@@ -14853,8 +14869,12 @@ echo $child->id();');
         out.stdout, out.stderr
     );
     assert_eq!(out.stdout, "2");
+}
 
-    let err = compile_and_run_expect_failure(
+/// Verifies eval-declared method overrides reject nullable return widening.
+#[test]
+fn test_eval_declared_method_return_type_override_rejects_nullable_widening() {
+    assert_eval_failure_contains(
         r#"<?php
 eval('class EvalReturnNarrowBase {
     public function id(): int { return 1; }
@@ -14863,13 +14883,14 @@ class EvalReturnWiderNullable extends EvalReturnNarrowBase {
     public function id(): ?int { return 2; }
 }');
 "#,
+        "Fatal error: eval() runtime failed",
     );
-    assert!(
-        err.contains("Fatal error: eval() runtime failed"),
-        "stderr did not contain eval runtime fatal diagnostic: {err}"
-    );
+}
 
-    let err = compile_and_run_expect_failure(
+/// Verifies eval-declared method overrides reject replacing `static` with `self`.
+#[test]
+fn test_eval_declared_method_return_type_override_rejects_static_to_self() {
+    assert_eval_failure_contains(
         r#"<?php
 eval('class EvalReturnStaticBase {
     public function make(): static { return $this; }
@@ -14878,13 +14899,14 @@ class EvalReturnSelfChild extends EvalReturnStaticBase {
     public function make(): self { return $this; }
 }');
 "#,
+        "Fatal error: eval() runtime failed",
     );
-    assert!(
-        err.contains("Fatal error: eval() runtime failed"),
-        "stderr did not contain eval runtime fatal diagnostic: {err}"
-    );
+}
 
-    let err = compile_and_run_expect_failure(
+/// Verifies eval-declared method overrides reject widening nullable returns to `mixed`.
+#[test]
+fn test_eval_declared_method_return_type_override_rejects_mixed_widening() {
+    assert_eval_failure_contains(
         r#"<?php
 eval('class EvalReturnNullableBase {
     public function maybe(): ?int { return null; }
@@ -14893,16 +14915,13 @@ class EvalReturnMixedChildBad extends EvalReturnNullableBase {
     public function maybe(): mixed { return null; }
 }');
 "#,
-    );
-    assert!(
-        err.contains("Fatal error: eval() runtime failed"),
-        "stderr did not contain eval runtime fatal diagnostic: {err}"
+        "Fatal error: eval() runtime failed",
     );
 }
 
-/// Verifies eval-declared method overrides enforce contravariant parameter types.
+/// Verifies eval-declared method overrides accept contravariant parameter types.
 #[test]
-fn test_eval_declared_method_parameter_type_override_contracts() {
+fn test_eval_declared_method_parameter_type_override_accepts_contravariance() {
     let out = compile_and_run_capture(
         r#"<?php
 eval('class EvalParamBase {
@@ -14927,8 +14946,12 @@ echo $child->maybeInt(null) === null ? "null" : "bad";');
         out.stdout, out.stderr
     );
     assert_eq!(out.stdout, "7:mixed:ok:null");
+}
 
-    let err = compile_and_run_expect_failure(
+/// Verifies eval-declared parameter overrides reject unrelated child types.
+#[test]
+fn test_eval_declared_method_parameter_type_override_rejects_unrelated_type() {
+    assert_eval_failure_contains(
         r#"<?php
 eval('class EvalParamTypeBase {
     public function read(int $value) { return $value; }
@@ -14937,13 +14960,14 @@ class EvalParamStringChild extends EvalParamTypeBase {
     public function read(string $value) { return $value; }
 }');
 "#,
+        "Fatal error: eval() runtime failed",
     );
-    assert!(
-        err.contains("Fatal error: eval() runtime failed"),
-        "stderr did not contain eval runtime fatal diagnostic: {err}"
-    );
+}
 
-    let err = compile_and_run_expect_failure(
+/// Verifies eval-declared parameter overrides reject removing parent nullability.
+#[test]
+fn test_eval_declared_method_parameter_type_override_rejects_nullable_narrowing() {
+    assert_eval_failure_contains(
         r#"<?php
 eval('class EvalParamNullableBase {
     public function maybe(?int $value) { return $value; }
@@ -14952,13 +14976,14 @@ class EvalParamNonNullChild extends EvalParamNullableBase {
     public function maybe(int $value) { return $value; }
 }');
 "#,
+        "Fatal error: eval() runtime failed",
     );
-    assert!(
-        err.contains("Fatal error: eval() runtime failed"),
-        "stderr did not contain eval runtime fatal diagnostic: {err}"
-    );
+}
 
-    let err = compile_and_run_expect_failure(
+/// Verifies eval-declared parameter overrides reject narrowing an untyped parent.
+#[test]
+fn test_eval_declared_method_parameter_type_override_rejects_typed_child() {
+    assert_eval_failure_contains(
         r#"<?php
 eval('class EvalParamUntypedBase {
     public function read($value) { return $value; }
@@ -14967,10 +14992,7 @@ class EvalParamTypedChild extends EvalParamUntypedBase {
     public function read(int $value) { return $value; }
 }');
 "#,
-    );
-    assert!(
-        err.contains("Fatal error: eval() runtime failed"),
-        "stderr did not contain eval runtime fatal diagnostic: {err}"
+        "Fatal error: eval() runtime failed",
     );
 }
 
@@ -19472,10 +19494,10 @@ eval('class EvalAotFinalPropertyChild extends EvalAotFinalPropertyBase {
     );
 }
 
-/// Verifies eval validates generated/AOT parent property visibility and storage contracts.
+/// Verifies eval rejects reducing a generated/AOT parent property's visibility.
 #[test]
-fn test_eval_declared_class_rejects_incompatible_aot_parent_property_contracts() {
-    for source in [
+fn test_eval_declared_class_rejects_reduced_aot_parent_property_visibility() {
+    assert_eval_failure_contains(
         r#"<?php
 class EvalAotPublicPropertyBase {
     public int $value = 1;
@@ -19484,6 +19506,14 @@ eval('class EvalAotProtectedPropertyChild extends EvalAotPublicPropertyBase {
     protected int $value = 2;
 }');
 "#,
+        "Fatal error: eval() runtime failed",
+    );
+}
+
+/// Verifies eval rejects replacing a generated/AOT static property with an instance property.
+#[test]
+fn test_eval_declared_class_rejects_aot_static_property_as_instance() {
+    assert_eval_failure_contains(
         r#"<?php
 class EvalAotStaticPropertyBase {
     public static int $value = 1;
@@ -19492,6 +19522,14 @@ eval('class EvalAotInstancePropertyChild extends EvalAotStaticPropertyBase {
     public int $value = 2;
 }');
 "#,
+        "Fatal error: eval() runtime failed",
+    );
+}
+
+/// Verifies eval rejects replacing a generated/AOT readonly property with a mutable property.
+#[test]
+fn test_eval_declared_class_rejects_aot_readonly_property_as_mutable() {
+    assert_eval_failure_contains(
         r#"<?php
 class EvalAotReadonlyPropertyBase {
     public readonly int $value;
@@ -19500,6 +19538,14 @@ eval('class EvalAotMutablePropertyChild extends EvalAotReadonlyPropertyBase {
     public int $value = 2;
 }');
 "#,
+        "Fatal error: eval() runtime failed",
+    );
+}
+
+/// Verifies eval rejects redeclaring a generated/AOT private-set property.
+#[test]
+fn test_eval_declared_class_rejects_redeclared_aot_private_set_property() {
+    assert_eval_failure_contains(
         r#"<?php
 class EvalAotPrivateSetPropertyBase {
     public private(set) int $value = 1;
@@ -19508,13 +19554,8 @@ eval('class EvalAotPrivateSetPropertyChild extends EvalAotPrivateSetPropertyBase
     public private(set) int $value = 2;
 }');
 "#,
-    ] {
-        let err = compile_and_run_expect_failure(source);
-        assert!(
-            err.contains("Fatal error: eval() runtime failed"),
-            "stderr did not contain eval runtime fatal diagnostic: {err}"
-        );
-    }
+        "Fatal error: eval() runtime failed",
+    );
 }
 
 /// Verifies eval rejects incompatible generated/AOT parent property types.
@@ -19756,37 +19797,56 @@ return EvalMultiConstEnum::G + EvalMultiConstEnum::H;');
     assert_eq!(out.stdout, "12:34:56:15");
 }
 
-/// Verifies eval rejects PHP's reserved `class` class-constant name.
+/// Verifies eval classes reject PHP's reserved `class` constant name.
 #[test]
-fn test_eval_declared_reserved_class_constant_name_fails() {
-    for source in [
+fn test_eval_declared_class_rejects_reserved_class_constant_name() {
+    assert_eval_failure_contains(
         r#"<?php
 eval('class EvalBadConstName {
     const class = 1;
 }');
 "#,
+        "Fatal error: eval() fragment uses an unsupported construct",
+    );
+}
+
+/// Verifies eval interfaces reject PHP's reserved `class` constant name.
+#[test]
+fn test_eval_declared_interface_rejects_reserved_class_constant_name() {
+    assert_eval_failure_contains(
         r#"<?php
 eval('interface EvalBadIfaceConstName {
     const class = 1;
 }');
 "#,
+        "Fatal error: eval() fragment uses an unsupported construct",
+    );
+}
+
+/// Verifies eval traits reject PHP's reserved `class` constant name.
+#[test]
+fn test_eval_declared_trait_rejects_reserved_class_constant_name() {
+    assert_eval_failure_contains(
         r#"<?php
 eval('trait EvalBadTraitConstName {
     const class = 1;
 }');
 "#,
+        "Fatal error: eval() fragment uses an unsupported construct",
+    );
+}
+
+/// Verifies eval enums reject PHP's reserved `class` constant name.
+#[test]
+fn test_eval_declared_enum_rejects_reserved_class_constant_name() {
+    assert_eval_failure_contains(
         r#"<?php
 eval('enum EvalBadEnumConstName {
     const class = 1;
 }');
 "#,
-    ] {
-        let err = compile_and_run_expect_failure(source);
-        assert!(
-            err.contains("Fatal error: eval() fragment uses an unsupported construct"),
-            "stderr did not contain eval unsupported-construct diagnostic: {err}"
-        );
-    }
+        "Fatal error: eval() fragment uses an unsupported construct",
+    );
 }
 
 /// Asserts one eval fragment rejects a PHP-reserved class-like declaration name.
@@ -19945,9 +20005,9 @@ eval('class EvalAotFinalConstChild extends EvalAotFinalConstBase {
     );
 }
 
-/// Verifies eval-declared class constants preserve PHP visibility redeclaration rules.
+/// Verifies eval-declared class constants accept public visibility redeclarations.
 #[test]
-fn test_eval_declared_class_constant_visibility_contracts() {
+fn test_eval_declared_class_constant_visibility_accepts_public_redeclarations() {
     let out = compile_and_run_capture(
         r#"<?php
 eval('class EvalConstVisibilityBase {
@@ -19972,8 +20032,12 @@ echo EvalConstVisibilityImpl::TOKEN;');
         out.stdout, out.stderr
     );
     assert_eq!(out.stdout, "7:5");
+}
 
-    let err = compile_and_run_expect_failure(
+/// Verifies eval-declared class constants cannot reduce inherited public visibility.
+#[test]
+fn test_eval_declared_class_constant_visibility_rejects_reduced_parent_visibility() {
+    assert_eval_failure_contains(
         r#"<?php
 eval('class EvalConstPublicBase {
     public const SEED = 1;
@@ -19982,13 +20046,14 @@ class EvalConstProtectedChild extends EvalConstPublicBase {
     protected const SEED = 2;
 }');
 "#,
+        "Fatal error: eval() runtime failed",
     );
-    assert!(
-        err.contains("Fatal error: eval() runtime failed"),
-        "stderr did not contain eval runtime fatal diagnostic: {err}"
-    );
+}
 
-    let err = compile_and_run_expect_failure(
+/// Verifies eval-declared classes cannot reduce interface constant visibility.
+#[test]
+fn test_eval_declared_class_constant_visibility_rejects_reduced_interface_visibility() {
+    assert_eval_failure_contains(
         r#"<?php
 eval('interface EvalConstPublicContract {
     public const SEED = 1;
@@ -19997,22 +20062,20 @@ class EvalConstProtectedImpl implements EvalConstPublicContract {
     protected const SEED = 2;
 }');
 "#,
+        "Fatal error: eval() runtime failed",
     );
-    assert!(
-        err.contains("Fatal error: eval() runtime failed"),
-        "stderr did not contain eval runtime fatal diagnostic: {err}"
-    );
+}
 
-    let err = compile_and_run_expect_failure(
+/// Verifies eval-declared interfaces reject protected constants.
+#[test]
+fn test_eval_declared_interface_rejects_protected_constant() {
+    assert_eval_failure_contains(
         r#"<?php
 eval('interface EvalConstProtectedIface {
     protected const SEED = 1;
 }');
 "#,
-    );
-    assert!(
-        err.contains("Fatal error: eval() fragment uses an unsupported construct"),
-        "stderr did not contain eval unsupported-construct diagnostic: {err}"
+        "Fatal error: eval() fragment uses an unsupported construct",
     );
 }
 

--- a/tests/codegen/optimizer.rs
+++ b/tests/codegen/optimizer.rs
@@ -5,7 +5,9 @@
 //! - `cargo test` through Rust's test harness.
 //!
 //! Key details:
-//! - Submodules group focused fixtures for constant folding, constant propagation, dead-code elimination, EIR identity arithmetic folding, EIR peephole patterns, EIR dead instruction elimination, EIR dead store elimination, EIR branch simplification, EIR constant folding, EIR common-subexpression elimination, EIR loop-invariant code motion, ownership cleanup, and memory-model-aware propagation hazards.
+//! - Submodules group focused fixtures for constant folding, constant propagation,
+//!   dead-code elimination, checked integer sinks, EIR identity/peephole/CSE/LICM
+//!   passes, ownership cleanup, and memory-model-aware propagation hazards.
 
 use crate::support::*;
 
@@ -17,6 +19,8 @@ mod call_result_alias;
 mod constant_folding;
 #[path = "optimizer/constant_propagation.rs"]
 mod constant_propagation;
+#[path = "optimizer/checked_int_sink.rs"]
+mod checked_int_sink;
 #[path = "optimizer/eir_common_subexpression.rs"]
 mod eir_common_subexpression;
 #[path = "optimizer/dead_code_elimination.rs"]

--- a/tests/codegen/optimizer/checked_int_sink.rs
+++ b/tests/codegen/optimizer/checked_int_sink.rs
@@ -1,0 +1,173 @@
+//! Purpose:
+//! End-to-end regression coverage for issue #623 checked integer sink specialization.
+//!
+//! Called from:
+//! - `cargo test --test codegen_tests optimizer::checked_int_sink`.
+//!
+//! Key details:
+//! - CLI `--emit-ir` comparisons pin CSE and LICM structure with optimization on/off.
+//! - Runtime fixtures pin exact overflow casts, Mixed-observer preservation, and heap cleanup.
+
+use super::*;
+
+/// Emits optimized or unoptimized EIR and returns only the `main` function body.
+fn emit_main_ir(source: &str, extra_args: &[&str]) -> String {
+    let dir = make_cli_test_dir("elephc_issue_623_ir");
+    let php_path = dir.join("main.php");
+    fs::write(&php_path, source).expect("write issue-623 EIR fixture");
+    let mut command = elephc_cli_command(&dir);
+    command.arg("--emit-ir").args(extra_args).arg(&php_path);
+    let output = command.output().expect("run elephc --emit-ir");
+    assert!(
+        output.status.success(),
+        "emit-ir failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let text = String::from_utf8(output.stdout).expect("EIR is UTF-8");
+    let main = text
+        .split("function main(")
+        .nth(1)
+        .expect("EIR contains main")
+        .split("\n  function ")
+        .next()
+        .expect("main body")
+        .to_string();
+    let _ = fs::remove_dir_all(dir);
+    main
+}
+
+/// Compiles and runs one CLI fixture with the requested optimizer flags.
+fn compile_and_run_cli_variant(source: &str, extra_args: &[&str]) -> String {
+    let dir = make_cli_test_dir("elephc_issue_623_run");
+    let php_path = dir.join("main.php");
+    fs::write(&php_path, source).expect("write issue-623 runtime fixture");
+    let mut command = elephc_cli_command(&dir);
+    command.args(extra_args).arg(&php_path);
+    let compile = command.output().expect("compile issue-623 fixture");
+    assert!(
+        compile.status.success(),
+        "compile failed: {}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = run_binary(&dir.join("main"), &dir);
+    assert!(
+        run.status.success(),
+        "fixture failed: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8(run.stdout).expect("program stdout is UTF-8");
+    let _ = fs::remove_dir_all(dir);
+    stdout
+}
+
+/// Repeated immutable buffer indices collapse from three checked boxes to one scalar value.
+#[test]
+fn test_issue_623_cse_collapses_integer_only_index_arithmetic() {
+    let source = r#"<?php
+buffer<int> $values = buffer_new<int>(16);
+int $index = $argc;
+int $offset = 2;
+$values[$index + $offset] = $values[$index + $offset] + 1;
+echo $values[$index + $offset];
+buffer_free($values);
+"#;
+    let unoptimized = emit_main_ir(source, &["--no-ir-opt"]);
+    let optimized = emit_main_ir(source, &[]);
+
+    assert_eq!(
+        unoptimized.matches("= ichecked_add ").count(),
+        4,
+        "three indices plus the loaded-value increment start boxed"
+    );
+    assert_eq!(optimized.matches("= ichecked_add ").count(), 0);
+    assert_eq!(
+        optimized.matches("= ichecked_add_to_int ").count(),
+        2,
+        "CSE shares one index expression while the value increment remains distinct"
+    );
+    assert_eq!(compile_and_run(source), "1");
+}
+
+/// An invariant `$argc + 2` index and its constant operand move into the loop preheader.
+#[test]
+fn test_issue_623_licm_hoists_integer_only_index_arithmetic() {
+    let source = r#"<?php
+buffer<int> $values = buffer_new<int>(16);
+$values[3] = 7;
+int $i = 0;
+while ($i < 3) {
+    echo $values[$argc + 2];
+    $i++;
+}
+buffer_free($values);
+"#;
+    let unoptimized = emit_main_ir(source, &["--no-ir-opt"]);
+    let optimized = emit_main_ir(source, &[]);
+    let preheader = optimized.split("while.cond:").next().expect("loop preheader");
+    let body = optimized
+        .split("while.body:")
+        .nth(1)
+        .expect("loop body")
+        .split("while.exit:")
+        .next()
+        .expect("body before exit");
+
+    assert!(unoptimized.contains("while.body:"));
+    assert!(unoptimized.contains("= ichecked_add "));
+    assert!(preheader.contains("= ichecked_add_to_int "));
+    assert!(preheader.contains("origin: licm"));
+    assert!(!body.contains("= ichecked_add_to_int "));
+    assert_eq!(compile_and_run(source), "777");
+}
+
+/// Overflow follows PHP's double promotion and exact float-to-int cast with optimization on/off.
+#[test]
+fn test_issue_623_overflow_cast_matches_unoptimized_semantics() {
+    let source = r#"<?php
+int $one = $argc;
+echo (int) (PHP_INT_MAX + $one), "|";
+echo (int) (PHP_INT_MIN - $one), "|";
+int $three = $argc + 2;
+echo (int) (PHP_INT_MAX * $three);
+"#;
+    let expected = "-9223372036854775808|-9223372036854775808|-9223372036854775808";
+    assert_eq!(compile_and_run_cli_variant(source, &["--no-ir-opt"]), expected);
+    assert_eq!(compile_and_run_cli_variant(source, &[]), expected);
+}
+
+/// A direct Mixed observer keeps the boxed checked operation and its float result on overflow.
+#[test]
+fn test_issue_623_mixed_observer_remains_boxed() {
+    let source = "<?php int $one = $argc; echo PHP_INT_MAX + $one;";
+    let optimized = emit_main_ir(source, &[]);
+    assert!(optimized.contains("= ichecked_add "));
+    assert!(!optimized.contains("= ichecked_add_to_int "));
+    assert_eq!(
+        compile_and_run_cli_variant(source, &[]),
+        compile_and_run_cli_variant(source, &["--no-ir-opt"])
+    );
+}
+
+/// The optimized loop eliminates transient index boxes without upsetting heap ownership.
+#[test]
+fn test_issue_623_integer_sink_loop_is_heap_debug_clean() {
+    let output = compile_and_run_with_heap_debug(
+        r#"<?php
+buffer<int> $values = buffer_new<int>(16);
+$values[3] = 7;
+int $i = 0;
+while ($i < 20) {
+    echo $values[$argc + 2];
+    $i++;
+}
+buffer_free($values);
+"#,
+    );
+    assert!(output.success, "program failed: {}", output.stderr);
+    assert_eq!(output.stdout, "7".repeat(20));
+    assert!(
+        output.stderr.contains("HEAP DEBUG: leak summary: clean"),
+        "expected a clean heap, got: {}",
+        output.stderr
+    );
+}

--- a/tests/codegen/optimizer/eir_common_subexpression.rs
+++ b/tests/codegen/optimizer/eir_common_subexpression.rs
@@ -2,9 +2,9 @@
 //! Integration tests for the EIR common-subexpression elimination pass (`cse`)
 //! driven by the fixed-point pass driver. Fixtures use a local seeded from the
 //! runtime `$argc` value so the repeated subexpressions are not constant-folded
-//! away at the AST level and reach EIR, where peephole load forwarding collapses
-//! the repeated reads to one value and CSE then deduplicates the identical pure
-//! computations built on it.
+//! away at the AST level and reach EIR. Mixed-observing checked arithmetic stays
+//! boxed and is deliberately outside CSE; issue-623 integer-sink coverage lives
+//! in the adjacent `checked_int_sink` integration module.
 //!
 //! Called from:
 //! - `cargo test` through Rust's test harness.

--- a/tests/codegen/optimizer/eir_licm.rs
+++ b/tests/codegen/optimizer/eir_licm.rs
@@ -9,11 +9,11 @@
 //! - `cargo test` through Rust's test harness.
 //!
 //! Key details:
-//! - PHP loop variables live in local slots and are reloaded each iteration
-//!   through impure `load_local`, so a loop-invariant *source* expression is not
-//!   yet a pure-operand computation LICM can hoist; the pass's hoisting logic is
-//!   covered by the unit tests on hand-built EIR. These fixtures verify behavior
-//!   is preserved on real loops. `$argc` is 1 with no CLI arguments.
+//! - Mutable PHP loop variables still use effectful `load_local` instructions.
+//!   Read-only scalar inputs and single-assignment entry locals can now be proven
+//!   immutable and hoisted with dependent pure computations; issue-623 structural
+//!   coverage lives in the adjacent `checked_int_sink` module. `$argc` is 1 with
+//!   no CLI arguments.
 
 use super::*;
 


### PR DESCRIPTION
## Summary

- specialize non-constant integer `+`, `-`, and `*` when every consumer observes the result as a PHP `int`
- add allocation-free AArch64 and x86_64 lowering that preserves PHP overflow-to-float-to-int semantics
- classify provably immutable integer local loads so CSE can share repeated index arithmetic and LICM can hoist invariant expressions
- keep Mixed-observing, aliased, mutable, lifetime-pinned, and otherwise unknown consumer paths conservative

## Why

Checked integer arithmetic currently returns an owned boxed `Mixed` value because PHP promotes overflowing integer operations to float. Even when every downstream consumer immediately narrows the result back to `int`, that transient box prevents CSE and LICM from optimizing common buffer index arithmetic.

## Implementation

- introduce `ICheckedAddToInt`, `ICheckedSubToInt`, and `ICheckedMulToInt`
- add a whole-function sink analysis that rewrites only complete integer-observing use graphs and removes redundant cast/acquire/release scaffolding
- add conservative immutable-local analysis for concrete `I64` / PHP `Int` slots, rejecting reference aliases, by-reference parameters, multiple writes, non-entry writes, and unknown slot operations
- extend LICM to move proven-immutable local loads and the nullary materializations required by a hoisted computation
- lower overflow paths through the shared exact PHP float-to-int helper without allocating an intermediate Mixed cell
- update buffer documentation to describe bounds-checked native addressing and optimizer behavior accurately

## Semantics and safety

- in-range operations stay entirely scalar
- overflow recomputes the operation as double and applies the same PHP float-to-int conversion used by the unoptimized path
- direct output, returns, comparisons, Mixed stores, calls, lifetime pins, and unknown consumers retain the existing boxed checked operation
- the optimized heap-debug regression remains leak-free

## Testing

- `cargo build`
- `cargo build --release --bin elephc`
- `cargo test --lib checked_int_sink_test`
- `cargo test --lib immutable_local_loads_test`
- `cargo test --lib licm_test`
- `cargo test --test codegen_tests optimizer::checked_int_sink`
- `cargo test --test codegen_tests optimizer::eir_common_subexpression`
- `cargo test --test codegen_tests optimizer::eir_licm`
- `./scripts/test-linux-x86_64.sh checked_int_sink`
- `./scripts/test-linux-arm64.sh -p elephc checked_int_sink`
- `python3 scripts/check_asm_comments.py src/codegen/lower_inst.rs src/codegen/lower_inst/arithmetic.rs src/codegen/lower_inst/checked_int_to_int.rs`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #623
