### PR TITLE
ci: raise the slow-timeout for the eval readonly-property test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -111,6 +111,14 @@ filter = 'test(test_eval_declared_inherited_property_redeclaration_contracts)'
 slow-timeout = { period = "180s", terminate-after = 1 }
 
 [[profile.default.overrides]]
+filter = 'test(test_eval_declared_readonly_property_rules)'
+slow-timeout = { period = "180s", terminate-after = 1 }
+
+[[profile.ci.overrides]]
+filter = 'test(test_eval_declared_readonly_property_rules)'
+slow-timeout = { period = "180s", terminate-after = 1 }
+
+[[profile.default.overrides]]
 filter = 'test(test_eval_declared_interface_property_hook_contracts)'
 slow-timeout = { period = "180s", terminate-after = 1 }
 


### PR DESCRIPTION
The macOS eval shards intermittently fail with

```
TRY 2 TMT [ 60.014s] elephc::codegen_tests codegen::eval::test_eval_declared_readonly_property_rules
(test timed out)
```

The test is not hung. It compiles, links and runs several complete programs through the eval path in one test, and measures **38s on an unloaded Linux host** — 63% of the global 60s guard — before the eval shards' `-j 2` and GitHub's shared macOS runners are involved. On a loaded runner it crosses the line, both attempts terminate, and the shard fails.

This gives it the same 180s budget the neighbouring eval regression tests already carry, following the per-test pattern this file established.

### Worth a separate decision

It joins **eight siblings from the same `codegen::eval` family** already listed in `.config/nextest.toml`, added one at a time as each one flaked. That pattern suggests the group as a whole sits near the guard, and a single `binary(codegen_tests) and test(~codegen::eval)` override would stop the recurring churn.

I did not do that here: it would weaken the guard for every eval test, so a genuinely hung one would take 180s to be caught instead of 60s. That is a policy call for the maintainers rather than something to fold into a flake fix.

### Verification

`cargo nextest list` could not be run locally (building the full test binary set exhausts this machine's disk), so the filter was verified by exact-string comparison instead: the test name is byte-identical across the source (`tests/codegen/eval.rs:16418`), the CI failure log, and both new override entries, and it uses the same `test(...)` form as the ten existing entries.