### PR TITLE
ci: build and release Linux x86_64/arm64 binaries

### DIFF
--- a/.github/workflows/backfill-linux.yml
+++ b/.github/workflows/backfill-linux.yml
@@ -1,0 +1,153 @@
+name: Backfill Linux Release Assets
+
+# Adds Linux x86_64 / ARM64 tarballs to a release that was published before
+# release.yml built Linux targets. Dispatch once per tag; assets upload to the
+# existing release without touching its notes, date, or the macOS assets.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to backfill (v0.25.2 or newer)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  verify:
+    name: Verify tag eligibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require Linux CI coverage (v0.25.2+)
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          # The full sharded Linux test suite entered CI with 0468eeab9 and
+          # first shipped in v0.25.2. Older tags never ran the Linux suite, so
+          # refuse to publish untested Linux binaries for them.
+          FLOOR="v0.25.2"
+          if [ "$(printf '%s\n' "$FLOOR" "$TAG" | sort -V | head -n1)" != "$FLOOR" ]; then
+            echo "::error::${TAG} predates Linux CI coverage (${FLOOR}); refusing to backfill."
+            exit 1
+          fi
+
+      - name: Require an existing GitHub release for the tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName
+
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    needs:
+      - verify
+    strategy:
+      # Each architecture uploads independently; a failure on one runner must
+      # not cancel the other upload.
+      fail-fast: false
+      matrix:
+        include:
+          # Same runner generation as release.yml: glibc 2.35 keeps the
+          # binaries usable on older distros (Ubuntu 22.04, Debian 12, RHEL 9).
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-22.04
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-22.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set version from tag
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          # The tagged commit does not contain the release version: the release
+          # workflow patches Cargo.toml/Cargo.lock after tagging and pushes the
+          # bump to main separately. Re-apply the same patch locally so the
+          # backfilled binary reports the right --version.
+          VERSION="${TAG#v}"
+          export VERSION
+          python3 - <<'PY'
+          from pathlib import Path
+          import os
+          import re
+
+          version = os.environ["VERSION"]
+
+          cargo_toml = Path("Cargo.toml")
+          cargo_toml.write_text(
+              re.sub(
+                  r'^version = ".*"$',
+                  f'version = "{version}"',
+                  cargo_toml.read_text(),
+                  count=1,
+                  flags=re.MULTILINE,
+              )
+          )
+
+          cargo_lock = Path("Cargo.lock")
+          cargo_lock.write_text(
+              re.sub(
+                  r'(\[\[package\]\]\nname = "elephc"\nversion = ")[^"]+(")',
+                  rf'\g<1>{version}\2',
+                  cargo_lock.read_text(),
+                  count=1,
+              )
+          )
+          PY
+          echo "Set Cargo.toml and Cargo.lock version to ${VERSION}"
+
+      - name: Determine the staticlib set shipped by this release
+        run: |
+          # The bridge staticlib set has changed over time (bcmath joined after
+          # v0.26.0). Mirror exactly what this tag's own release workflow put
+          # in the macOS tarball instead of hardcoding today's set.
+          LIBS="$(grep -o 'libelephc_[a-z_]*\.a' .github/workflows/release.yml | sort -u | tr '\n' ' ')"
+          test -n "${LIBS// /}"
+          CRATES=""
+          for lib in $LIBS; do
+            name="${lib#libelephc_}"
+            name="${name%.a}"
+            CRATES="$CRATES -p elephc-${name//_/-}"
+          done
+          echo "BRIDGE_LIBS=$LIBS" >> "$GITHUB_ENV"
+          echo "BRIDGE_CRATES=$CRATES" >> "$GITHUB_ENV"
+          echo "Staticlibs for this tag: $LIBS"
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Build release bridge staticlibs
+        run: |
+          # shellcheck disable=SC2086 # BRIDGE_CRATES expands to multiple -p flags
+          cargo build --release $BRIDGE_CRATES
+
+      - name: Strip binary
+        run: strip target/release/elephc
+
+      - name: Create tarball
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          cd target/release
+          TARBALL="elephc-${TAG}-${{ matrix.target }}.tar.gz"
+          # shellcheck disable=SC2086 # BRIDGE_LIBS expands to multiple archives
+          tar czf "$TARBALL" elephc $BRIDGE_LIBS
+          sha256sum "$TARBALL" > "$TARBALL.sha256"
+
+      - name: Upload assets to the existing release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          gh release upload "$TAG" \
+            "target/release/elephc-${TAG}-${{ matrix.target }}.tar.gz" \
+            "target/release/elephc-${TAG}-${{ matrix.target }}.tar.gz.sha256" \
+            --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,21 +56,24 @@ jobs:
 
           echo "Found successful Build & Test check: ${CHECK_URL}"
 
-  build:
-    name: Build macOS ARM64
+  prepare:
+    name: Bump version on main
     if: github.event.ref_type == 'tag' && startsWith(github.event.ref, 'v')
-    runs-on: macos-14  # Apple Silicon runner
+    runs-on: ubuntu-latest
     needs:
       - verify-ci
