### PR TITLE
feat: add CLI version flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,16 @@ jobs:
       - name: Build release binary
         run: cargo build --release
 
+      - name: Verify release binary version
+        run: |
+          EXPECTED="elephc ${GITHUB_REF_NAME#v}"
+          ACTUAL="$(target/release/elephc --version)"
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "::error::Release version mismatch: expected '${EXPECTED}', got '${ACTUAL}'."
+            exit 1
+          fi
+          echo "Verified release binary version: ${ACTUAL}"
+
       - name: Build release bridge staticlibs
         run: cargo build --release -p elephc-tls -p elephc-pdo -p elephc-crypto -p elephc-bcmath -p elephc-phar -p elephc-tz -p elephc-image -p elephc-web
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ elephc hello.php
 ./hello
 elephc hello.lfc
 
+# Print the compiler version
+elephc --version
+elephc -V
+
 # Custom heap size (default: 8MB)
 elephc --heap-size=16777216 heavy.php
 

--- a/docs/compiling/cli-reference.md
+++ b/docs/compiling/cli-reference.md
@@ -16,12 +16,13 @@ exhaustive *what*.
 
 ```text
 elephc [OPTIONS] <source-file>
+elephc --version
 elephc native <COMMAND> [OPTIONS]
 ```
 
-Exactly one positional argument is required: the path to tagged `.php` or
-tagless `.lfc` source. The binary is written next to it, named after the source
-without its extension.
+Except for `--help` and `--version`, exactly one positional argument is required:
+the path to tagged `.php` or tagless `.lfc` source. The binary is written next
+to it, named after the source without its extension.
 Only an exact first argument of `native` selects the package command family. A
 source file literally named `native` must therefore be passed as `./native` or
 by another explicit path.
@@ -414,6 +415,8 @@ The other 44 directives of the PHP 8.5 set are runtime-overridable.
 | `--quiet` / `-q` | — | off | Disable progress lines and colorized compiler output. |
 | `--gc-stats` | — | off | Print allocation/free counters at exit. |
 | `--heap-debug` | — | off | Enable runtime heap verification (double-free, bad refcount, free-list corruption). |
+| `--help` / `-h` | — | off | Print the compiler help, including the current elephc version, and exit successfully. |
+| `--version` / `-V` | — | off | Print the elephc compiler version and exit successfully. |
 | `--mascotte` | — | off | Print the embedded ASCII mascot and a randomly selected quote before normal output. |
 
 See [Output formats and diagnostics](output-and-diagnostics.md).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,6 +24,9 @@ const RUNTIME_CAPABILITY_FLAGS: &[&str] = &["regex"];
 /// The full categorized reference lives in `HELP`.
 pub(crate) const USAGE: &str = "Usage: elephc [OPTIONS] <source-file>";
 
+/// Compiler package version embedded into the binary by Cargo.
+pub(crate) const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 /// ASCII mascot printed by `--mascotte`, embedded at compile time (not read
 /// from a filesystem path — the original source file lives outside this
 /// repo, on one contributor's machine, and wouldn't exist anywhere else).
@@ -77,11 +80,17 @@ fn wants_help(args: &[String]) -> bool {
     args.iter().any(|a| a == "-h" || a == "--help")
 }
 
+/// Returns true if `-V` or `--version` appears anywhere in the argument list.
+fn wants_version(args: &[String]) -> bool {
+    args.iter().any(|a| a == "-V" || a == "--version")
+}
+
 /// Full `--help` reference text, categorized by section. Printed to stdout
 /// with exit code 0 — this is a successful, requested action, not an error.
