### PR TITLE
fix: parse assignment in operand position

### DIFF
--- a/src/parser/expr/pratt.rs
+++ b/src/parser/expr/pratt.rs
@@ -360,7 +360,7 @@ fn parse_expr_bp_inner(
         }
 
         if let Some((op, l_bp, r_bp)) = assignment_bp(&tokens[*pos].0) {
-            if l_bp < min_bp {
+            if l_bp < min_bp && !is_assignment_expression_target(&lhs) {
                 break;
             }
 

--- a/tests/ir_backend_smoke_test.rs
+++ b/tests/ir_backend_smoke_test.rs
@@ -6981,3 +6981,25 @@ fn unique_test_id() -> u128 {
         .expect("system time should be after unix epoch")
         .as_nanos()
 }
+
+/// Verifies that an assignment used as the right operand of a comparison evaluates with PHP
+/// semantics: the assignment happens first and its value is what the comparison sees.
+#[test]
+fn ir_backend_evaluates_assignment_as_right_operand_of_comparison() {
+    let source = "<?php $s = \"a/b/c\"; if (false !== $pos = strrpos($s, \"/\")) { echo $pos; }";
+    assert_eq!(
+        compile_and_run_ir_backend("assign_in_comparison", source),
+        "3"
+    );
+}
+
+/// Verifies that a chained assignment inside an arithmetic expression assigns the inner
+/// variable and folds its value into the surrounding sum, matching PHP.
+#[test]
+fn ir_backend_evaluates_assignment_as_right_operand_of_arithmetic() {
+    let source = "<?php $x = 1 + $y = 2; echo $x; echo $y;";
+    assert_eq!(
+        compile_and_run_ir_backend("assign_in_arithmetic", source),
+        "32"
+    );
+}

--- a/tests/parser_tests/expressions/assignments.rs
+++ b/tests/parser_tests/expressions/assignments.rs
@@ -236,3 +236,60 @@ fn test_parse_union_typed_assign() {
         other => panic!("Expected typed assign, got {:?}", other),
     }
 }
+
+/// Verifies that an assignment used as the right operand of a comparison binds tighter
+/// than the comparison, so `false !== $pos = strrpos($s, "/")` parses as
+/// `false !== ($pos = strrpos($s, "/"))` rather than as an assignment to the comparison.
+#[test]
+fn test_assignment_as_right_operand_of_comparison() {
+    let stmts = parse_source("<?php if (false !== $pos = strrpos($s, \"/\")) { echo $pos; }");
+    let condition = match &stmts[0].kind {
+        StmtKind::If { condition, .. } => condition,
+        other => panic!("expected If, got {:?}", other),
+    };
+    match &condition.kind {
+        ExprKind::BinaryOp { left, op, right } => {
+            assert_eq!(op, &BinOp::StrictNotEq);
+            assert_eq!(left.kind, ExprKind::BoolLiteral(false));
+            assert!(
+                matches!(&right.kind, ExprKind::Assignment { .. }),
+                "expected the comparison's right operand to be an assignment, got {:?}",
+                right.kind
+            );
+        }
+        other => panic!("expected BinaryOp, got {:?}", other),
+    }
+}
+
+/// Verifies that an assignment as the right operand of an arithmetic operator binds tighter
+/// than that operator, so `$x = 1 + $y = 2;` parses as `$x = 1 + ($y = 2)`.
+#[test]
+fn test_assignment_as_right_operand_of_arithmetic() {
+    let stmts = parse_source("<?php $x = 1 + $y = 2;");
+    match &stmts[0].kind {
+        StmtKind::Assign { name, value } => {
+            assert_eq!(name, "x");
+            match &value.kind {
+                ExprKind::BinaryOp { left, op, right } => {
+                    assert_eq!(op, &BinOp::Add);
+                    assert_eq!(left.kind, ExprKind::IntLiteral(1));
+                    assert!(
+                        matches!(&right.kind, ExprKind::Assignment { .. }),
+                        "expected an assignment on the right of `+`, got {:?}",
+                        right.kind
+                    );
+                }
+                other => panic!("expected BinaryOp, got {:?}", other),
+            }
+        }
+        other => panic!("expected Assign, got {:?}", other),
+    }
+}
+
+/// Verifies that a non-variable left-hand side is still rejected, so relaxing precedence
+/// for assignment does not admit assignments to arbitrary expressions.
+#[test]
+fn test_assignment_to_non_variable_still_rejected() {
+    assert!(parse_fails("<?php $x = (1 + 2) = 3;"));
+    assert!(parse_fails("<?php $x = foo() = 3;"));
+}


### PR DESCRIPTION
## Summary

Fixes #722.

PHP spells assignment as `variable '=' expr`. Because the left-hand side must be
a `variable` rather than an arbitrary expression, an assignment is grammatical
wherever a variable has just been parsed — including positions where operator
precedence alone would have ended the expression. That is why PHP parses

```php
false !== $pos = strrpos($s, '/')
```

as `false !== ($pos = strrpos($s, '/'))`, and why the manual notes on the
operator-precedence page that `if (!$a = foo())` is allowed despite `=` binding
looser than `!`.

The Pratt loop stopped on binding power alone, so by the time the assignment
operator was reached the comparison had already been folded into the left-hand
side. `is_assignment_expression_target()` then saw `false !== $pos` and reported
`Invalid assignment target`.

The fix keeps the loop going when the left-hand side is a valid assignment
target. That predicate already mirrors PHP's `variable` non-terminal — it admits
`Variable`, `PropertyAccess`, `DynamicPropertyAccess`, `StaticPropertyAccess`
and `ArrayAccess` over those — so the condition expresses the grammar rule
directly. The binding-power table is unchanged.

```diff
-            if l_bp < min_bp {
+            if l_bp < min_bp && !is_assignment_expression_target(&lhs) {
                 break;
             }
```

A non-variable left-hand side still takes the existing error path, so
`(1 + 2) = 3` and `foo() = 3` remain rejected.

## Why it matters

Composer's generated `vendor/composer/ClassLoader.php` uses this idiom three
times (lines 500, 522 and 551 in Composer 2.8):

```php
while (false !== $lastPos = strrpos($subPath, '\\')) {
if (false !== $pos = strrpos($class, '\\')) {
if ($this->useIncludePath && $file = stream_resolve_include_path($logicalPathPsr0)) {
```

Before this change, compiling anything that reaches `vendor/autoload.php` failed
with 14 errors inside Composer's own autoloader, well before any application
code. After it, `ClassLoader.php` parses cleanly end to end; the first
diagnostic on that file is now the deliberate compile-time-constant-path
restriction on `require $file` at line 576, which is a separate matter.

## Tests

Parser (`tests/parser_tests/expressions/assignments.rs`):

* `test_assignment_as_right_operand_of_comparison` — asserts the AST shape is
  `false !== (assignment)`, not an assignment to the comparison.
* `test_assignment_as_right_operand_of_arithmetic` — `$x = 1 + $y = 2;` nests the
  assignment under the `+`.
* `test_assignment_to_non_variable_still_rejected` — `(1 + 2) = 3` and
  `foo() = 3` continue to fail, so the relaxation does not admit assignments to
  arbitrary expressions.

Execution (`tests/ir_backend_smoke_test.rs`), covering runtime semantics rather
than just parse shape:

* `ir_backend_evaluates_assignment_as_right_operand_of_comparison` — prints `3`.
* `ir_backend_evaluates_assignment_as_right_operand_of_arithmetic` — prints `32`,
  pinning the order in which the two assignments happen.

All five outputs were checked against `php` on the same snippets.

`cargo test --lib` is green (1251 + 1379 across the module suites, 0 failures)
and `cargo fmt --check` is clean.

Two pre-existing failures on `main` are unrelated to this change and reproduce on
an unmodified checkout:

* `codegen_support::abi::tests::basics::test_emit_frame_prologue_rejects_undersized_frame`
  hangs and is eventually SIGKILLed.
* `cargo clippy` fails in `elephc-builtin-contract` with
  `approximate value of f{32,64}::consts::E found`.