+    outputs:
+      # The bump commit every build job checks out, so all three targets build
+      # the same patched tree without re-applying (or racing to push) the
+      # version bump themselves.
+      sha: ${{ steps.bump.outputs.sha }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Set version from tag and commit
+      - name: Set version from tag and push bump to main
+        id: bump
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           export VERSION
@@ -108,6 +111,34 @@ jobs:
           git add Cargo.toml Cargo.lock
           git commit -m "chore: bump version to ${VERSION}" || true
           git push origin HEAD:main
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.target }}
+    if: github.event.ref_type == 'tag' && startsWith(github.event.ref, 'v')
+    runs-on: ${{ matrix.runner }}
+    needs:
+      - verify-ci
+      - prepare
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            runner: macos-14  # Apple Silicon runner
+          # Linux release builds run on ubuntu-22.04 (glibc 2.35) rather than
+          # the ubuntu-24.04 generation CI tests on, so the published binaries
+          # also run on older distros (Ubuntu 22.04, Debian 12, RHEL 9, ...).
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-22.04
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-22.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build release binary
         run: cargo build --release
@@ -118,14 +149,11 @@ jobs:
       - name: Strip binary
         run: strip target/release/elephc
 
-      - name: Get version
-        id: version
-        run: echo "version=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
-
       - name: Create tarball
         run: |
           cd target/release
-          tar czf elephc-${{ steps.version.outputs.version }}-aarch64-apple-darwin.tar.gz \
+          TARBALL="elephc-${GITHUB_REF_NAME}-${{ matrix.target }}.tar.gz"
+          tar czf "$TARBALL" \
             elephc \
             libelephc_tls.a \
             libelephc_pdo.a \
@@ -135,28 +163,54 @@ jobs:
             libelephc_tz.a \
             libelephc_image.a \
             libelephc_web.a
-          shasum -a 256 elephc-${{ steps.version.outputs.version }}-aarch64-apple-darwin.tar.gz > elephc-${{ steps.version.outputs.version }}-aarch64-apple-darwin.tar.gz.sha256
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$TARBALL" > "$TARBALL.sha256"
+          else
+            shasum -a 256 "$TARBALL" > "$TARBALL.sha256"
+          fi
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.target }}
+          path: |
+            target/release/elephc-*.tar.gz
+            target/release/elephc-*.tar.gz.sha256
+          retention-days: 1
+          if-no-files-found: error
+
+  release:
+    name: Publish release
+    if: github.event.ref_type == 'tag' && startsWith(github.event.ref, 'v')
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          merge-multiple: true
+          path: dist
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: |
-            target/release/elephc-${{ steps.version.outputs.version }}-aarch64-apple-darwin.tar.gz
-            target/release/elephc-${{ steps.version.outputs.version }}-aarch64-apple-darwin.tar.gz.sha256
+          files: dist/*
 
       - name: Update Homebrew tap
         env:
           TAP_TOKEN: ${{ secrets.TAP_TOKEN }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
+          VERSION="${GITHUB_REF_NAME}"
           VERSION_NUM="${VERSION#v}"
           TARBALL="elephc-${VERSION}-aarch64-apple-darwin.tar.gz"
-          SHA256=$(cat target/release/${TARBALL}.sha256 | awk '{print $1}')
+          SHA256=$(awk '{print $1}' "dist/${TARBALL}.sha256")
           URL="https://github.com/illegalstudio/elephc/releases/download/${VERSION}/${TARBALL}"
 
           # Clone tap repo
-          git clone https://x-access-token:${TAP_TOKEN}@github.com/illegalstudio/homebrew-tap.git /tmp/homebrew-tap
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/illegalstudio/homebrew-tap.git" /tmp/homebrew-tap
           mkdir -p /tmp/homebrew-tap/Formula
 
           # Generate formula

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -66,9 +66,24 @@ cp target/release/elephc /usr/local/bin/
 
 ## From GitHub releases
 
-Pre-built binaries may be available on the [releases page](https://github.com/illegalstudio/elephc/releases). Download the artifact for your platform, make it executable if needed, and move it to your `PATH`:
+Each release on the [releases page](https://github.com/illegalstudio/elephc/releases)
+ships a tarball per supported platform:
+
+- `elephc-<version>-aarch64-apple-darwin.tar.gz` — macOS ARM64
+- `elephc-<version>-x86_64-unknown-linux-gnu.tar.gz` — Linux x86_64
+- `elephc-<version>-aarch64-unknown-linux-gnu.tar.gz` — Linux ARM64
+
+Each tarball contains the `elephc` binary plus the bridge staticlibs
+(`libelephc_*.a`) that compiled programs link against. Install them in a layout
+elephc searches: the staticlibs either in the same directory as the binary, or
+in a `lib/` directory next to the `bin/` directory holding the binary — for
+example `/usr/local/bin` and `/usr/local/lib`:
 
 ```bash
-chmod +x elephc
-mv elephc /usr/local/bin/
+tar xzf elephc-<version>-<target>.tar.gz
+sudo install -m 755 elephc /usr/local/bin/
+sudo install -m 644 libelephc_*.a /usr/local/lib/
 ```
+
+The Linux tarballs are built against glibc 2.35 and run on any distribution
+with that glibc or newer (Ubuntu 22.04+, Debian 12+, RHEL 9+, ...).


### PR DESCRIPTION
Split release.yml into a version-bump prepare job, a three-target build
matrix (macOS ARM64, Linux x86_64/arm64 on ubuntu-22.04 for glibc 2.35),
and a single publish job. Add a manual backfill workflow that uploads
Linux tarballs to existing releases (v0.25.2+, mirroring each tag's own
staticlib set), and document the per-platform tarballs.