-pub(crate) const HELP: &str = "Usage: elephc [OPTIONS] <source-file>
+pub(crate) const HELP: &str = concat!("Usage: elephc [OPTIONS] <source-file>
 
 A PHP-to-native AOT compiler
+Version: ", env!("CARGO_PKG_VERSION"), "
 
 Arguments:
   <source-file>           Tagged .php or tagless .lfc source file to compile
@@ -126,8 +135,9 @@ Diagnostics:
 
 Other:
   -h, --help              Print this help and exit
+  -V, --version           Print version and exit
   --mascotte              Print an ASCII mascot and a random quote before output
-";
+");
 
 /// Configuration derived from command-line arguments, passed to the compile pipeline.
 /// Controls heap allocation size, debug output, code generation options, and linking behavior.
@@ -223,6 +233,10 @@ fn parse_compile_args(args: &[String]) -> CliConfig {
     }
     if wants_help(args) {
         println!("{HELP}");
+        process::exit(0);
+    }
+    if wants_version(args) {
+        println!("elephc {VERSION}");
         process::exit(0);
     }
 
@@ -981,6 +995,39 @@ mod tests {
     fn wants_help_false_without_help_flag() {
         let args = vec!["elephc".into(), "app.php".into()];
         assert!(!wants_help(&args));
+    }
+
+    /// Verifies `--version` is detected anywhere in the argument list.
+    #[test]
+    fn wants_version_detects_long_flag_anywhere() {
+        let args = vec![
+            "elephc".into(),
+            "--check".into(),
+            "--version".into(),
+            "app.php".into(),
+        ];
+        assert!(wants_version(&args));
+    }
+
+    /// Verifies `-V` is detected as the short alias for `--version`.
+    #[test]
+    fn wants_version_detects_short_flag() {
+        let args = vec!["elephc".into(), "-V".into()];
+        assert!(wants_version(&args));
+    }
+
+    /// Verifies normal arguments are not mistaken for a version request.
+    #[test]
+    fn wants_version_false_without_version_flag() {
+        let args = vec!["elephc".into(), "app.php".into()];
+        assert!(!wants_version(&args));
+    }
+
+    /// Verifies help exposes both the current compiler version and its version flags.
+    #[test]
+    fn help_includes_version_and_version_flags() {
+        assert!(HELP.contains(&format!("Version: {VERSION}")));
+        assert!(HELP.contains("-V, --version"));
     }
 
     /// Verifies `--mascotte` is detected anywhere in the argument list.

--- a/tests/codegen/cli.rs
+++ b/tests/codegen/cli.rs
@@ -10,6 +10,34 @@
 
 use crate::support::*;
 
+/// Verifies both compiler version flags print the Cargo package version and exit successfully.
+#[test]
+fn test_cli_version_flags_report_package_version() {
+    let dir = make_cli_test_dir("elephc_cli_version");
+    let expected = format!("elephc {}\n", env!("CARGO_PKG_VERSION"));
+
+    for flag in ["--version", "-V"] {
+        let output = elephc_cli_command(&dir)
+            .arg(flag)
+            .output()
+            .unwrap_or_else(|error| panic!("failed to run elephc {flag}: {error}"));
+        assert!(output.status.success(), "elephc {flag} should succeed");
+        assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
+        assert!(output.stderr.is_empty(), "elephc {flag} should not write stderr");
+    }
+
+    let help = elephc_cli_command(&dir)
+        .arg("--help")
+        .output()
+        .expect("failed to run elephc --help");
+    assert!(help.status.success(), "elephc --help should succeed");
+    let stdout = String::from_utf8_lossy(&help.stdout);
+    assert!(stdout.contains(&format!("Version: {}", env!("CARGO_PKG_VERSION"))));
+    assert!(stdout.contains("-V, --version"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
 /// Verifies native help is handled before project discovery and bare native is a usage error.
 #[test]
 fn test_cli_native_help_and_bare_usage() {


### PR DESCRIPTION
## Summary

- add `--version` and `-V` to the elephc compiler CLI, reporting the Cargo package version
- show the current compiler version and both version flags in `--help`
- document the new top-level command and cover both aliases with unit and end-to-end tests

## Testing

- `cargo build --bin elephc`
- `cargo test --bin elephc wants_version`
- `cargo test --bin elephc help_includes_version_and_version_flags`
- `cargo test --test codegen_tests test_cli_version_flags_report_package_version`
- `cargo fmt --all -- --check`
- `git diff --check`

