### PR TITLE
refactor(monitor): `--live` asks the program it launched, `--attach` reads it — neither is macOS-only now

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,8 @@ elephc --gc-stats heavy.php
 # profile on disk, inlined calls recovered as virtual frames (macOS)
 elephc monitor hot.php
 
-# Top-style live view of a running program and its worker children
+# Top-style live view of a running program and its worker children. Reads the
+# process from the outside, so build it with --keep-symbols and allow tracing
 elephc monitor --attach <pid> --live
 
 # Embed the profiling capability (dormant until asked); the .key sidecar it

--- a/crates/elephc-probe/src/lib.rs
+++ b/crates/elephc-probe/src/lib.rs
@@ -1107,6 +1107,18 @@ pub unsafe extern "C" fn elephc_probe_init(table: *const SymtabEntry, len: usize
         flag.write(1);
         ASKED.store(true, Ordering::Relaxed);
         arm_timer();
+        // The same channel that said "you are being monitored" can also answer
+        // "what have you sampled so far" — but only for a monitor that said it
+        // would ask. The exact path spawns, waits for the program to finish and
+        // reads its output; a thread parked in `recv` for the whole of that run
+        // is one nobody wanted, and one more thing between the program and its
+        // exit.
+        if POLLED.load(Ordering::Relaxed) {
+            std::thread::Builder::new()
+                .name("elephc-probe-control".to_string())
+                .spawn(serve_control_channel)
+                .ok();
+        }
     }
 
     // fork() RESETS interval timers in the child (POSIX; `man 2 fork`), so a
@@ -1124,7 +1136,7 @@ pub unsafe extern "C" fn elephc_probe_init(table: *const SymtabEntry, len: usize
     // The remote endpoint is opt-in: a Unix socket path in ELEPHC_PROBE_ADDR
     // turns it on. A background thread accepts connections, runs the build-key
     // handshake, and serves the folded profile — so a live production process
-    // can be profiled by `elephc monitor --probe-host` without SIGPROF from
+    // can be profiled by `elephc monitor <addr>` without SIGPROF from
     // outside and without suspending the process.
     if !key.is_null() {
         if let Ok(path) = std::env::var("ELEPHC_PROBE_ADDR") {
@@ -1133,6 +1145,119 @@ pub unsafe extern "C" fn elephc_probe_init(table: *const SymtabEntry, len: usize
             }
         }
     }
+}
+
+/// Request byte the monitor sends on the control channel to ask for a snapshot
+/// of what has been sampled so far.
+///
+/// One byte, because the channel carries exactly one question. Anything else is
+/// ignored rather than answered: fd 3 is an ordinary number and this thread must
+/// never invent a reply to a protocol it does not own.
+const CONTROL_SNAPSHOT_REQUEST: u8 = b'S';
+
+/// Serves sampled snapshots to the process that launched us, over the control
+/// channel it already holds the other end of.
+///
+/// The channel IS the credential. A socketpair created before the fork cannot be
+/// opened, guessed, or replayed by anything else on the machine, which is why
+/// this path needs no key handshake where the network endpoint does — the same
+/// reasoning that lets init treat its magic byte as "you are being monitored".
+///
+/// What this buys is `--live` without an external sampler. Reading a process
+/// from the outside needs a tool that ships on macOS alone, so the live table
+/// was macOS-only — for a program `monitor` had launched ITSELF, and could
+/// therefore simply have asked. Answering here is the ask.
+///
+/// Snapshots are cumulative, exactly as the endpoint's answer is; a caller that
+/// wants one window subtracts two of them. Keeping the accumulation on this side
+/// would mean the probe deciding what a window is, which is the caller's
+/// question, and would lose a sample to every reader that ever disconnected.
+fn serve_control_channel() {
+    // Both for the reasons the endpoint thread blocks them. SIGPIPE: a monitor
+    // that exits mid-write must not take the profiled process down with it.
+    // SIGPROF: `ITIMER_PROF` is delivered to the PROCESS and the kernel picks
+    // any thread not blocking it, so the sampler would otherwise interrupt this
+    // thread and fill the ring with the profiler's own frames instead of the
+    // ones running PHP.
+    unsafe {
+        let mut set: libc::sigset_t = std::mem::zeroed();
+        libc::sigemptyset(&mut set);
+        libc::sigaddset(&mut set, libc::SIGPIPE);
+        libc::sigaddset(&mut set, libc::SIGPROF);
+        libc::pthread_sigmask(libc::SIG_BLOCK, &set, std::ptr::null_mut());
+    }
+    loop {
+        let mut request = [0u8; 1];
+        // Safety: CONTROL_FD is the socketpair end init identified; this thread
+        // is its only reader.
+        let read = unsafe {
+            libc::recv(
+                CONTROL_FD,
+                request.as_mut_ptr() as *mut libc::c_void,
+                1,
+                0,
+            )
+        };
+        if read < 0 {
+            // A signal that arrived mid-wait is not the monitor leaving. Treating
+            // `EINTR` as the end would stop serving snapshots silently, and the
+            // live loop on the other side reads that as "the target is gone" and
+            // stops with the program still running.
+            if std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return;
+        }
+        if read == 0 {
+            // A real EOF: the monitor is gone, which is the end of the reason
+            // this thread exists.
+            return;
+        }
+        if request[0] != CONTROL_SNAPSHOT_REQUEST {
+            continue;
+        }
+        let profile = sampled_answer();
+        let bytes = profile.as_bytes();
+        let header = (bytes.len() as u32).to_le_bytes();
+        if !control_send_all(&header) || !control_send_all(bytes) {
+            return;
+        }
+    }
+}
+
+/// Writes every byte of `data` to the control channel, or reports that it could
+/// not.
+///
+/// A short write on a stream socket is ordinary, not an error, and a reply that
+/// stops halfway is worse than no reply: the reader is length-prefixed and would
+/// block waiting for a body that is never coming.
+fn control_send_all(data: &[u8]) -> bool {
+    let mut sent = 0usize;
+    while sent < data.len() {
+        // Safety: writing `data`'s own bytes to a socket this thread owns.
+        let wrote = unsafe {
+            libc::send(
+                CONTROL_FD,
+                data[sent..].as_ptr() as *const libc::c_void,
+                data.len() - sent,
+                0,
+            )
+        };
+        if wrote < 0 {
+            // Same reasoning as the read side: an interrupted write has sent
+            // nothing and can simply be retried, where reporting failure would
+            // truncate a reply the reader is length-prefixed to wait for.
+            if std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return false;
+        }
+        if wrote == 0 {
+            return false;
+        }
+        sent += wrote as usize;
+    }
+    true
 }
 
 /// Starts sampled collection, because someone authenticated and asked for it.
@@ -1403,8 +1528,29 @@ const CONTROL_FD: i32 = 3;
 /// buffered when the child looks. A stray inherited socket on the same descriptor
 /// says nothing and is ignored.
 const CONTROL_MAGIC: &[u8] = b"ELEPHC-MONITOR-1";
+/// The same marker, from a monitor that intends to POLL this process for
+/// snapshots rather than read its output at the end.
+///
+/// Same length as the plain one, so the peek that decides whether fd 3 is ours
+/// is unchanged — it reads a fixed sixteen bytes and compares. Written before
+/// the fork like the other, which is what makes this free of a race: the child
+/// cannot look before the parent has decided.
+///
+/// The distinction earns its keep by NOT starting a server for a run that will
+/// never ask. `--live` polls; the exact path spawns, waits for the program to
+/// end and reads its output, and a thread parked in `recv` for the whole of that
+/// is a thread nobody wanted.
+const CONTROL_MAGIC_LIVE: &[u8] = b"ELEPHC-MONITOR-L";
 /// Returned to the spawning monitor only after the marker was consumed.
 const CONTROL_ACK: &[u8] = b"ELEPHC-MONITOR-ACK-1";
+
+/// Whether the monitor that started this process said it would poll it.
+///
+/// Set by the marker check, read by init. A plain word rather than a return
+/// value because `control_fd_present` answers a yes/no question that three
+/// callers already depend on, and widening it would make every one of them
+/// carry a distinction only one of them uses.
+static POLLED: AtomicBool = AtomicBool::new(false);
 
 /// Whether this process was started by `elephc monitor`.
 ///
@@ -1447,9 +1593,11 @@ fn control_fd_present() -> bool {
             buf.len(),
             libc::MSG_PEEK | libc::MSG_DONTWAIT,
         );
-        if read != CONTROL_MAGIC.len() as isize || buf != CONTROL_MAGIC {
+        let polled = buf == CONTROL_MAGIC_LIVE;
+        if read != CONTROL_MAGIC.len() as isize || (buf != CONTROL_MAGIC && !polled) {
             return false;
         }
+        POLLED.store(polled, Ordering::Relaxed);
         // It is ours: consume the marker so nothing downstream reads it back.
         libc::recv(
             CONTROL_FD,
@@ -1732,9 +1880,73 @@ fn decode_hex(text: &str) -> Option<Vec<u8>> {
     Some(out)
 }
 
+/// How far the fold has already carried, as a ticket number.
+///
+/// The ring's head only grows, so this is a watermark: everything below it has
+/// been taken out of the buffer and added to `CARRIED`, and re-reading it would
+/// count the same samples twice.
+static CARRIED_THROUGH: AtomicU64 = AtomicU64::new(0);
+
+/// Everything carried out of the ring so far.
+///
+/// Touched only by a reader — the control thread answering a snapshot, or the
+/// exit-time dump — and never by the signal handler, which is what makes a lock
+/// safe here at all.
+static CARRIED: std::sync::Mutex<Carried> = std::sync::Mutex::new(Carried::new());
+
+/// The cumulative half of the answer: stacks, allocation weights, and the count
+/// of samples that produced a walkable stack.
+struct Carried {
+    folded: std::collections::BTreeMap<Vec<String>, u64>,
+    allocated: std::collections::BTreeMap<Vec<String>, u64>,
+    valid: u64,
+}
+
+impl Carried {
+    const fn new() -> Self {
+        Self {
+            folded: std::collections::BTreeMap::new(),
+            allocated: std::collections::BTreeMap::new(),
+            valid: 0,
+        }
+    }
+}
+
+/// Adds one fold's worth of ring to what has been carried, and answers the
+/// running total.
+///
+/// A poisoned lock answers the fresh fold rather than panicking: a profiler that
+/// takes the program down because its own bookkeeping tripped is worse than one
+/// that reports a short window.
+fn carry_forward(
+    taken: u64,
+    folded: std::collections::BTreeMap<Vec<String>, u64>,
+    allocated: std::collections::BTreeMap<Vec<String>, u64>,
+    valid: u64,
+) -> (
+    std::collections::BTreeMap<Vec<String>, u64>,
+    std::collections::BTreeMap<Vec<String>, u64>,
+    u64,
+) {
+    let Ok(mut carried) = CARRIED.lock() else {
+        return (folded, allocated, valid);
+    };
+    for (stack, count) in folded {
+        *carried.folded.entry(stack).or_default() += count;
+    }
+    for (stack, allocs) in allocated {
+        *carried.allocated.entry(stack).or_default() += allocs;
+    }
+    carried.valid += valid;
+    CARRIED_THROUGH.store(taken, Ordering::Relaxed);
+    (carried.folded.clone(), carried.allocated.clone(), carried.valid)
+}
+
 /// Renders the current folded profile for the endpoint responder.
 pub fn current_folded_profile() -> Option<String> {
-    unsafe { folded_profile() }
+    // Cumulative: this is the answer `monitor --live` subtracts one window from
+    // the previous, and the endpoint's own contract says the same.
+    unsafe { folded_profile_with(true) }
 }
 
 /// How long the first sampled answer waits for collection to produce something.
@@ -1829,6 +2041,24 @@ pub unsafe extern "C" fn elephc_probe_dump() {
 /// a concurrent handler may add a sample mid-read (endpoint) — a raced slot
 /// only skews one count, never corrupts memory.
 unsafe fn folded_profile() -> Option<String> {
+    folded_profile_with(false)
+}
+
+/// The same fold, optionally CUMULATIVE across calls.
+///
+/// `cumulative` is what the snapshot answer needs and the exit dump does not.
+/// The dump reads once, with the timer disarmed, and "everything still in the
+/// ring" is exactly right for it; a reader that asks every window needs the
+/// total, because the ring stops growing the moment its head wraps and a
+/// consumer subtracting one answer from the last then sees nothing at all.
+///
+/// Kept as a parameter rather than made unconditional because a fold that
+/// carries is not idempotent, and both the dump and the tests fold more than
+/// once expecting the same answer twice.
+///
+/// # Safety
+/// As `folded_profile`.
+unsafe fn folded_profile_with(cumulative: bool) -> Option<String> {
     let table = TABLE_PTR.load(Ordering::Relaxed) as *const SymtabEntry;
     let table_len = TABLE_LEN.load(Ordering::Relaxed);
     if table.is_null() || table_len == 0 {
@@ -1850,8 +2080,26 @@ unsafe fn folded_profile() -> Option<String> {
 
     let head = region_head()?;
     let base = REGION.load(Ordering::Relaxed);
-    let taken = head.load(Ordering::Relaxed) as usize;
-    let available = taken.min(RING_SLOTS);
+    let taken = head.load(Ordering::Relaxed);
+    // Fold by TICKET, not by slot, and only the tickets not folded already.
+    //
+    // The ring holds the last `RING_SLOTS` samples, so folding all of it answers
+    // "the recent window" — which stops growing the moment the head wraps. The
+    // answer is documented as CUMULATIVE and `monitor --live` subtracts one from
+    // the previous on that basis, so past 8192 samples every delta went zero or
+    // negative and the live table emptied while the program ran flat out. What
+    // is cumulative is not the ring; it is what has been carried out of it.
+    //
+    // A slot caught mid-write is skipped, as it always was, and the watermark
+    // still advances past it: one sample lost rather than the same slot counted
+    // again on the next read. The reader that falls more than a full ring behind
+    // loses what was overwritten, which no fixed ring can avoid.
+    let oldest_live = taken.saturating_sub(RING_SLOTS as u64);
+    let from = if cumulative {
+        CARRIED_THROUGH.load(Ordering::Relaxed).max(oldest_live)
+    } else {
+        oldest_live
+    };
     let mut valid = 0u64;
     let mut folded: std::collections::BTreeMap<Vec<String>, u64> = std::collections::BTreeMap::new();
     // Allocations charged to each stack, kept apart from the sample counts: they
@@ -1859,7 +2107,8 @@ unsafe fn folded_profile() -> Option<String> {
     // profile whose bars mean two things at once.
     let mut allocated: std::collections::BTreeMap<Vec<String>, u64> =
         std::collections::BTreeMap::new();
-    for index in 0..available {
+    for ticket in from..taken {
+        let index = (ticket % RING_SLOTS as u64) as usize;
         // Acquire the depth gate before reading the PCs the handler stored; a
         // torn or in-flight slot with depth 0 is skipped.
         // Read the sequence first: odd means a handler is inside this slot right
@@ -1916,6 +2165,14 @@ unsafe fn folded_profile() -> Option<String> {
         }
         *folded.entry(stack).or_default() += 1;
     }
+    // Carried out of the ring before anything is rendered, so what the answer
+    // reports is every sample since the process started and not merely the ones
+    // still in the buffer.
+    let (folded, allocated, valid) = if cumulative {
+        carry_forward(taken, folded, allocated, valid)
+    } else {
+        (folded, allocated, valid)
+    };
     // A dormant binary took no samples and recorded no events. Saying
     // "elephc-probe-samples: 0" would still announce a profiler to anyone
     // reading the program's own stderr, which is exactly what
@@ -2508,6 +2765,116 @@ mod tests {
             !mid_write.as_deref().unwrap_or_default().contains(name),
             "a slot a handler is inside must not fold, however readable it looks: {mid_write:?}"
         );
+    }
+
+    /// The cumulative answer keeps growing after the ring's head has lapped.
+    ///
+    /// The ring holds the last `RING_SLOTS` samples, so folding all of it
+    /// answers "the recent window" — and `monitor --live` subtracts one answer
+    /// from the previous on the documented promise that it is CUMULATIVE. Past
+    /// 8192 samples the count stopped growing, so every later delta was zero or
+    /// negative and the live table emptied while the program ran flat out. The
+    /// CLI fixtures run six seconds at about a kilohertz and never reach the
+    /// lap, which is why nothing saw it.
+    ///
+    /// Staged rather than run for real: a fixture long enough to take 8192
+    /// samples is eight seconds of CPU in a unit test, and what is under test is
+    /// the arithmetic across the lap, not the sampler.
+    #[test]
+    fn a_lapped_ring_still_answers_a_growing_total() {
+        let _serial = ROUTE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let name = "hot\0";
+        let end = "<end>\0";
+        let symbols = [
+            SymtabEntry {
+                address: 0x1000,
+                name_ptr: name.as_ptr() as u64,
+                name_len: name.len() as u64,
+            },
+            SymtabEntry {
+                address: 0x2000,
+                name_ptr: end.as_ptr() as u64,
+                name_len: end.len() as u64,
+            },
+        ];
+        let mut region = vec![0u8; REGION_BYTES];
+        let base = region.as_mut_ptr() as usize;
+
+        let saved_region = REGION.swap(base, Ordering::Relaxed);
+        let saved_ptr = TABLE_PTR.swap(symbols.as_ptr() as usize, Ordering::Relaxed);
+        let saved_len = TABLE_LEN.swap(symbols.len(), Ordering::Relaxed);
+        let saved_stopped = STOPPED.swap(false, Ordering::Relaxed);
+        reset_carried();
+
+        let answers = unsafe {
+            let head = region_head().expect("mapped");
+
+            // One sample, taken as ticket 0 and still in the ring.
+            head.store(1, Ordering::Relaxed);
+            region_word(base, 0, 0).store(1, Ordering::Release);
+            region_word(base, 0, PC_WORD0).store(0x1000, Ordering::Relaxed);
+            region_word(base, 0, SEQ_WORD).store(slot_seq_settled(0), Ordering::Release);
+            let first = folded_profile_with(true);
+
+            // Asked AGAIN with nothing new taken. The total must not move: a
+            // sample still sitting in the ring has already been carried, and a
+            // fold that re-reads it counts it twice — which grows the total for
+            // the wrong reason and would hide the lap defect from this test.
+            let asked_twice = folded_profile_with(true);
+
+            // The head has now lapped: `RING_SLOTS` further samples were taken
+            // and the newest of them landed back in slot 0, overwriting the one
+            // above. All the reader can still SEE is one sample; the total it
+            // must report is two.
+            let lapped = RING_SLOTS as u64 + 1;
+            head.store(lapped, Ordering::Relaxed);
+            region_word(base, 0, 0).store(1, Ordering::Release);
+            region_word(base, 0, PC_WORD0).store(0x1000, Ordering::Relaxed);
+            region_word(base, 0, SEQ_WORD).store(slot_seq_settled(lapped - 1), Ordering::Release);
+            let after_lap = folded_profile_with(true);
+            (first, asked_twice, after_lap)
+        };
+
+        REGION.store(saved_region, Ordering::Relaxed);
+        TABLE_PTR.store(saved_ptr, Ordering::Relaxed);
+        TABLE_LEN.store(saved_len, Ordering::Relaxed);
+        STOPPED.store(saved_stopped, Ordering::Relaxed);
+        reset_carried();
+
+        let (first, asked_twice, after_lap) = answers;
+        let first = first.unwrap_or_default();
+        let asked_twice = asked_twice.unwrap_or_default();
+        let after_lap = after_lap.unwrap_or_default();
+        assert!(
+            first.contains("elephc-probe-samples: 1"),
+            "the first answer counts the one sample taken: {first}"
+        );
+        assert!(
+            asked_twice.contains("elephc-probe-samples: 1"),
+            "asking twice must not count the same sample twice: {asked_twice}"
+        );
+        assert!(
+            after_lap.contains("elephc-probe-samples: 2"),
+            "a lapped ring must still answer a GROWING total; a count that stops at what the \
+             buffer still holds is what emptied the live table: {after_lap}"
+        );
+        // Matched on the tail rather than on `"hot 2"`: the fixture's symbol
+        // names carry their C terminator, so the folded line reads `hot\0 2`.
+        assert!(
+            after_lap
+                .lines()
+                .any(|line| line.starts_with("elephc-probe: ") && line.ends_with(" 2")),
+            "and the per-stack weight has to grow with it: {after_lap}"
+        );
+    }
+
+    /// Clears what previous folds carried, so one test's samples are not another
+    /// test's total. The accumulator is process-wide by design.
+    fn reset_carried() {
+        CARRIED_THROUGH.store(0, Ordering::Relaxed);
+        if let Ok(mut carried) = CARRIED.lock() {
+            *carried = Carried::new();
+        }
     }
 
     /// Two writers a lap apart cannot agree on a settled value.

--- a/crates/elephc-probe/src/lib.rs
+++ b/crates/elephc-probe/src/lib.rs
@@ -1114,10 +1114,11 @@ pub unsafe extern "C" fn elephc_probe_init(table: *const SymtabEntry, len: usize
         // is one nobody wanted, and one more thing between the program and its
         // exit.
         if POLLED.load(Ordering::Relaxed) {
-            std::thread::Builder::new()
-                .name("elephc-probe-control".to_string())
-                .spawn(serve_control_channel)
-                .ok();
+            start_control_channel(CONTROL_FD, || {
+                std::thread::Builder::new()
+                    .name("elephc-probe-control".to_string())
+                    .spawn(serve_control_channel)
+            });
         }
     }
 
@@ -1143,6 +1144,25 @@ pub unsafe extern "C" fn elephc_probe_init(table: *const SymtabEntry, len: usize
             if !path.is_empty() {
                 endpoint::spawn(path);
             }
+        }
+    }
+}
+
+/// Starts the control server, disconnecting the authenticated channel on failure.
+/// A receive timeout cannot distinguish a slow server from one that never started.
+/// Closing the unserved peer lets the monitor report failure and leave PHP running.
+/// The spawn operation is injected so resource exhaustion can be tested without
+/// exhausting the application's own thread or memory limits.
+fn start_control_channel(
+    fd: libc::c_int,
+    spawn: impl FnOnce() -> std::io::Result<std::thread::JoinHandle<()>>,
+) {
+    if spawn().is_err() {
+        // SAFETY: init owns this authenticated socket and no server was created.
+        // Shutdown also disconnects any inherited duplicates of the peer.
+        unsafe {
+            libc::shutdown(fd, libc::SHUT_RDWR);
+            libc::close(fd);
         }
     }
 }
@@ -2863,6 +2883,51 @@ mod tests {
                 .any(|line| line.starts_with("elephc-probe: ") && line.ends_with(" 2")),
             "and the per-stack weight has to grow with it: {after_lap}"
         );
+    }
+
+    /// A refused thread spawn must expose EOF, not an unserved socket that times out.
+    #[test]
+    fn failed_control_thread_start_disconnects_the_monitor() {
+        use std::io::{Read, Write};
+        use std::os::fd::IntoRawFd;
+        use std::os::unix::net::UnixStream;
+
+        let (mut monitor, mut server) = UnixStream::pair().unwrap();
+        monitor.set_read_timeout(Some(std::time::Duration::from_millis(200))).unwrap();
+        server.write_all(&CONTROL_ACK).unwrap();
+        start_control_channel(server.into_raw_fd(), || {
+            Err(std::io::Error::from_raw_os_error(libc::EAGAIN))
+        });
+        let mut ack = [0; CONTROL_ACK.len()];
+        monitor.read_exact(&mut ack).unwrap();
+        assert_eq!(ack, CONTROL_ACK);
+        let mut byte = [0];
+        assert_eq!(monitor.read(&mut byte).expect("startup failure must not become a timeout"), 0);
+    }
+
+    /// Successful startup retains the peer so the server can answer its monitor.
+    #[test]
+    fn successful_control_thread_start_keeps_the_channel_open() {
+        use std::io::{Read, Write};
+        use std::os::fd::{FromRawFd, IntoRawFd};
+        use std::os::unix::net::UnixStream;
+
+        let (mut monitor, server) = UnixStream::pair().unwrap();
+        monitor.set_read_timeout(Some(std::time::Duration::from_secs(2))).unwrap();
+        let fd = server.into_raw_fd();
+        start_control_channel(fd, || {
+            std::thread::Builder::new().spawn(move || {
+                // SAFETY: ownership transfers only after the server thread starts.
+                let mut server = unsafe { UnixStream::from_raw_fd(fd) };
+                let mut request = [0];
+                server.read_exact(&mut request).unwrap();
+                server.write_all(&request).unwrap();
+            })
+        });
+        monitor.write_all(b"S").unwrap();
+        let mut answer = [0];
+        monitor.read_exact(&mut answer).unwrap();
+        assert_eq!(&answer, b"S");
     }
 
     /// Concurrent endpoint/control readers must count each settled ticket once,

--- a/crates/elephc-probe/src/lib.rs
+++ b/crates/elephc-probe/src/lib.rs
@@ -1880,18 +1880,10 @@ fn decode_hex(text: &str) -> Option<Vec<u8>> {
     Some(out)
 }
 
-/// How far the fold has already carried, as a ticket number.
-///
-/// The ring's head only grows, so this is a watermark: everything below it has
-/// been taken out of the buffer and added to `CARRIED`, and re-reading it would
-/// count the same samples twice.
-static CARRIED_THROUGH: AtomicU64 = AtomicU64::new(0);
-
 /// Everything carried out of the ring so far.
 ///
-/// Touched only by a reader — the control thread answering a snapshot, or the
-/// exit-time dump — and never by the signal handler, which is what makes a lock
-/// safe here at all.
+/// Shared by control-channel and endpoint readers, never by the signal handler.
+/// The lock covers ticket selection, folding and publication as one transaction.
 static CARRIED: std::sync::Mutex<Carried> = std::sync::Mutex::new(Carried::new());
 
 /// The cumulative half of the answer: stacks, allocation weights, and the count
@@ -1900,14 +1892,18 @@ struct Carried {
     folded: std::collections::BTreeMap<Vec<String>, u64>,
     allocated: std::collections::BTreeMap<Vec<String>, u64>,
     valid: u64,
+    /// First ticket not yet included in these totals; protected by the same lock.
+    through: u64,
 }
 
 impl Carried {
+    /// Creates an empty accumulator before any ring tickets have been consumed.
     const fn new() -> Self {
         Self {
             folded: std::collections::BTreeMap::new(),
             allocated: std::collections::BTreeMap::new(),
             valid: 0,
+            through: 0,
         }
     }
 }
@@ -1915,10 +1911,9 @@ impl Carried {
 /// Adds one fold's worth of ring to what has been carried, and answers the
 /// running total.
 ///
-/// A poisoned lock answers the fresh fold rather than panicking: a profiler that
-/// takes the program down because its own bookkeeping tripped is worse than one
-/// that reports a short window.
+/// The caller holds the accumulator lock from ticket selection through publication.
 fn carry_forward(
+    carried: &mut Carried,
     taken: u64,
     folded: std::collections::BTreeMap<Vec<String>, u64>,
     allocated: std::collections::BTreeMap<Vec<String>, u64>,
@@ -1928,9 +1923,6 @@ fn carry_forward(
     std::collections::BTreeMap<Vec<String>, u64>,
     u64,
 ) {
-    let Ok(mut carried) = CARRIED.lock() else {
-        return (folded, allocated, valid);
-    };
     for (stack, count) in folded {
         *carried.folded.entry(stack).or_default() += count;
     }
@@ -1938,7 +1930,7 @@ fn carry_forward(
         *carried.allocated.entry(stack).or_default() += allocs;
     }
     carried.valid += valid;
-    CARRIED_THROUGH.store(taken, Ordering::Relaxed);
+    carried.through = taken;
     (carried.folded.clone(), carried.allocated.clone(), carried.valid)
 }
 
@@ -2052,9 +2044,8 @@ unsafe fn folded_profile() -> Option<String> {
 /// total, because the ring stops growing the moment its head wraps and a
 /// consumer subtracting one answer from the last then sees nothing at all.
 ///
-/// Kept as a parameter rather than made unconditional because a fold that
-/// carries is not idempotent, and both the dump and the tests fold more than
-/// once expecting the same answer twice.
+/// The raw dump stays independent of the snapshot accumulator. Repeated reads
+/// without new samples are idempotent in either mode.
 ///
 /// # Safety
 /// As `folded_profile`.
@@ -2078,6 +2069,11 @@ unsafe fn folded_profile_with(cumulative: bool) -> Option<String> {
         .collect();
     symbols.sort_by_key(|(address, _)| *address);
 
+    // Readers share both the totals and the ticket watermark. Hold one lock
+    // across selection, folding and publication so concurrent endpoint/control
+    // readers cannot carry the same interval twice. A poisoned transaction has
+    // no trustworthy totals; return no profile instead of publishing a false one.
+    let mut carried = if cumulative { Some(CARRIED.lock().ok()?) } else { None };
     let head = region_head()?;
     let base = REGION.load(Ordering::Relaxed);
     let taken = head.load(Ordering::Relaxed);
@@ -2095,8 +2091,8 @@ unsafe fn folded_profile_with(cumulative: bool) -> Option<String> {
     // again on the next read. The reader that falls more than a full ring behind
     // loses what was overwritten, which no fixed ring can avoid.
     let oldest_live = taken.saturating_sub(RING_SLOTS as u64);
-    let from = if cumulative {
-        CARRIED_THROUGH.load(Ordering::Relaxed).max(oldest_live)
+    let from = if let Some(carried) = carried.as_ref() {
+        carried.through.max(oldest_live)
     } else {
         oldest_live
     };
@@ -2168,11 +2164,12 @@ unsafe fn folded_profile_with(cumulative: bool) -> Option<String> {
     // Carried out of the ring before anything is rendered, so what the answer
     // reports is every sample since the process started and not merely the ones
     // still in the buffer.
-    let (folded, allocated, valid) = if cumulative {
-        carry_forward(taken, folded, allocated, valid)
+    let (folded, allocated, valid) = if let Some(carried) = carried.as_mut() {
+        carry_forward(carried, taken, folded, allocated, valid)
     } else {
         (folded, allocated, valid)
     };
+    drop(carried);
     // A dormant binary took no samples and recorded no events. Saying
     // "elephc-probe-samples: 0" would still announce a profiler to anyone
     // reading the program's own stderr, which is exactly what
@@ -2868,10 +2865,63 @@ mod tests {
         );
     }
 
+    /// Concurrent endpoint/control readers must count each settled ticket once,
+    /// including both sample counts and allocation weights after a full ring.
+    #[test]
+    fn concurrent_readers_carry_each_ring_ticket_once() {
+        let _serial = ROUTE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let name = "concurrent_hot";
+        let end = "<end>";
+        let symbols = [
+            SymtabEntry { address: 0x1000, name_ptr: name.as_ptr() as u64, name_len: name.len() as u64 },
+            SymtabEntry { address: 0x2000, name_ptr: end.as_ptr() as u64, name_len: end.len() as u64 },
+        ];
+        let mut region = vec![0u64; REGION_BYTES / 8];
+        let base = region.as_mut_ptr() as usize;
+        let saved_region = REGION.swap(base, Ordering::Relaxed);
+        let saved_ptr = TABLE_PTR.swap(symbols.as_ptr() as usize, Ordering::Relaxed);
+        let saved_len = TABLE_LEN.swap(symbols.len(), Ordering::Relaxed);
+        reset_carried();
+        unsafe {
+            for ticket in 0..RING_SLOTS {
+                region_word(base, ticket, 0).store(1, Ordering::Release);
+                region_word(base, ticket, 2).store(3, Ordering::Relaxed);
+                region_word(base, ticket, PC_WORD0).store(0x1000, Ordering::Relaxed);
+                region_word(base, ticket, SEQ_WORD)
+                    .store(slot_seq_settled(ticket as u64), Ordering::Release);
+            }
+            region_head().expect("mapped").store(RING_SLOTS as u64, Ordering::Relaxed);
+        }
+        let barrier = &std::sync::Barrier::new(4);
+        let answers = std::thread::scope(|scope| {
+            let readers: Vec<_> = (0..4)
+                .map(|_| scope.spawn(move || {
+                    barrier.wait();
+                    current_folded_profile()
+                }))
+                .collect();
+            readers.into_iter().map(|reader| reader.join().unwrap()).collect::<Vec<_>>()
+        });
+        let serial = current_folded_profile();
+        REGION.store(saved_region, Ordering::Relaxed);
+        TABLE_PTR.store(saved_ptr, Ordering::Relaxed);
+        TABLE_LEN.store(saved_len, Ordering::Relaxed);
+        reset_carried();
+        for answer in answers.into_iter().chain([serial]) {
+            let answer = answer.expect("published symbols");
+            for expected in [
+                format!("elephc-probe-samples: {RING_SLOTS}"),
+                format!("elephc-probe: {name} {RING_SLOTS}"),
+                format!("elephc-probe-alloc: {name} {}", RING_SLOTS * 3),
+            ] {
+                assert!(answer.lines().any(|line| line == expected), "{answer}");
+            }
+        }
+    }
+
     /// Clears what previous folds carried, so one test's samples are not another
     /// test's total. The accumulator is process-wide by design.
     fn reset_carried() {
-        CARRIED_THROUGH.store(0, Ordering::Relaxed);
         if let Ok(mut carried) = CARRIED.lock() {
             *carried = Carried::new();
         }

--- a/docs/beyond-php/profiling.md
+++ b/docs/beyond-php/profiling.md
@@ -59,8 +59,8 @@ The capability matrix is explicit about each dimension:
 | local `monitor` | not measured as an OS CPU clock; the UI can show wall minus recorded waits | exact enter/exit time, rooted at `{main}` | exact | exact / exact | exact | exact curl operations and wait | not available | exact DB-driver and network wait | untagged local run |
 | service default | sampled CPU-time ring | unavailable; blocked time is invisible | unavailable | exact deltas only between samples, with sampled attribution; no retained count | unavailable in combined `--with-monitoring` | unavailable in combined `--with-monitoring` | unavailable | unavailable in combined `--with-monitoring` | sampled stacks carry the exact route tag |
 | service `--exact` or signed request | not measured separately; wall minus recorded waits is only a derived remainder | exact for one completed request, rooted at `{main}` | exact | exact / exact | exact | exact curl operations and wait | not available | exact DB-driver and network wait | exact request route/trace context |
-| `--live` | sampled externally | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable |
-| `--attach` | sampled externally | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable |
+| `--live` | sampled CPU, asked over the channel | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable |
+| `--attach` | sampled from the outside (`ptrace` on Linux, `/usr/bin/sample` on macOS) | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable |
 
 A probe-only binary can emit exact per-route DB and outgoing-network operation
 and wait counters beside its sampled stacks. `--with-monitoring` links both
@@ -203,12 +203,33 @@ elephc monitor hot.php --live          # top-style, refreshed each window
 elephc monitor --attach <pid> --live   # profile a process already running
 ```
 
-These two are the exception to *exact by default*, and the only place the
-distinction still surfaces. They read a process from the **outside**, once per
-millisecond of CPU time, because that is the only way to look at a program that
-is already running under someone else's control. So their numbers are sampled
-estimates, they cannot see time spent blocked on I/O, and they need
-`/usr/bin/sample` — which ships on macOS only.
+These two are the exception to *exact by default*. Both answer from the sampled
+ring rather than the instrumented table, once per millisecond of CPU time, so
+their numbers are estimates that sharpen as samples accumulate and neither can
+see time spent blocked on I/O.
+
+Where they differ is who is being asked. `--live` **launches** the program, so it
+hands it a socketpair and asks it directly — the same channel the exact path has
+always used, and the reason a live table needs no external tool and works
+wherever elephc does. `--attach` is given a pid that is already running under
+someone else's control, with no channel in, so reading it means reading a process
+from the **outside**: `/usr/bin/sample` on macOS, and on Linux elephc does it
+itself, stopping each thread with `ptrace` and walking its frame chain.
+
+Reading from the outside asks two things of the target that asking it does not:
+
+- **Its symbols.** An address is not a name. elephc strips the symbol table by
+  default, because nothing *inside* a program reads it — so build a program you
+  intend to attach to with `--keep-symbols` (or `--debug-info`). Attaching to a
+  stripped binary says so rather than reporting a profile of `<native>`.
+- **Permission to trace it.** On Linux, `yama/ptrace_scope` commonly restricts
+  attaching to descendants; the refusal names the setting when it is what stopped
+  you. In a container, `--cap-add=SYS_PTRACE` and a seccomp profile that permits
+  `ptrace`.
+
+Neither applies to the endpoint, which is why it stays the answer for a program
+you cannot rebuild or are not allowed to trace: start it with
+`ELEPHC_PROBE_ADDR` and read it with `elephc monitor <addr>`.
 
 `--live` refreshes a top-style table once per window (`--duration`, default 3s in
 live mode) with trend arrows against the previous window and a cumulative share.
@@ -344,8 +365,9 @@ card rather than a glaring white one, while the hot end stays gold → magenta.
 
 ### Per-line source view
 
-A **sampled** capture (`--live`, `--attach`) can place every sample on a *source
-line*, because a sample is an address and the dSYM says which line owns it. Open
+A **sampled** capture can place every sample on a *source line*, because a sample
+is an address and the dSYM says which line owns it — so this view needs a macOS
+build with its `.dSYM` beside the binary. Open
 the call graph and hit **📄 Source** (or `s`):
 
 ```text
@@ -673,14 +695,15 @@ its callees'). Across a run the exclusive times sum to the root's inclusive — 
 real partition of the program's time.
 
 A **sampled** view exists alongside it in three paths. A running service's
-default endpoint answer comes from the in-process CPU-time ring;
-`--live` and `--attach` read a process from the outside with `/usr/bin/sample`.
-All three report estimates that sharpen as samples accumulate, carry noise
-(around ±0.3 points at ~1,500 samples), and cannot see time spent blocked on I/O
-because their CPU-time clocks do not tick while a program waits. Only the
-in-process ring carries sampled allocation deltas and route tags; external
-`--live`/`--attach` do not. Where a page or table shows sampled numbers it says
-so.
+default endpoint answer comes from the in-process CPU-time ring, and so does
+`--live`, which launches its target and asks it over a socketpair. Only
+`--attach` reads a process from the outside, because it is handed a pid and has
+no channel in. All three report estimates that sharpen as samples accumulate,
+carry noise (around ±0.3 points at ~1,500 samples), and cannot see time spent
+blocked on I/O because their CPU-time clocks do not tick while a program waits.
+An outside reading carries no sampled allocation deltas or route tags — those
+come from the in-process ring, which `--attach` is not talking to. Where a page
+or table shows sampled numbers it says so.
 
 ### Narrowing it to a few functions
 
@@ -787,7 +810,11 @@ where a figure would otherwise be trusted further than it should be:
   case that is exact.
 - **At most 4,096 coroutines can be suspended at once.** Past that a suspension
   is refused and the frame is left where it was, which is the old attribution
-  rather than a new one; the report says how many.
+  rather than a new one; the report says how many. A suspension also releases
+  whatever was still parked under its own coroutine: a fiber address is handed to
+  the next fiber once the first is freed, so a group still standing under it
+  belongs to a coroutine that is gone and will never be resumed. Abandoned
+  generators therefore cost a slot only until their address is reused.
 
 **Memory too.** `incl_allocs` / `excl_allocs` are the exact number of heap
 allocations attributed to each function — the same shadow-stack math applied to
@@ -1098,6 +1125,12 @@ so any Perfetto/`chrome://tracing`-compatible viewer opens it. Standalone, set
 running a monitored binary. The trace is bounded (500k calls by default)
 so a hot program's trace stays openable; the overflow count is reported.
 
+A coroutine is the one thing that produces more than one slice per call. A
+suspension ends a span exactly as a return does, so a generator resumed three
+times appears as three slices on its own row, with the consumer's work between
+them where it belongs — and an abandoned generator still gets the slice it ran
+for, even though its exit never arrives.
+
 ### Recommendations and assertions
 
 `monitor` ends with a short **recommendations** section — the time
@@ -1264,13 +1297,24 @@ sampled function makes inlining visible by difference.
   self-restart) keeps the armed sampling timer, which would kill the new image.
   Call the exported `elephc_probe_disarm` before such an exec. Ordinary
   `exec()`/`proc_open`/`popen` (which fork first) are already safe.
-- **`--live` and `--attach` are macOS-only.** They read a process from the
-  outside, which needs `/usr/bin/sample`; no equivalent ships on Linux. The
-  Linux answer needs no external tool: run the program with `ELEPHC_PROBE_ADDR`
-  set and read it with `elephc monitor <addr>`, which reaches a live process and
-  answers from the sample ring, or with `--exact` returns the measured
-  per-function table for one completed request. Everything else — profiling a
-  source, a binary, a service, the assertions, the exports, `--stitch` — is
+- **`--attach` needs symbols, permission, and frame pointers.** It is handed a
+  pid already running under someone else's control, so there is no channel in and
+  it has to read the process from the outside — `/usr/bin/sample` on macOS,
+  `ptrace` on Linux. That costs three things asking does not: the target must
+  keep its symbol table (`--keep-symbols`), the kernel must permit tracing it
+  (`yama/ptrace_scope`, `CAP_SYS_PTRACE` in a container), and its stacks are
+  walked through the frame pointer, so a chain that loses one ends there rather
+  than being guessed past. Where any of the three is missing, the endpoint needs
+  none of them: run the program with `ELEPHC_PROBE_ADDR` set and read it with
+  `elephc monitor <addr>`, which reaches a live process and answers from the
+  sample ring, or with `--exact` returns the measured per-function table for one
+  completed request.
+
+  `--live` used to be listed here beside it and did not belong: it LAUNCHES the
+  target, so it can hand it a socketpair and ask, exactly as the exact path
+  always has. It simply never opened one, and reading its own child from the
+  outside was the consequence. Everything else — profiling a source, a binary, a
+  service, the assertions, the exports, `--stitch` — was already
   platform-independent.
 - **A service answers from the ring by default; `--exact` measures one request.**
   `elephc monitor <addr>` returns folded sampled stacks — shares that sharpen as

--- a/docs/compiling/cli-reference.md
+++ b/docs/compiling/cli-reference.md
@@ -57,8 +57,8 @@ selection, toolchain overrides, and transactional behavior.
 |---|---|---|
 | `monitor` | `<program\|source.php> [--html <file>] [--trace <file>] [--assert <expr>] [--assert-file <file>] [--save <file>] [--baseline <file>] [--out <file.speedscope.json>]` | Profile a program built with `--with-monitoring` (a `.php` source is built first): exact per-function wall time, allocations, retained objects, DB-driver wait, SQL queries, outgoing network operations and network wait, plus calls, rooted at `{main}`. File I/O is not measured. A service endpoint answers from the sampled CPU-time ring instead unless `--exact` requests one completed request. A binary without the capability is refused. |
 | `monitor <address>` | `<host:port\|http://host\|https://host\|/path/to.sock> [--key <file>] [--out <file>] [--pprof <file>] [--dot <file>] [--html <file>]` | Profile a service already running. Sampled CPU time, allocation attribution and route tags by default; no blocked wall time or combined-build SQL/wait summary. `--exact` returns the measured table for the next completed request. Needs the build key. |
-| `monitor --attach` | `<pid> [--live] [--duration <seconds>]` | Monitor an already-running local process (and its worker children) instead of spawning one. Sampled, and macOS-only. |
-| `monitor --live` | `<program\|source.php> [--duration <seconds>] [--html <file>] [--serve <host:port>]` | Top-style table refreshed once per window. Sampled, and macOS-only. |
+| `monitor --attach` | `<pid> [--live] [--duration <seconds>]` | Monitor an already-running local process (and its worker children) instead of spawning one. Sampled, and reads the process from the outside, so the target must have been built with `--keep-symbols` and the OS must permit tracing it. |
+| `monitor --live` | `<program\|source.php> [--duration <seconds>] [--html <file>] [--serve <host:port>]` | Top-style table refreshed once per window. Sampled — it answers from the ring — but on every platform: it launches the program, so it asks over the same control channel the exact path uses rather than reading it from the outside. |
 | `monitor --stitch` | `<log> [<log>...] [--html <file>] [--otlp <endpoint>] [--prometheus <file>]` | Correlate per-request slices from several services into distributed traces, joined by W3C trace id; summarise them per service and route, and export them as OpenTelemetry spans or Prometheus metrics. |
 
 `elephc monitor` runs the program and renders what it measured: a per-function
@@ -87,7 +87,7 @@ because a degraded profile that looks like the real one is worse than none.
 | launched default | exact wall; recorded waits are derived dimensions, not OS CPU | exact | exact plus exact retained | exact DB queries and curl operations; no file-I/O metrics; exact DB and network wait | untagged |
 | service default | sampled CPU; no blocked wall time | none | exact inter-sample deltas with sampled attribution; no retained | none in combined `--with-monitoring`; no file-I/O metrics | sampled stacks carry route tags |
 | service `--exact` / signed request | exact request wall; no separate OS CPU | exact | exact plus exact retained | exact DB queries and curl operations; no file-I/O metrics; exact DB and network wait | exact request route/trace |
-| `--live` / `--attach` | external sampled CPU only | none | none | none | none |
+| `--live` / `--attach` | sampled CPU only — `--live` asks the child it launched, `--attach` reads the process from the outside (`ptrace` on Linux, `/usr/bin/sample` on macOS) | none | none | none | none |
 
 Reading a running service (`monitor <address>`) needs the build key: from
 `--key <file>`, the `ELEPHC_PROBE_KEY` hex environment variable, or a `.key`
@@ -126,12 +126,17 @@ bare-binary capture cannot, and the asymmetry reads as phantom deltas.
 Sampling noise on identical runs measures around ±0.3 points at ~1,500
 samples; thresholds of a few points are well clear of it.
 
-`--live` and `--attach` read a process from the **outside** with `/usr/bin/sample`
-— the only way to look at a program already running under someone else's control,
-with nothing built into it. Their numbers are sampled shares, they cannot see
-time spent blocked on I/O, and they need macOS. On Linux, or for a process that
-does carry the capability, use `monitor <address>`: it answers from the process's
-own CPU-time sample ring, which also cannot see blocked wall time. In a combined
+`--live` launches its target, so it can hand it a socketpair and **ask**: it needs
+no external tool and works wherever elephc does. `--attach` is handed a pid that
+is already running under someone else's control, with no channel in, so it reads
+the process from the **outside** — `/usr/bin/sample` on macOS, and on Linux
+elephc does it itself, stopping each thread with `ptrace` and walking its frame
+chain. Reading from the outside also needs the target's symbol table
+(`--keep-symbols`) and the kernel's permission (`yama/ptrace_scope`, or
+`CAP_SYS_PTRACE` in a container). Both report sampled shares and cannot see time
+spent blocked on I/O. For a process that carries the capability, use
+`monitor <address>`: it answers from the process's own CPU-time sample ring,
+which also cannot see blocked wall time. In a combined
 `--with-monitoring` build that default answer has no SQL/wait summary; `--exact`
 returns the measured per-function table and DB-driver wait for one completed
 request.
@@ -140,10 +145,11 @@ request.
 (`--duration`, default 3s in live mode): the current window's shares with
 trend arrows against the previous window, the cumulative share alongside, and
 a final cumulative table on exit. `--attach <pid>` monitors a process that is
-already running — Ctrl-C stops monitoring and leaves it running. In both
-modes the target's direct children are discovered each window and merged, so
-a `--web` prefork server is measured across all its workers, not just the
-master. Live mode skips inlined-frame recovery to keep the refresh light. When
+already running — Ctrl-C stops monitoring and leaves it running. `--attach`
+discovers the target's direct children each window and merges them, so a
+`--web` prefork server is measured across all its workers, not just the master.
+A launched `--live` asks the program it started, over the channel it handed it,
+so its answer is that process's own. Live mode skips inlined-frame recovery to keep the refresh light. When
 the sampler refuses (it will not read a process it did not spawn without
 elevation), the command says so rather than reporting an empty capture.
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -354,7 +354,7 @@ src/
 │   ├── function_variants.rs   Include-loaded function-variant dispatcher emission
 │   ├── literal_defaults.rs    Literal property defaults → backend-native values
 │   ├── eval_*_helpers.rs      Eval-to-native bridge helpers: callables, class constants, constructors, methods, properties, ref args, reflection (+ owners), static properties (9 files)
-│   ├── shared_{count_guard,helper,mixed_string}.rs Shared once-per-program helper frames and common frame plumbing (3 files)
+│   ├── shared_*.rs            Shared once-per-program helper frames: the count() TypeError guard, the boxed-mixed __toString ladder, their common helper-frame plumbing, and the module-wide state that dedupes callable descriptors and owns the label counter (4 files)
 │   ├── fibers.rs              Fiber-aware EIR codegen integration
 │   └── web.rs                 `--web` program-entry lowering
 │

--- a/src/ir_passes/inline.rs
+++ b/src/ir_passes/inline.rs
@@ -753,6 +753,24 @@ fn transplant_callee_body(
 
             let mut new_inst = old_inst.clone();
             new_inst.result = new_res;
+            // A load whose effects were stripped was proven pure IN THE CALLEE,
+            // and that proof does not travel. `immutable_local_loads` clears
+            // `READS_LOCAL` from a load of a slot it can show is written once —
+            // which a parameter of a small function always is. Spliced into a
+            // caller's LOOP, that same slot is written once PER ITERATION, and
+            // the load is no longer pure at all: LICM took the purity at face
+            // value and hoisted `spin`'s `$rounds` read above the store that
+            // gives it a value, so `while (…) { $t += spin(1000); }` ran the
+            // inner `for ($i = 0; $i < $rounds; …)` against whatever the frame
+            // held and never came back.
+            //
+            // Restored rather than re-proven: the pass runs again on the host
+            // and will strip it a second time where it is still true, so being
+            // conservative here costs a round, and being wrong costs the
+            // program.
+            if new_inst.op == Op::LoadLocal {
+                new_inst.effects |= Op::LoadLocal.default_effects();
+            }
             host.instructions.push(new_inst);
             // Re-borrow block only for append.
             host.block_mut(new_bid)

--- a/src/ir_passes/tests/inline_test.rs
+++ b/src/ir_passes/tests/inline_test.rs
@@ -487,6 +487,91 @@ fn inliner_handles_multi_block_callee() {
     assert!(validate_module(&module).is_ok());
 }
 
+/// A load the CALLEE proved pure does not stay pure in the caller.
+///
+/// `immutable_local_loads` clears `READS_LOCAL` from a load whose slot it can
+/// show is written once — which a parameter of a small function always is, and
+/// which CSE and LICM then rely on. Spliced into a caller's LOOP that slot is
+/// written once PER ITERATION, so the proof is gone and the load is not pure at
+/// all: LICM took it at face value and hoisted `spin`'s `$rounds` read above the
+/// store that gives it a value, and `while (...) { $t += spin(1000); }` ran
+/// `for ($i = 0; $i < $rounds; ...)` against whatever the frame happened to hold
+/// and never came back.
+///
+/// Asserted on the spliced instruction rather than by running such a program,
+/// because the wrong answer there is a HANG — and a test that hangs reports
+/// nothing.
+#[test]
+fn inliner_restores_the_effects_of_a_load_it_splices() {
+    let mut module = Module::new(Target::new(Platform::MacOS, Arch::AArch64));
+
+    let mut callee = Function::new("reads_param".to_string(), IrType::I64, PhpType::Int);
+    let slot = callee.add_local(
+        Some("rounds".to_string()),
+        IrType::I64,
+        PhpType::Int,
+        LocalKind::PhpLocal,
+    );
+    {
+        let mut b = Builder::new(&mut callee);
+        let entry = b.create_named_block("entry", vec![]);
+        b.set_entry(entry);
+        b.position_at_end(entry);
+        let loaded = b
+            .emit(
+                Op::LoadLocal,
+                vec![],
+                Some(Immediate::LocalSlot(slot)),
+                IrType::I64,
+                PhpType::Int,
+                Ownership::NonHeap,
+            )
+            .unwrap();
+        b.terminate(Terminator::Return { value: Some(loaded) });
+    }
+    // Exactly what the pass leaves behind once it has proven the slot immutable
+    // in THIS function: the load reads nothing, as far as anything downstream
+    // can see.
+    for inst in &mut callee.instructions {
+        if inst.op == Op::LoadLocal {
+            inst.effects = crate::ir::Effects::empty();
+        }
+    }
+    module.add_function(callee);
+
+    let mut host = Function::new("h".to_string(), IrType::I64, PhpType::Int);
+    {
+        let mut b = Builder::new(&mut host);
+        let entry = b.create_named_block("entry", vec![]);
+        b.set_entry(entry);
+        b.position_at_end(entry);
+        let data = module.data.intern_function_name("reads_param");
+        let r = b
+            .emit(
+                Op::Call,
+                vec![],
+                Some(Immediate::Data(data)),
+                IrType::I64,
+                PhpType::Int,
+                Ownership::NonHeap,
+            )
+            .unwrap();
+        b.terminate(Terminator::Return { value: Some(r) });
+    }
+    module.add_function(host);
+
+    assert!(inline_small_functions(&mut module));
+    let h = module.functions.iter().find(|f| f.name == "h").unwrap();
+    let loads: Vec<_> = h.instructions.iter().filter(|i| i.op == Op::LoadLocal).collect();
+    assert!(!loads.is_empty(), "the callee's load must have been spliced in at all");
+    assert!(
+        loads.iter().all(|i| i.effects.contains(crate::ir::Effects::READS_LOCAL)),
+        "a load spliced into another function reads that function's local again; leaving it \
+         pure is what let LICM hoist it above the store that fills the slot"
+    );
+    assert!(validate_module(&module).is_ok());
+}
+
 /// Structural test: FVC call-site name resolution must use the canonical
 /// `resolve_variant_callee_name` over `module.functions`, and inlining at that
 /// site must remove the `FunctionVariantCall` opcode (using the shipped search

--- a/src/monitor/attach.rs
+++ b/src/monitor/attach.rs
@@ -1,0 +1,339 @@
+//! Purpose:
+//! Turns raw program counters read out of another process into the display
+//! stacks the rest of `monitor` already renders, exports and diffs.
+//!
+//! Called from:
+//! - `crate::monitor` on Linux, for `--attach`, which is handed a pid already
+//!   running under someone else's control and has no channel to ask over.
+//!
+//! Key details:
+//! - Naming only. The syscalls that produce the addresses live next to this and
+//!   are the one part a host without `ptrace` cannot exercise; everything here
+//!   takes numbers and returns names, and is tested on any host.
+//! - The frame chain is walked innermost-first, which is the order a sampler
+//!   collects it and the reverse of the order a profile displays it.
+
+use super::elf::{symbolize, FuncSymbol};
+use super::Kind;
+
+/// The name given to a frame no symbol claims.
+///
+/// One bucket rather than an address, because an address is not a name: it says
+/// nothing a reader can act on, and a hundred distinct ones would split a single
+/// runtime helper into a hundred rows that each look insignificant.
+pub(crate) const UNNAMED: &str = "<native>";
+
+/// Turns one sampled frame chain into a display stack, outermost first.
+///
+/// The addresses arrive innermost-first — a sampler reads the interrupted `pc`
+/// and then climbs — and every consumer downstream reads a stack the other way,
+/// from the root inwards. Reversing here rather than at each of them is what
+/// keeps `{main}` at the top of a table instead of the bottom.
+///
+/// Names are demangled on the way out, to the same spelling the in-process
+/// paths print: an operator comparing an attached profile against an asked one
+/// is looking at one program, and `_fn_hot_u_leaf` beside `hot_leaf` reads as
+/// two different functions.
+///
+/// A run of consecutive unnamed frames collapses to one. A profile is read to
+/// find the code that costs, and six rows of `<native>` between two PHP
+/// functions tell a reader nothing while pushing what they came for off the
+/// screen — which is the same reason the exact profiler folds inlined bodies
+/// into their caller.
+pub(crate) fn display_stack(
+    frames: &[u64],
+    symbols: &[FuncSymbol],
+    bias: u64,
+) -> Vec<(String, Kind)> {
+    let mut out: Vec<(String, Kind)> = Vec::new();
+    for address in frames.iter().rev() {
+        match symbolize(symbols, bias, *address) {
+            // Classified on the MANGLED name and displayed as the SOURCE one.
+            // The prefix is what says which kind of time this is, and it is
+            // exactly what demangling removes — so the order is not a
+            // preference. Reading the other way round leaves every PHP function
+            // classified as native, and a profile that says a PHP program spends
+            // none of its time in PHP.
+            Some(name) => out.push((super::render::demangle(name), kind_of(name))),
+            None => {
+                if out.last().map(|(name, _)| name.as_str()) != Some(UNNAMED) {
+                    out.push((UNNAMED.to_string(), Kind::Native));
+                }
+            }
+        }
+    }
+    out
+}
+
+/// What kind of time a named frame represents.
+///
+/// The compiler emits PHP functions under `_php_`/`_fn_` prefixes and its own
+/// helpers under `__rt_`, so the name itself says which is which — and the
+/// distinction is what lets a reader tell their own hot function from the
+/// runtime doing work on its behalf.
+fn kind_of(symbol: &str) -> Kind {
+    let bare = symbol.strip_prefix('_').unwrap_or(symbol);
+    if bare.starts_with("_rt_") || bare.starts_with("rt_") {
+        Kind::Helper
+    } else if bare.starts_with("php_") || bare.starts_with("fn_") || bare == "main" {
+        Kind::Php
+    } else {
+        Kind::Native
+    }
+}
+
+/// Counts identical stacks, which is what a sample count IS.
+///
+/// A sampler produces one stack per interrupt and says nothing about time; the
+/// weight of a stack is how many times it was seen. Folding here rather than
+/// storing every sample keeps a long window bounded by the program's shapes
+/// rather than by its duration.
+pub(crate) fn fold(stacks: Vec<Vec<(String, Kind)>>) -> Vec<(Vec<(String, Kind)>, u64)> {
+    let mut counted: std::collections::BTreeMap<Vec<(String, Kind)>, u64> =
+        std::collections::BTreeMap::new();
+    for stack in stacks {
+        if stack.is_empty() {
+            continue;
+        }
+        *counted.entry(stack).or_default() += 1;
+    }
+    counted.into_iter().collect()
+}
+
+/// What a running process's addresses have to be read against: the function
+/// symbols of the image behind it, and where that image actually landed.
+///
+/// Built once per `--attach` rather than per window. The symbols do not change
+/// while the program runs, and re-reading a binary's symbol table every two
+/// seconds to answer the same question is work charged to a live view for
+/// nothing.
+pub(crate) struct Image {
+    pub(crate) symbols: Vec<FuncSymbol>,
+    /// The executable's path as the kernel reports it, and the first address its
+    /// own headers ask to be loaded at.
+    ///
+    /// Kept because the symbols are shared by a whole process tree but the BIAS
+    /// is not: a prefork server's workers run the same image, so they resolve
+    /// against the same table, and each is mapped where its own `/proc` says.
+    /// Deriving a worker's bias needs these two and not the file again.
+    pub(crate) exe: String,
+    pub(crate) first_vaddr: u64,
+}
+
+/// Reads the image behind a running pid, or says which part was not readable.
+///
+/// Four things can be missing and they are not interchangeable — a stripped
+/// binary, an unreadable `/proc`, an image that is not ELF, a mapping that is
+/// not there. An operator who is told "cannot attach" learns nothing; one told
+/// Why an image could not be built, and whether the kernel REFUSED it.
+///
+/// The distinction exists to keep one sentence off the other three. The
+/// `yama/ptrace_scope` hint used to be appended to every failure here, so an
+/// absent pid answered `cannot read /proc/999999/exe: No such file or directory
+/// (the kernel's yama/ptrace_scope is 1, ...)` and a stripped binary ended the
+/// same way — a hint naming a cause that had not occurred, which is the same
+/// class of wrong answer as the refusal that used to read as a target that had
+/// exited.
+pub(crate) struct ImageError {
+    /// What went wrong, in the operator's terms.
+    pub(crate) reason: String,
+    /// Whether the kernel refused the read, as opposed to there being nothing
+    /// to read. Only this earns the hint.
+    pub(crate) denied: bool,
+}
+
+impl ImageError {
+    /// A failure that has nothing to do with permission: an absent pid, a
+    /// binary that is not ELF64, a program with no symbols left.
+    fn plain(reason: String) -> Self {
+        Self { reason, denied: false }
+    }
+
+    /// A failed read, which the kernel may or may not have refused.
+    fn from_read(what: String, error: &std::io::Error) -> Self {
+        Self {
+            reason: format!("{what}: {error}"),
+            denied: error.kind() == std::io::ErrorKind::PermissionDenied,
+        }
+    }
+}
+
+/// which of the four learns what to do about it.
+#[cfg(target_os = "linux")]
+pub(crate) fn image_for(pid: u32) -> Result<Image, ImageError> {
+    use super::elf;
+    use super::ptrace;
+
+    let exe = ptrace::executable_path(pid)
+        .map_err(|error| ImageError::from_read(format!("cannot read /proc/{pid}/exe"), &error))?;
+    let bytes = std::fs::read(&exe).map_err(|error| {
+        ImageError::from_read(format!("cannot read the target's binary {}", exe.display()), &error)
+    })?;
+    let first_vaddr = elf::first_load_vaddr(&bytes)
+        .ok_or_else(|| ImageError::plain(format!("{} is not an ELF64 image this can read", exe.display())))?;
+    let maps = ptrace::memory_maps(pid)
+        .map_err(|error| ImageError::from_read(format!("cannot read /proc/{pid}/maps"), &error))?;
+    // Read and discarded: what it answers for the ROOT is not reused, because
+    // every process of the tree derives its own. It is read anyway because
+    // failing HERE is the difference between one clear sentence and a window
+    // that silently comes back empty.
+    elf::load_bias(&maps, &exe.to_string_lossy(), first_vaddr).ok_or_else(|| {
+        ImageError::plain(format!(
+            "{} is running but is not mapped in /proc/{pid}/maps",
+            exe.display()
+        ))
+    })?;
+    let symbols = elf::function_symbols(&bytes);
+    if symbols.is_empty() {
+        return Err(ImageError::plain(format!(
+            "{} carries no function symbols, so an attached sampler has nothing to name its \
+             addresses with. elephc strips them by default because nothing INSIDE a program \
+             reads them; a sampler reads them from the outside. Rebuild it with \
+             --keep-symbols (or --debug-info), or read it through its endpoint instead: \
+             ELEPHC_PROBE_ADDR=127.0.0.1:9411, then `elephc monitor 127.0.0.1:9411`.",
+            exe.display()
+        )));
+    }
+    Ok(Image { symbols, exe: exe.to_string_lossy().into_owned(), first_vaddr })
+}
+
+/// Where one process of the tree is mapped, for a tree that shares this image.
+///
+/// A prefork server's workers are forks: same executable, same symbol table,
+/// their own mappings. Reusing the root's bias for a worker would resolve every
+/// one of its addresses against the wrong offset — which does not fail, it
+/// names the wrong functions, and a table that is confidently wrong is worse
+/// than one that is short.
+#[cfg(target_os = "linux")]
+pub(crate) fn bias_of(image: &Image, pid: u32) -> Option<u64> {
+    let maps = super::ptrace::memory_maps(pid).ok()?;
+    super::elf::load_bias(&maps, &image.exe, image.first_vaddr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn symbols() -> Vec<FuncSymbol> {
+        // Sorted by address, which is what `symbolize` binary-searches, and
+        // spelled the way the compiler actually emits them: `fn_`-prefixed with
+        // `_u_` standing in for an underscore. Reading an attached profile of a
+        // real program is what these names have to survive.
+        vec![
+            FuncSymbol { value: 0x1000, size: 0x100, name: "_fn_spin".into() },
+            FuncSymbol { value: 0x2000, size: 0x100, name: "_fn_hot_u_leaf".into() },
+            FuncSymbol { value: 0x3000, size: 0x100, name: "__rt_mixed_add".into() },
+            FuncSymbol { value: 0x4000, size: 0x100, name: "main".into() },
+        ]
+    }
+
+    /// The stack comes back outermost-first, whichever way the sampler collected
+    /// it. Every consumer downstream reads a stack from the root inwards, and
+    /// reversing at each of them instead is how `{main}` ends up at the bottom
+    /// of a table it should head.
+    #[test]
+    fn a_chain_is_turned_around_so_the_root_comes_first() {
+        let bias = 0xaaaa_0000_0000;
+        // Innermost first, as a sampler reads it: spin called by hot_leaf
+        // called by main.
+        let frames = [bias + 0x1010, bias + 0x2010, bias + 0x4010];
+        assert_eq!(
+            display_stack(&frames, &symbols(), bias),
+            vec![
+                ("{main}".to_string(), Kind::Php),
+                ("hot_leaf".to_string(), Kind::Php),
+                ("spin".to_string(), Kind::Php),
+            ]
+        );
+    }
+
+    /// A runtime helper is named as one, so a reader can tell their own hot
+    /// function from the runtime working on its behalf.
+    #[test]
+    fn a_helper_is_not_reported_as_php() {
+        let bias = 0;
+        assert_eq!(
+            display_stack(&[0x3010], &symbols(), bias),
+            vec![("__rt_mixed_add".to_string(), Kind::Helper)]
+        );
+    }
+
+    /// Frames no symbol claims collapse into one row rather than one each.
+    ///
+    /// A profile is read to find the code that costs. Six rows of `<native>`
+    /// between two PHP functions tell a reader nothing and push what they came
+    /// for off the screen.
+    #[test]
+    fn a_run_of_unnamed_frames_is_one_row() {
+        let bias = 0;
+        // spin, then three addresses in nobody's range, then main.
+        let frames = [0x1010, 0x9000, 0x9100, 0x9200, 0x4010];
+        assert_eq!(
+            display_stack(&frames, &symbols(), bias),
+            vec![
+                ("{main}".to_string(), Kind::Php),
+                (UNNAMED.to_string(), Kind::Native),
+                ("spin".to_string(), Kind::Php),
+            ]
+        );
+    }
+
+    /// Two unnamed runs SEPARATED by a named frame stay two rows: collapsing
+    /// those would join stretches of the program that are not adjacent.
+    #[test]
+    fn unnamed_runs_on_either_side_of_a_name_stay_apart() {
+        let bias = 0;
+        let frames = [0x9000, 0x2010, 0x9100, 0x4010];
+        assert_eq!(
+            display_stack(&frames, &symbols(), bias),
+            vec![
+                ("{main}".to_string(), Kind::Php),
+                (UNNAMED.to_string(), Kind::Native),
+                ("hot_leaf".to_string(), Kind::Php),
+                (UNNAMED.to_string(), Kind::Native),
+            ]
+        );
+    }
+
+    /// A frame is CLASSIFIED on its mangled name and DISPLAYED as its source
+    /// one, and both halves have to hold at once.
+    ///
+    /// The prefix that says which kind of time a frame is — `fn_`, `__rt_` — is
+    /// exactly what demangling removes, so doing them in the wrong order is not
+    /// a matter of taste: classify after demangling and every PHP function comes
+    /// out native, leaving a profile that says a PHP program spends none of its
+    /// time in PHP.
+    ///
+    /// The spelling matters on its own too. An operator comparing an attached
+    /// profile against an asked one is looking at one program, and
+    /// `_fn_hot_u_leaf` beside `hot_leaf` reads as two different functions.
+    #[test]
+    fn a_frame_is_classified_mangled_and_displayed_demangled() {
+        let named = display_stack(&[0x2010, 0x3010, 0x4010], &symbols(), 0);
+        assert_eq!(
+            named,
+            vec![
+                ("{main}".to_string(), Kind::Php),
+                // A helper's name is not a PHP name, so demangling leaves it be.
+                ("__rt_mixed_add".to_string(), Kind::Helper),
+                ("hot_leaf".to_string(), Kind::Php),
+            ]
+        );
+        assert!(
+            !named.iter().any(|(name, _)| name.contains("_u_") || name.starts_with("_fn_")),
+            "a mangled spelling reached the display: {named:?}"
+        );
+    }
+
+    /// The weight of a stack is how many times it was seen, which is the only
+    /// thing a sampler measures.
+    #[test]
+    fn identical_stacks_are_counted_rather_than_kept() {
+        let one = vec![("main".to_string(), Kind::Php)];
+        let two = vec![("main".to_string(), Kind::Php), ("_php_spin".to_string(), Kind::Php)];
+        let folded = fold(vec![one.clone(), two.clone(), one.clone(), vec![]]);
+        assert_eq!(folded.len(), 2, "an empty sample is not a shape: {folded:?}");
+        assert!(folded.contains(&(one, 2)));
+        assert!(folded.contains(&(two, 1)));
+    }
+}

--- a/src/monitor/channel.rs
+++ b/src/monitor/channel.rs
@@ -74,6 +74,31 @@ pub(crate) fn compile_php_monitored(source: &str) -> Result<PathBuf, String> {
 /// an environment variable, which every process on the machine can read, and
 /// which therefore has to be signed to be safe at all.
 pub(crate) fn open_control_channel() -> Option<ControlChannel> {
+    open_channel_with(CONTROL_MAGIC)
+}
+
+/// The same channel, with the marker that tells the child it will be POLLED.
+///
+/// Only `--live` uses it. The difference costs the child a thread it would
+/// otherwise park in `recv` for the whole of a run nobody intends to interrupt.
+pub(crate) fn open_polled_control_channel() -> Option<ControlChannel> {
+    let channel = open_channel_with(CONTROL_MAGIC_LIVE)?;
+    // A read on this end must not be able to wait forever.
+    //
+    // The reply comes from a thread the child starts, and the child may not have
+    // started one: a spawn can fail under a thread or memory limit, and the fd
+    // stays open with nobody behind it. `recv` on a live peer that never writes
+    // does not return — so a live view would hang on a program still running,
+    // which is the one failure mode worse than a missing profile because it
+    // gives no reason.
+    //
+    // Generous against the answer itself, which waits out a 400 ms warm-up
+    // before reporting an empty ring, and finite against everything else.
+    set_receive_deadline(channel.parent, 5);
+    Some(channel)
+}
+
+fn open_channel_with(magic: &[u8]) -> Option<ControlChannel> {
     unsafe {
         let mut fds = [0i32; 2];
         if libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) != 0 {
@@ -87,11 +112,11 @@ pub(crate) fn open_control_channel() -> Option<ControlChannel> {
         // than racing the child's init.
         let wrote = libc::send(
             channel.parent,
-            CONTROL_MAGIC.as_ptr() as *const libc::c_void,
-            CONTROL_MAGIC.len(),
+            magic.as_ptr() as *const libc::c_void,
+            magic.len(),
             0,
         );
-        if wrote != CONTROL_MAGIC.len() as isize {
+        if wrote != magic.len() as isize {
             return None;
         }
         Some(channel)
@@ -100,6 +125,32 @@ pub(crate) fn open_control_channel() -> Option<ControlChannel> {
 
 /// Whether the child acknowledged consuming the control marker and activating
 /// its embedded monitoring runtime.
+///
+/// `MSG_PEEK`, and that is the whole contract: this is a QUESTION about the
+/// stream, and it shares that stream with `request_snapshot`. It used to answer
+/// by CONSUMING, under `MSG_WAITALL` — which asks the kernel to hold on until
+/// all twenty bytes are there, and which `MSG_DONTWAIT` does not override on
+/// macOS. Measured on a socketpair already holding one four-byte reply, the
+/// shortest there is, since an empty snapshot is a length word and nothing else:
+///
+/// | flags | the probe | the reply afterwards |
+/// |---|---|---|
+/// | `DONTWAIT\|WAITALL`, no deadline | never returns | — |
+/// | `DONTWAIT\|WAITALL`, 1 s deadline | returns after 1.002 s | DESTROYED |
+/// | `DONTWAIT\|PEEK` | returns in 1.9 µs | intact |
+///
+/// So asking whether the child had activated spent a whole receive deadline and
+/// swallowed the answer it was not looking for. The next length parsed came out
+/// of the middle of a message, which reads as `Gone`, and `Gone` ends the live
+/// view and reaps a program that was replying perfectly well. On the channel
+/// that carries no deadline — the check made once the program has finished — it
+/// did not come back at all.
+///
+/// Leaving the ACK where it is costs nothing, because `request_snapshot` already
+/// has to cope with finding one in front of a reply — a child that boots slower
+/// than the activation deadline puts it there — and now always takes that path
+/// rather than only under load. One consumer of the stream, and it is the one
+/// that knows the framing.
 pub(crate) fn control_channel_activated(channel: &ControlChannel) -> bool {
     let mut ack = [0u8; CONTROL_ACK.len()];
     let read = unsafe {
@@ -107,10 +158,344 @@ pub(crate) fn control_channel_activated(channel: &ControlChannel) -> bool {
             channel.parent,
             ack.as_mut_ptr() as *mut libc::c_void,
             ack.len(),
-            libc::MSG_DONTWAIT | libc::MSG_WAITALL,
+            libc::MSG_DONTWAIT | libc::MSG_PEEK,
         )
     };
     read == ack.len() as isize && ack == CONTROL_ACK
+}
+
+/// Waits, briefly, for the child's activation ACK to arrive.
+///
+/// `control_channel_activated` asks without blocking, which is right for a
+/// caller that has already waited for the program to finish. A live view has
+/// not: it starts asking while the child is still booting, and the ACK is sent
+/// once, at init.
+///
+/// What it answers is "has the child reached its activation point", not "is the
+/// stream ready to read". Both messages share one stream, and the reply is
+/// length-prefixed, so an ACK in front of a reply hands `ELEP` to the length
+/// parser — which `request_snapshot` recognises and steps over. Under no load
+/// the ACK always beat the first window and that path never ran; under a
+/// parallel test batch it did, every time.
+///
+/// This no longer drains anything (see `control_channel_activated`), so a `false`
+/// here is a statement about the child and not a stream that has been eaten. The
+/// caller may ask again next window without cost.
+///
+/// Bounded, because a program that never activates must not hang the view: after
+/// the deadline the caller proceeds and finds out from the snapshot itself.
+pub(crate) fn await_activation(channel: &ControlChannel, timeout: std::time::Duration) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if control_channel_activated(channel) {
+            return true;
+        }
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        // Short enough that a program which boots promptly is not made to look
+        // slow, long enough not to spin on a socket that has nothing to say.
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+}
+
+/// Every line prefix the profiler emits on a program's stderr.
+///
+/// An exact list, not a pattern. Both mechanisms write to the same stream, so
+/// the monitor has to tell its own output from the program's, and the two ways
+/// of being wrong are not equal: an unrecognised profiler line reaches the
+/// operator as a visible, harmless extra row, while a program's line matched by
+/// mistake is DELETED with nothing to say it existed.
+///
+/// So a new kind of profiler line has to be added here, and until it is, it
+/// leaks. That is the direction to fail in — and the reason this is a list a
+/// reader can check against `elephc-instr`/`elephc-probe` rather than a rule
+/// that quietly covers whatever it happens to cover.
+const PROFILER_LINE_PREFIXES: [&str; 9] = [
+    "elephc-instr:",
+    "elephc-instr-edge:",
+    "elephc-instr-query:",
+    "elephc-instr-query-dropped:",
+    "elephc-instr-trace:",
+    "elephc-probe:",
+    "elephc-probe-alloc:",
+    "elephc-probe-io:",
+    "elephc-probe-samples:",
+];
+
+/// Whether a line of a monitored program's stderr is the profiler's own output
+/// rather than the program's.
+///
+/// Matched on the whole first token against the list above. A prefix test would
+/// swallow a program that writes `elephc-instrumentation disabled` on its own
+/// stderr — a line the author wrote, removed by the tool that was supposed to be
+/// watching it — and even a prefix-plus-colon test would take
+/// `elephc-instr-custom:` from a program that chose that name.
+pub(crate) fn is_profiler_line(line: &str) -> bool {
+    let Some(first) = line.split_whitespace().next() else {
+        return false;
+    };
+    PROFILER_LINE_PREFIXES.contains(&first)
+}
+
+/// Gives a socket a receive deadline, in whole seconds.
+///
+/// Split out so a test can ask for a short one. The behaviour worth testing is
+/// what happens WHEN a deadline passes, and a test that has to wait five real
+/// seconds to reach it is a test that gets shortened until it no longer reaches
+/// it at all.
+pub(crate) fn set_receive_deadline(fd: i32, seconds: i64) {
+    let timeout = libc::timeval { tv_sec: seconds, tv_usec: 0 };
+    // Safety: setting a documented option on a socket this process owns.
+    unsafe {
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_RCVTIMEO,
+            &timeout as *const libc::timeval as *const libc::c_void,
+            std::mem::size_of::<libc::timeval>() as libc::socklen_t,
+        );
+    }
+}
+
+/// How many consecutive deadlines a half-delivered reply may miss before the
+/// channel is called finished.
+///
+/// A reply arriving in pieces resets the deadline on every piece, so reaching
+/// even one of these means a whole deadline passed with NOTHING arriving
+/// mid-message — a writer that has stopped rather than one that is slow. Three,
+/// because ending the view reaps the target, and the difference between slow and
+/// stopped is worth a few seconds of patience.
+const MID_MESSAGE_STALLS: u32 = 3;
+
+/// What asking the child for a snapshot produced.
+///
+/// Three outcomes and not two, because "no answer" and "no child" call for
+/// opposite things. A live view that ends kills the target it was watching — the
+/// program only outlives the loop if the loop is still running — so treating a
+/// slow answer as a dead one does not merely lose a window: it stops a healthy
+/// program the operator was in the middle of profiling.
+pub(crate) enum Snapshot {
+    /// The child answered.
+    Answered(String),
+    /// It did not answer in time and nothing OF THE REPLY was consumed, so it
+    /// can be asked again on the next window.
+    ///
+    /// `activation_seen` is true when this call took the child's ACK off the
+    /// front before giving up on the reply. The caller has to record that:
+    /// otherwise its `activated` flag stays false over an ACK that no longer
+    /// exists, and every later window opens by spending the whole activation
+    /// deadline waiting for a message nobody will send again.
+    Late { activation_seen: bool },
+    /// The channel is finished — closed, broken, or desynchronised by a reply
+    /// that stopped half way. Nothing further can be asked over it.
+    Gone,
+}
+
+/// Request byte the probe answers with a snapshot of what it has sampled.
+///
+/// Mirrors `CONTROL_SNAPSHOT_REQUEST` in `elephc-probe`; the two are one
+/// protocol and the constant is named the same on both sides so a `grep` finds
+/// the pair.
+const CONTROL_SNAPSHOT_REQUEST: u8 = b'S';
+
+/// Asks the monitored child for everything it has sampled so far.
+///
+/// The channel is the credential: only this process holds the parent end, so a
+/// program `monitor` launched can simply be asked. That is the whole reason
+/// `--live` no longer needs a tool that reads a process from the outside — and
+/// therefore no longer needs macOS.
+///
+/// Cumulative, like the endpoint's answer. One window is the difference between
+/// two of these, which is the caller's arithmetic rather than the probe's: a
+/// probe that reset on every read would lose a window to any reader that
+/// disconnected, and would have to decide what a window is.
+///
+/// Three answers, and the caller has to tell them apart. `Answered` carries the
+/// child's cumulative text. `Late` is the empty window — a child too young to
+/// have a thread reading yet, or one that missed the deadline with nothing
+/// consumed; it is asked again on the next one. `Gone` is NOT an empty window:
+/// the channel is finished, and the live loop ends the view and reaps the target
+/// on it. This paragraph used to describe a `None` returned "on any failure" and
+/// read as an empty window — the shape before `Snapshot` existed, and it folded
+/// together exactly the two cases the enum was added to separate. Written
+/// against it, a caller hangs a live view on a dead child.
+pub(crate) fn request_snapshot(channel: &ControlChannel) -> Snapshot {
+    let fd = channel.parent;
+    let request = [CONTROL_SNAPSHOT_REQUEST];
+    // Safety: `fd` is this process's end of the socketpair, owned by `channel`.
+    let sent = unsafe {
+        libc::send(fd, request.as_ptr() as *const libc::c_void, 1, 0)
+    };
+    if sent != 1 {
+        // `EPIPE` here, with SIGPIPE ignored by the runtime, means the peer is
+        // closed: the child is gone.
+        return Snapshot::Gone;
+    }
+    let mut header = [0u8; 4];
+    // A timeout on the FIRST word consumed nothing, so the stream is still where
+    // it was and the next window can ask again. A timeout after that did not: the
+    // reply is half read, and asking again would parse the rest of it as the next
+    // answer's length. That is why the two are distinguished here rather than
+    // both being called "no answer".
+    match recv_exact(fd, &mut header) {
+        Read::Filled => {}
+        Read::TimedOutClean => return Snapshot::Late { activation_seen: false },
+        Read::Ended => return Snapshot::Gone,
+    }
+    // The activation ACK is sent once, at the child's init, and may still be in
+    // the buffer when this reads. `await_activation` is supposed to have taken
+    // it — but it has a deadline, and a child that boots slower than that
+    // deadline sends its ACK straight into this read instead. Its first four
+    // bytes are `ELEP`, which decodes as a 1.3 GB length, which the bound below
+    // refuses as `Gone`, which ends a live view on a program that is running
+    // perfectly well.
+    //
+    // So it is handled here rather than only prevented upstream: a wait that can
+    // TIME OUT cannot be the only thing standing between the two messages. This
+    // holds whatever the child's boot takes.
+    if header == CONTROL_ACK[..4] {
+        let mut rest = [0u8; CONTROL_ACK.len() - 4];
+        // Mid-message now, exactly as in the body loop below: the stream owes
+        // these bytes, so a clean timeout is worth retrying rather than
+        // abandoning half an ACK for the next window to parse as a length.
+        let mut stalls = 0u32;
+        loop {
+            match recv_exact(fd, &mut rest) {
+                Read::Filled => break,
+                Read::TimedOutClean if stalls + 1 < MID_MESSAGE_STALLS => stalls += 1,
+                Read::TimedOutClean | Read::Ended => return Snapshot::Gone,
+            }
+        }
+        if rest != CONTROL_ACK[4..] {
+            return Snapshot::Gone;
+        }
+        // The reply this call asked for is still on its way. The ACK, though, is
+        // consumed and gone — so this `Late` has to carry that out with it.
+        match recv_exact(fd, &mut header) {
+            Read::Filled => {}
+            Read::TimedOutClean => return Snapshot::Late { activation_seen: true },
+            Read::Ended => return Snapshot::Gone,
+        }
+    }
+    let len = u32::from_le_bytes(header) as usize;
+    if len == 0 {
+        return Snapshot::Answered(String::new());
+    }
+    // Bounded by what a folded profile can be, so a corrupt or hostile length
+    // cannot make this allocate the machine away. The probe folds at most the
+    // ring, which is orders of magnitude below this.
+    const MAX_SNAPSHOT: usize = 64 * 1024 * 1024;
+    if len > MAX_SNAPSHOT {
+        return Snapshot::Gone;
+    }
+    let mut body = vec![0u8; len];
+    // Being mid-message is a property of the MESSAGE, not of this read. The
+    // header is already consumed, so the stream owes exactly `len` bytes — which
+    // is what makes waiting longer safe here and nowhere else, whether or not
+    // any of the body has arrived yet.
+    //
+    // That distinction is the whole of it, and the first version of this got it
+    // wrong: it retried only once a body byte had landed, so the ordinary shape
+    // — header, then a stall — fell straight through to `Gone`, and `Gone` reaps
+    // the target.
+    let mut stalls = 0u32;
+    loop {
+        match recv_exact(fd, &mut body) {
+            Read::Filled => break,
+            Read::TimedOutClean if stalls + 1 < MID_MESSAGE_STALLS => {
+                // Nothing was taken, so the next attempt starts where this one
+                // did and refills the same buffer from the same place.
+                stalls += 1;
+            }
+            // Out of patience, or a channel that is finished for another reason.
+            Read::TimedOutClean | Read::Ended => return Snapshot::Gone,
+        }
+    }
+    match String::from_utf8(body) {
+        Ok(text) => Snapshot::Answered(text),
+        Err(_) => Snapshot::Gone,
+    }
+}
+
+/// How a read of a fixed-size field ended.
+enum Read {
+    Filled,
+    /// The deadline passed with NOTHING taken off the stream.
+    TimedOutClean,
+    /// Closed, broken, or timed out part way — either way, unusable.
+    Ended,
+}
+
+/// Fills `buf` completely, or reports that it could not.
+///
+/// A stream socket may deliver a reply in pieces. Treating a short read as the
+/// whole answer would truncate a profile mid-line and silently drop the frames
+/// that did not arrive.
+fn recv_exact(fd: i32, buf: &mut [u8]) -> Read {
+    let mut filled = 0usize;
+    let mut stalls = 0u32;
+    while filled < buf.len() {
+        // Safety: writing into `buf`'s own bytes from a socket this process owns.
+        let read = unsafe {
+            libc::recv(
+                fd,
+                buf[filled..].as_mut_ptr() as *mut libc::c_void,
+                buf.len() - filled,
+                0,
+            )
+        };
+        if read < 0 {
+            let error = std::io::Error::last_os_error();
+            // An interrupted read has consumed nothing; ending here would report
+            // a truncated snapshot as a dead channel and stop the live loop with
+            // the program still running.
+            if error.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+            ) {
+                // Nothing taken yet: the stream is where it was, so the next
+                // window can ask again.
+                if filled == 0 {
+                    return Read::TimedOutClean;
+                }
+                // Part way through. Retrying is safe HERE and only here —
+                // `filled` says exactly how much of this reply is still owed, so
+                // reading on continues the same message rather than parsing the
+                // next one's length out of its tail.
+                //
+                // Given more deadlines rather than one, because each already
+                // measures a stall with no bytes at all, and a child that is
+                // merely slow deserves better than being cut off mid-sentence.
+                // Bounded, because a writer that has genuinely stopped must not
+                // hold the view open for as long as it likes.
+                stalls += 1;
+                if stalls < MID_MESSAGE_STALLS {
+                    continue;
+                }
+                return Read::Ended;
+            }
+            return Read::Ended;
+        }
+        if read == 0 {
+            return Read::Ended;
+        }
+        filled += read as usize;
+        // Bytes arrived, so the budget above is spent on a writer that STOPPED
+        // and not on one that is slow — which is the distinction its own comment
+        // draws, and the code did not make. Without this line the stalls only
+        // ever accumulate: a child that sends a piece, pauses past the deadline,
+        // sends another, pauses again, is cut off on the third pause while it is
+        // visibly still writing. `Ended` here means `Gone`, and `Gone` ends the
+        // live view and reaps the target — so the reading that kills a healthy
+        // program is the one to get wrong last, which is the arbitration
+        // `Snapshot` was introduced to make.
+        stalls = 0;
+    }
+    Read::Filled
 }
 
 /// Arranges for `channel`'s child end to arrive as `CONTROL_FD` in the spawned

--- a/src/monitor/command.rs
+++ b/src/monitor/command.rs
@@ -111,11 +111,14 @@ per-function table of the next request that completes; that answer is the table
 alone, so --exact cannot be combined with --out, --pprof, --dot or --html.
 
 --live refreshes the table window after window, top-style, until the target
-exits (or Ctrl-C). --attach reads an already-running local process; child worker
-processes (a --web prefork server's workers) are discovered and merged in both
-modes. Those two use an external sampler, which only macOS ships; elsewhere,
-point monitor at the program's endpoint instead. They report sampled CPU stacks
-only: no calls, allocation/retained counts, SQL/file-I/O counts, wait, or route
+exits (or Ctrl-C). --attach reads an already-running local process, discovering
+its child worker processes (a --web prefork server's workers) each window and
+merging them. A launched --live asks the program it started over the channel it
+handed it, so its answer is that process's own. --live launches its target and asks it over a socketpair, so it needs no
+external tool and works wherever elephc does; --attach is handed a pid it did not
+launch and reads it from the outside -- /usr/bin/sample on macOS, ptrace on
+Linux, and nowhere else, so point monitor at the program's endpoint instead.
+They report sampled CPU stacks only: no calls, allocation/retained counts, SQL/file-I/O counts, wait, or route
 tags. Everything else works on Linux and macOS alike.
 
 --pprof writes the capture as a gzip pprof profile. --dot writes a Graphviz call

--- a/src/monitor/elf.rs
+++ b/src/monitor/elf.rs
@@ -1,0 +1,443 @@
+//! Purpose:
+//! Reads function symbols and the load bias out of an ELF64 image, so a process
+//! can be symbolised from the outside without DWARF and without an in-process
+//! helper.
+//!
+//! Called from:
+//! - `crate::monitor` on Linux, where `--attach` is handed a pid that is already
+//!   running under someone else's control and has no channel to answer on.
+//!
+//! Key details:
+//! - Parsing only. Every function here takes bytes and returns values, so the
+//!   whole of it is exercised by ordinary tests on any host, which matters for
+//!   code whose real use is on a platform its author may not be able to run.
+//! - Little-endian ELF64 only, which is what both supported Linux targets are.
+//!   A file that is anything else is refused rather than misread.
+
+/// One function the target's image defines, in the addresses the FILE uses.
+///
+/// Runtime addresses are these plus the load bias; keeping the two apart is
+/// deliberate, because mixing them is the mistake this module exists to avoid
+/// and the one that produces a plausible, wrong symbol rather than none.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FuncSymbol {
+    pub(crate) value: u64,
+    pub(crate) size: u64,
+    pub(crate) name: String,
+}
+
+const EI_NIDENT: usize = 16;
+const ELFCLASS64: u8 = 2;
+const ELFDATA2LSB: u8 = 1;
+const SHT_SYMTAB: u32 = 2;
+const SHT_DYNSYM: u32 = 11;
+const PT_LOAD: u32 = 1;
+const STT_FUNC: u8 = 2;
+
+fn u16_at(bytes: &[u8], at: usize) -> Option<u16> {
+    bytes.get(at..at + 2).map(|b| u16::from_le_bytes([b[0], b[1]]))
+}
+
+fn u32_at(bytes: &[u8], at: usize) -> Option<u32> {
+    bytes
+        .get(at..at + 4)
+        .map(|b| u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+}
+
+fn u64_at(bytes: &[u8], at: usize) -> Option<u64> {
+    bytes.get(at..at + 8).map(|b| {
+        u64::from_le_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]])
+    })
+}
+
+/// Whether `bytes` is a little-endian ELF64 image.
+///
+/// Checked before anything is indexed. Every read below is bounds-checked too,
+/// but a wrong-class file would otherwise be parsed field by field into numbers
+/// that mean nothing — and a symbol table built from those is worse than an
+/// empty one, because it answers.
+fn is_elf64_le(bytes: &[u8]) -> bool {
+    bytes.len() > EI_NIDENT
+        && bytes[0..4] == [0x7f, b'E', b'L', b'F']
+        && bytes[4] == ELFCLASS64
+        && bytes[5] == ELFDATA2LSB
+}
+
+/// The lowest virtual address any `PT_LOAD` segment asks for.
+///
+/// This is what a runtime mapping is biased AGAINST: the loader places the image
+/// somewhere, and the distance from that placement to this value is the bias
+/// every file address needs. A non-PIE image asks for a fixed address and its
+/// bias comes out zero, which is the same arithmetic rather than a special case.
+pub(crate) fn first_load_vaddr(bytes: &[u8]) -> Option<u64> {
+    if !is_elf64_le(bytes) {
+        return None;
+    }
+    let phoff = u64_at(bytes, 0x20)? as usize;
+    let phentsize = u16_at(bytes, 0x36)? as usize;
+    let phnum = u16_at(bytes, 0x38)? as usize;
+    let mut lowest: Option<u64> = None;
+    for index in 0..phnum {
+        let at = phoff.checked_add(index.checked_mul(phentsize)?)?;
+        if u32_at(bytes, at)? != PT_LOAD {
+            continue;
+        }
+        let vaddr = u64_at(bytes, at + 0x10)?;
+        lowest = Some(lowest.map_or(vaddr, |low: u64| low.min(vaddr)));
+    }
+    lowest
+}
+
+/// Every `STT_FUNC` symbol the image defines, with its file address.
+///
+/// `.symtab` is preferred and `.dynsym` is the fallback: a stripped binary keeps
+/// only the latter, and half a symbol table still names more frames than none.
+/// Symbols with no address are dropped — an undefined symbol names a function
+/// this image does not contain, and letting one through would attribute a frame
+/// to a body that is somewhere else entirely.
+pub(crate) fn function_symbols(bytes: &[u8]) -> Vec<FuncSymbol> {
+    let mut best: Vec<FuncSymbol> = Vec::new();
+    for wanted in [SHT_SYMTAB, SHT_DYNSYM] {
+        let found = symbols_from_section_kind(bytes, wanted);
+        if !found.is_empty() {
+            best = found;
+            break;
+        }
+    }
+    // A symbol table is in whatever order the linker wrote it, which is not
+    // address order — and `symbolize` binary-searches. Sorting HERE rather than
+    // asking every caller to is what makes the two halves fit: the requirement
+    // belongs to the search, so the guarantee belongs to the thing that feeds
+    // it. Unsorted, the search does not fail loudly; it silently answers `None`
+    // for nearly every address, and a profile of a real program comes back
+    // naming nothing at all.
+    //
+    // By name on a tie, so two symbols at one address resolve the same way on
+    // every run rather than on symbol-table order.
+    best.sort_by(|a, b| a.value.cmp(&b.value).then_with(|| a.name.cmp(&b.name)));
+    best
+}
+
+fn symbols_from_section_kind(bytes: &[u8], kind: u32) -> Vec<FuncSymbol> {
+    let mut out = Vec::new();
+    if !is_elf64_le(bytes) {
+        return out;
+    }
+    let Some(shoff) = u64_at(bytes, 0x28).map(|v| v as usize) else {
+        return out;
+    };
+    let Some(shentsize) = u16_at(bytes, 0x3a).map(|v| v as usize) else {
+        return out;
+    };
+    let Some(shnum) = u16_at(bytes, 0x3c).map(|v| v as usize) else {
+        return out;
+    };
+    for index in 0..shnum {
+        let Some(at) = shoff.checked_add(index.wrapping_mul(shentsize)) else {
+            return out;
+        };
+        if u32_at(bytes, at + 4) != Some(kind) {
+            continue;
+        }
+        // `sh_link` on a symbol table names the string table its names live in.
+        // Following it rather than guessing `.strtab` is what makes this work on
+        // a stripped image, where the only pair left is `.dynsym`/`.dynstr`.
+        let (Some(off), Some(size), Some(entsize), Some(link)) = (
+            u64_at(bytes, at + 0x18).map(|v| v as usize),
+            u64_at(bytes, at + 0x20).map(|v| v as usize),
+            u64_at(bytes, at + 0x38).map(|v| v as usize),
+            u32_at(bytes, at + 0x28).map(|v| v as usize),
+        ) else {
+            continue;
+        };
+        if entsize == 0 || size == 0 {
+            continue;
+        }
+        let str_at = shoff.wrapping_add(link.wrapping_mul(shentsize));
+        let Some(str_off) = u64_at(bytes, str_at + 0x18).map(|v| v as usize) else {
+            continue;
+        };
+        let Some(str_size) = u64_at(bytes, str_at + 0x20).map(|v| v as usize) else {
+            continue;
+        };
+        for entry in 0..(size / entsize) {
+            let sym = off + entry * entsize;
+            let (Some(name_off), Some(info), Some(value), Some(sym_size)) = (
+                u32_at(bytes, sym).map(|v| v as usize),
+                bytes.get(sym + 4).copied(),
+                u64_at(bytes, sym + 8),
+                u64_at(bytes, sym + 16),
+            ) else {
+                break;
+            };
+            if info & 0xf != STT_FUNC || value == 0 {
+                continue;
+            }
+            let Some(name) = c_string_at(bytes, str_off, str_size, name_off) else {
+                continue;
+            };
+            out.push(FuncSymbol { value, size: sym_size, name });
+        }
+    }
+    out
+}
+
+/// Reads one NUL-terminated name out of a string table, refusing anything that
+/// would run past its end.
+fn c_string_at(bytes: &[u8], table_off: usize, table_size: usize, at: usize) -> Option<String> {
+    if at >= table_size {
+        return None;
+    }
+    let start = table_off.checked_add(at)?;
+    let end = table_off.checked_add(table_size)?;
+    let slice = bytes.get(start..end.min(bytes.len()))?;
+    let len = slice.iter().position(|byte| *byte == 0)?;
+    if len == 0 {
+        return None;
+    }
+    std::str::from_utf8(&slice[..len]).ok().map(str::to_string)
+}
+
+/// The distance between where the loader put the image and where the file asked
+/// to be, read from `/proc/<pid>/maps`.
+///
+/// Matched on the executable mapping of `exe`, not merely the first line naming
+/// it: a binary's data and read-only segments are mapped from the same path, and
+/// taking one of those as the base gives a bias that is wrong by a segment —
+/// which symbolises every frame to a plausible neighbour rather than failing.
+pub(crate) fn load_bias(maps: &str, exe: &str, first_vaddr: u64) -> Option<u64> {
+    for line in maps.lines() {
+        // `<range> <perms> <offset> <dev> <inode> <path>`, and the fields are
+        // taken by INDEX. Reading them off a half-consumed iterator is how the
+        // device number was once used as the file offset — a bias wrong by a
+        // whole segment, which names every frame after a plausible neighbour
+        // instead of failing.
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        let (Some(range), Some(perms), Some(offset), Some(path)) =
+            (fields.first(), fields.get(1), fields.get(2), fields.get(5))
+        else {
+            continue;
+        };
+        if !perms.contains('x') || *path != exe {
+            continue;
+        }
+        let start = u64::from_str_radix(range.split('-').next()?, 16).ok()?;
+        let offset = u64::from_str_radix(offset, 16).ok()?;
+        // The mapping offset says which part of the file this is; the bias is
+        // measured against the segment's own request, not the file's start.
+        return Some(start.wrapping_sub(first_vaddr).wrapping_sub(offset));
+    }
+    None
+}
+
+/// Names the function containing `addr`, given file-address symbols and a bias.
+///
+/// Sized symbols answer only for addresses inside them. An unsized one — which
+/// hand-written assembly often produces — answers for anything from it up to the
+/// next symbol, because refusing would leave the runtime's own helpers unnamed
+/// and those are exactly the frames a reader needs to recognise.
+pub(crate) fn symbolize(sorted: &[FuncSymbol], bias: u64, addr: u64) -> Option<&str> {
+    let file_addr = addr.checked_sub(bias)?;
+    let index = match sorted.binary_search_by(|entry| entry.value.cmp(&file_addr)) {
+        Ok(exact) => exact,
+        Err(0) => return None,
+        Err(after) => after - 1,
+    };
+    let entry = sorted.get(index)?;
+    if entry.size > 0 && file_addr >= entry.value + entry.size {
+        // Past the end of a sized symbol: the address belongs to whatever the
+        // linker put next, and naming it after this one would be a guess.
+        return None;
+    }
+    Some(&entry.name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds the smallest ELF64 image that carries one `PT_LOAD` and one
+    /// symbol table, so the parser is exercised on bytes rather than on a file
+    /// this host may not be able to produce.
+    fn image(sym_value: u64, sym_size: u64, name: &str, load_vaddr: u64) -> Vec<u8> {
+        image_of(&[(sym_value, sym_size, name)], load_vaddr)
+    }
+
+    /// The same, carrying several symbols in the order given — which is how a
+    /// real symbol table arrives, and never sorted by address.
+    fn image_of(symbols: &[(u64, u64, &str)], load_vaddr: u64) -> Vec<u8> {
+        let mut bytes = vec![0u8; 0x40];
+        bytes[0..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+        bytes[4] = ELFCLASS64;
+        bytes[5] = ELFDATA2LSB;
+
+        // One program header, one PT_LOAD.
+        let phoff = 0x40usize;
+        bytes.resize(phoff + 56, 0);
+        bytes[0x20..0x28].copy_from_slice(&(phoff as u64).to_le_bytes());
+        bytes[0x36..0x38].copy_from_slice(&56u16.to_le_bytes());
+        bytes[0x38..0x3a].copy_from_slice(&1u16.to_le_bytes());
+        bytes[phoff..phoff + 4].copy_from_slice(&PT_LOAD.to_le_bytes());
+        bytes[phoff + 0x10..phoff + 0x18].copy_from_slice(&load_vaddr.to_le_bytes());
+
+        // A string table holding a leading NUL and every name.
+        let str_off = bytes.len();
+        bytes.push(0);
+        let mut name_offsets = Vec::new();
+        for (_, _, name) in symbols {
+            name_offsets.push(bytes.len() - str_off);
+            bytes.extend_from_slice(name.as_bytes());
+            bytes.push(0);
+        }
+        let str_size = bytes.len() - str_off;
+
+        // The symbol entries, in the order given.
+        let sym_off = bytes.len();
+        for ((value, size, _), name_off) in symbols.iter().zip(&name_offsets) {
+            let mut sym = vec![0u8; 24];
+            sym[0..4].copy_from_slice(&(*name_off as u32).to_le_bytes());
+            sym[4] = STT_FUNC;
+            sym[8..16].copy_from_slice(&value.to_le_bytes());
+            sym[16..24].copy_from_slice(&size.to_le_bytes());
+            bytes.extend_from_slice(&sym);
+        }
+        let sym_size = bytes.len() - sym_off;
+
+        // Two sections: the symbol table, and the string table it links to.
+        let shoff = bytes.len();
+        let shentsize = 64usize;
+        let mut sections = vec![0u8; shentsize * 2];
+        sections[4..8].copy_from_slice(&SHT_SYMTAB.to_le_bytes());
+        sections[0x18..0x20].copy_from_slice(&(sym_off as u64).to_le_bytes());
+        sections[0x20..0x28].copy_from_slice(&(sym_size as u64).to_le_bytes());
+        sections[0x28..0x2c].copy_from_slice(&1u32.to_le_bytes());
+        sections[0x38..0x40].copy_from_slice(&24u64.to_le_bytes());
+        let second = shentsize;
+        sections[second + 0x18..second + 0x20].copy_from_slice(&(str_off as u64).to_le_bytes());
+        sections[second + 0x20..second + 0x28].copy_from_slice(&(str_size as u64).to_le_bytes());
+        bytes.extend_from_slice(&sections);
+        bytes[0x28..0x30].copy_from_slice(&(shoff as u64).to_le_bytes());
+        bytes[0x3a..0x3c].copy_from_slice(&(shentsize as u16).to_le_bytes());
+        bytes[0x3c..0x3e].copy_from_slice(&2u16.to_le_bytes());
+        bytes
+    }
+
+    /// A symbol table arrives in the linker's order, and the search over it
+    /// needs address order.
+    ///
+    /// The two halves were written together and never met: nothing called both
+    /// until an attached sampler did, and then the failure was silent in the
+    /// worst way. A binary search over unsorted input does not error — it just
+    /// answers `None` for nearly every address. A real program came back
+    /// profiled as 251 samples of `<native>`, which reads as "this program is
+    /// not PHP" rather than as "the names were never looked up".
+    ///
+    /// So the order is asserted where it is PRODUCED. A test that sorted first
+    /// and then searched would have passed against the bug.
+    #[test]
+    fn symbols_come_out_in_address_order_whatever_order_they_were_written_in() {
+        // Descending, which is close to what the table looked like in practice.
+        let bytes = image_of(
+            &[(0x9240, 0, "_php_last"), (0x8100, 0, "_php_middle"), (0x2000, 0, "_php_first")],
+            0,
+        );
+        let symbols = function_symbols(&bytes);
+        let values: Vec<u64> = symbols.iter().map(|entry| entry.value).collect();
+        assert_eq!(values, vec![0x2000, 0x8100, 0x9240], "{symbols:?}");
+
+        // And the consequence: addresses resolve, including ones BETWEEN
+        // symbols, which is where an interrupted program actually is.
+        assert_eq!(symbolize(&symbols, 0, 0x2000), Some("_php_first"));
+        assert_eq!(symbolize(&symbols, 0, 0x8104), Some("_php_middle"));
+        assert_eq!(symbolize(&symbols, 0, 0x9300), Some("_php_last"));
+        // Below the first symbol there is nothing to name an address after.
+        assert_eq!(symbolize(&symbols, 0, 0x100), None);
+    }
+
+    #[test]
+    fn reads_a_function_symbol_and_the_first_load_address() {
+        let bytes = image(0x1200, 0x40, "php_hot", 0x1000);
+        assert_eq!(first_load_vaddr(&bytes), Some(0x1000));
+        assert_eq!(
+            function_symbols(&bytes),
+            vec![FuncSymbol { value: 0x1200, size: 0x40, name: "php_hot".into() }]
+        );
+    }
+
+    /// Anything that is not a little-endian ELF64 is refused rather than parsed
+    /// into numbers that mean nothing. A symbol table built from those would
+    /// answer, and an answer is worse than nothing here.
+    #[test]
+    fn refuses_what_is_not_a_little_endian_elf64() {
+        let mut wrong_class = image(0x1200, 0x40, "php_hot", 0x1000);
+        wrong_class[4] = 1; // ELFCLASS32
+        assert!(function_symbols(&wrong_class).is_empty());
+        assert_eq!(first_load_vaddr(&wrong_class), None);
+
+        let mut big_endian = image(0x1200, 0x40, "php_hot", 0x1000);
+        big_endian[5] = 2; // ELFDATA2MSB
+        assert!(function_symbols(&big_endian).is_empty());
+
+        assert!(function_symbols(b"not an elf at all").is_empty());
+    }
+
+    /// The bias is measured against the EXECUTABLE mapping of the image.
+    ///
+    /// A binary's read-only and data segments are mapped from the same path, so
+    /// a reader that takes the first line naming the file gets a bias that is
+    /// wrong by a segment — and a wrong bias does not fail, it names every frame
+    /// after a plausible neighbour.
+    #[test]
+    fn the_bias_comes_from_the_executable_mapping_not_the_first_one() {
+        let maps = "\
+aaaa00000000-aaaa00001000 r--p 00000000 00:01 42 /app/hot
+aaaa00001000-aaaa00002000 r-xp 00001000 00:01 42 /app/hot
+aaaa00002000-aaaa00003000 rw-p 00002000 00:01 42 /app/hot
+ffff00000000-ffff00001000 rw-p 00000000 00:00 0 [stack]
+";
+        // The text segment asks for 0x1000 and was placed at 0xaaaa00001000 with
+        // a file offset of 0x1000, so everything shifted by 0xaaaa00000000.
+        assert_eq!(load_bias(maps, "/app/hot", 0x0), Some(0xaaaa_0000_0000));
+        assert_eq!(load_bias(maps, "/app/other", 0x0), None);
+    }
+
+    /// A non-PIE image asks for a fixed address, so its bias is zero — the same
+    /// arithmetic, not a special case.
+    #[test]
+    fn a_fixed_address_image_has_no_bias() {
+        let maps = "400000-401000 r-xp 00000000 00:01 7 /app/fixed\n";
+        assert_eq!(load_bias(maps, "/app/fixed", 0x400000), Some(0));
+    }
+
+    #[test]
+    fn names_the_function_containing_an_address_and_nothing_past_it() {
+        let symbols = vec![
+            FuncSymbol { value: 0x1000, size: 0x20, name: "first".into() },
+            FuncSymbol { value: 0x2000, size: 0x10, name: "second".into() },
+        ];
+        let bias = 0x1_0000_0000;
+        assert_eq!(symbolize(&symbols, bias, bias + 0x1000), Some("first"));
+        assert_eq!(symbolize(&symbols, bias, bias + 0x101f), Some("first"));
+        // One past the end of `first` is not `first`, and `second` has not
+        // started: naming it either way would be a guess.
+        assert_eq!(symbolize(&symbols, bias, bias + 0x1020), None);
+        assert_eq!(symbolize(&symbols, bias, bias + 0x2008), Some("second"));
+        // Below every symbol, and below the bias itself.
+        assert_eq!(symbolize(&symbols, bias, bias + 0x10), None);
+        assert_eq!(symbolize(&symbols, bias, 0x10), None);
+    }
+
+    /// An unsized symbol answers up to the next one. Hand-written runtime
+    /// helpers are emitted without a size, and refusing them would leave exactly
+    /// the frames a reader needs to recognise unnamed.
+    #[test]
+    fn an_unsized_symbol_answers_until_the_next_one() {
+        let symbols = vec![
+            FuncSymbol { value: 0x1000, size: 0, name: "__rt_helper".into() },
+            FuncSymbol { value: 0x2000, size: 0x10, name: "next".into() },
+        ];
+        assert_eq!(symbolize(&symbols, 0, 0x1000), Some("__rt_helper"));
+        assert_eq!(symbolize(&symbols, 0, 0x1fff), Some("__rt_helper"));
+        assert_eq!(symbolize(&symbols, 0, 0x2000), Some("next"));
+    }
+}

--- a/src/monitor/local.rs
+++ b/src/monitor/local.rs
@@ -12,6 +12,7 @@
 //! - The control channel is established before the spawn; the program reads it
 //!   during its own init.
 
+use super::attach::Image;
 use super::*;
 
 /// One sampling window over the whole process tree, rendered once: the bar
@@ -21,12 +22,19 @@ pub(crate) fn run_once(
     root: u32,
     binary: Option<&Path>,
     php_source: Option<&Path>,
+    image: Option<&Image>,
 ) -> i32 {
     let pids = discover_pids(root);
-    let reports = capture_window(&pids, cmd.duration_secs);
-    let samples = match samples_from_reports(&reports, binary, php_source) {
-        Some(samples) => samples,
-        None => {
+    let window = match capture_display(&pids, cmd.duration_secs, binary, php_source, image) {
+        Ok(Some(window)) => window,
+        // Said plainly, and never as "it may have exited": the target was there,
+        // the kernel would not let this process read it, and the message carries
+        // the setting to change.
+        Err(reason) => {
+            eprintln!("elephc monitor: {reason}");
+            return 1;
+        }
+        Ok(None) => {
             eprintln!(
                 "elephc monitor: no samples captured — the program may have exited before \
                  sampling started; try a longer-running input"
@@ -34,7 +42,7 @@ pub(crate) fn run_once(
             return 1;
         }
     };
-    let display = render_stacks(&samples);
+    let display = window.display;
     let out_path = cmd
         .out
         .clone()
@@ -68,10 +76,10 @@ pub(crate) fn run_once(
     };
     // Per-line attribution needs the dSYM and the source, so it rides the same
     // .php-target path that recovers inlined frames.
-    let lines = match (binary, php_source) {
-        (Some(binary), Some(source)) => reports
+    let lines = match (binary, php_source, &window.source) {
+        (Some(binary), Some(source), Some((reports, samples))) => reports
             .iter()
-            .find_map(|report| line_profile(&samples, report, binary, source)),
+            .find_map(|report| line_profile(samples, report, binary, source)),
         _ => None,
     };
     if let Err(error) = write_graph_exports(cmd, &display, &graph_title, lines.as_ref()) {
@@ -90,13 +98,45 @@ pub(crate) fn run_once(
     0
 }
 
+/// How a live view ended, and what that means for the program it was watching.
+///
+/// `--live` normally owns its target's lifetime: it launched the program so the
+/// operator could watch it, and leaving it behind when the view ends would be
+/// its own surprise. Losing the CHANNEL is the exception. That is this tool's
+/// plumbing failing, not the program's, and killing a running program because
+/// our own socket stopped answering destroys work the operator did not ask us to
+/// end — it just tells them which pid is still theirs to stop.
+pub(crate) struct LiveOutcome {
+    pub(crate) code: i32,
+    pub(crate) leave_target_running: bool,
+}
+
 /// The live loop: sample a window, merge the process tree, redraw, repeat
 /// until the target goes away. Prints the cumulative table on exit.
-pub(crate) fn run_live(cmd: &MonitorCommand, root: u32, mut child: Option<&mut process::Child>) -> i32 {
+pub(crate) fn run_live(
+    cmd: &MonitorCommand,
+    root: u32,
+    mut child: Option<&mut process::Child>,
+    channel: Option<&ControlChannel>,
+    image: Option<&Image>,
+) -> LiveOutcome {
     use std::io::IsTerminal;
     let interactive = std::io::stdout().is_terminal();
     let started = std::time::Instant::now();
     let mut cumulative: BTreeMap<Vec<(String, Kind)>, u64> = BTreeMap::new();
+    // The previous snapshot, when the target answers over the control channel.
+    // Windows are differences between snapshots, so the first one is measured
+    // against nothing and reports everything sampled since the program started.
+    let mut sampled_before: BTreeMap<Vec<(String, Kind)>, u64> = BTreeMap::new();
+    // Whether the child's activation ACK has been taken off the channel. One
+    // byte-sequence, sent once; leaving it there would put it in front of the
+    // first snapshot reply.
+    let mut activated = false;
+    // Whether a late window has already been mentioned.
+    let mut reported_late = false;
+    // Whether the view ended because the channel broke rather than because the
+    // program did.
+    let mut lost_channel = false;
     let mut previous: HashMap<String, f64> = HashMap::new();
     let mut windows = 0u32;
     let graph_title = if cmd.target.is_empty() {
@@ -122,14 +162,110 @@ pub(crate) fn run_live(cmd: &MonitorCommand, root: u32, mut child: Option<&mut p
             }
         }
         let pids = discover_pids(root);
-        let reports = capture_window(&pids, cmd.duration_secs);
-        let Some(samples) = samples_from_reports(&reports, None, None) else {
-            // Attach mode has no child handle: a window with zero reports is
-            // how we learn the target is gone.
-            break;
+        // A target this process launched can simply be ASKED — it holds the
+        // other end of a socketpair nothing else on the machine can open. Only
+        // a foreign process needs to be read from the outside, and that is the
+        // one tool that ships on macOS alone.
+        let display = if let Some(channel) = channel {
+            std::thread::sleep(std::time::Duration::from_secs(u64::from(cmd.duration_secs)));
+            // The child's activation ACK is sent once, at init, and sits in the
+            // buffer until somebody takes it. It has to come off BEFORE the first
+            // snapshot reply, because this reader is length-prefixed: it would
+            // otherwise read `ELEP` as a length, refuse it, and the loop would
+            // read that as a dead channel and stop after one window.
+            //
+            // Waited for rather than merely attempted. A non-blocking look
+            // succeeds whenever the child booted inside the first window, which
+            // is every run on an idle machine and not every run under load.
+            if !activated {
+                activated = await_activation(channel, std::time::Duration::from_secs(2));
+            }
+            let snapshot = match request_snapshot(channel) {
+                Snapshot::Answered(text) => {
+                    // An answer proves the child is past init, whether or not
+                    // `await_activation` was the one that saw the ACK — it may
+                    // have been consumed by the snapshot read itself. Without
+                    // this, every later window would spend its deadline waiting
+                    // for an ACK that has already been taken.
+                    activated = true;
+                    text
+                }
+                Snapshot::Late { activation_seen } => {
+                    // The read may have taken the ACK off the front before giving
+                    // up on the reply behind it. Recording that is what stops
+                    // every later window from opening with the full activation
+                    // deadline spent waiting for a message already consumed.
+                    activated |= activation_seen;
+                    // Slow is not gone. Ending the loop here would REAP a healthy
+                    // program: the target only outlives the view while the view is
+                    // still running, so a window nobody answered in time would
+                    // stop the thing being profiled.
+                    //
+                    // Said once, because a busy target would otherwise bury its
+                    // own table under the same line every window.
+                    if !reported_late {
+                        reported_late = true;
+                        eprintln!(
+                            "elephc monitor: the target did not answer within the window; \
+                             still watching"
+                        );
+                    }
+                    continue;
+                }
+                Snapshot::Gone => {
+                    // The channel is finished. Whether the PROGRAM is finished is
+                    // a different question, and the answer decides whether it
+                    // gets stopped: this tool's own plumbing failing is not a
+                    // reason to end work the operator is in the middle of.
+                    if child.as_deref_mut().is_some_and(|c| c.try_wait().ok().flatten().is_none()) {
+                        lost_channel = true;
+                        eprintln!(
+                            "elephc monitor: lost the channel to the target; it is still running \
+                             as pid {root} and is left alone. Reporting what was collected."
+                        );
+                    }
+                    break;
+                }
+            };
+            // Snapshots are cumulative, so the window is what this one has that
+            // the last did not. A stack that stopped being sampled contributes
+            // nothing rather than a negative.
+            // Summed, not collected. `folded_text_to_display` can emit the same
+            // display stack twice — one folded line becomes several stacks when
+            // it carries a native leaf — and `collect` into a map keeps the LAST
+            // of a pair instead of their total, which silently loses samples
+            // from the window and from every window after it.
+            let mut total: BTreeMap<Vec<(String, Kind)>, u64> = BTreeMap::new();
+            for (stack, count) in folded_text_to_display(&snapshot) {
+                *total.entry(stack).or_default() += count;
+            }
+            let window: Vec<(Vec<(String, Kind)>, u64)> = total
+                .iter()
+                .filter_map(|(stack, count)| {
+                    let before = sampled_before.get(stack).copied().unwrap_or(0);
+                    count.checked_sub(before).filter(|delta| *delta > 0).map(|delta| (stack.clone(), delta))
+                })
+                .collect();
+            sampled_before = total;
+            windows += 1;
+            window
+        } else {
+            let window = match capture_display(&pids, cmd.duration_secs, None, None, image) {
+                Ok(Some(window)) => window,
+                // Attach mode has no child handle: an empty window is how we
+                // learn the target is gone.
+                Ok(None) => break,
+                // A refusal is not a target that ended. Ending the view silently
+                // here is what made `yama/ptrace_scope=1` look like a program
+                // that had exited.
+                Err(reason) => {
+                    eprintln!("elephc monitor: {reason}");
+                    break;
+                }
+            };
+            windows += 1;
+            window.display
         };
-        windows += 1;
-        let display = render_stacks(&samples);
         for (stack, weight) in &display {
             *cumulative.entry(stack.clone()).or_default() += weight;
         }
@@ -157,8 +293,69 @@ pub(crate) fn run_live(cmd: &MonitorCommand, root: u32, mut child: Option<&mut p
         let merged: Vec<(Vec<(String, Kind)>, u64)> = cumulative.into_iter().collect();
         println!("\n=== cumulative ({windows} windows) ===");
         print!("{}", why_table(&merged, 1));
+    } else {
+        // A program shorter than one window left NOTHING behind: the loop sleeps
+        // first and asks second, so it was already gone by the first question,
+        // and the exit dump it wrote to its own stderr is filtered out of a live
+        // view on purpose. Silence and a zero exit reads as a broken profiler
+        // rather than as a program that finished, so say which it was.
+        eprintln!(
+            "elephc monitor: the program finished before the first window; there was nothing \
+             to sample. Use a longer-running input, or a shorter --duration."
+        );
     }
-    0
+    LiveOutcome { code: 0, leave_target_running: lost_channel }
+}
+
+/// One window of samples, already named and folded, whichever way it was read.
+///
+/// Two ways exist and they meet here. A process this tool can ask — anything
+/// launched or reachable through its endpoint — answers for itself. A process it
+/// can only WATCH answers for nothing, and has to be read from the outside:
+/// through `/usr/bin/sample` on macOS, and by stopping it with `ptrace` on
+/// Linux. `image` is what says which: it exists only for `--attach`, and only
+/// where reading a process from the outside is this tool's own job.
+///
+/// `None` means the window is empty, which is the same thing both ways: no
+/// samples landed, and for `--attach` that is how the target's disappearance is
+/// noticed at all.
+pub(crate) struct Window {
+    /// What every consumer downstream reads: named stacks and their weights.
+    pub(crate) display: Vec<(Vec<(String, Kind)>, u64)>,
+    /// The text a sampler produced, and the frames parsed out of it.
+    ///
+    /// Kept only because per-line attribution needs both again, and re-deriving
+    /// them from `display` is impossible — a name is not an address. `None` for
+    /// a window this tool sampled itself, which never had text to begin with.
+    pub(crate) source: Option<(Vec<String>, Vec<(Vec<Frame>, u64)>)>,
+}
+
+/// One window, and THREE answers rather than two.
+///
+/// `Err` is "this target cannot be read at all", which is not the same as the
+/// `Ok(None)` that means "read it, saw nothing". Attach treats an empty window
+/// as proof the target has gone, so folding a refusal into it told operators
+/// their still-running program had exited and swallowed the one line that named
+/// what to change.
+fn capture_display(
+    pids: &[u32],
+    duration_secs: u32,
+    binary: Option<&Path>,
+    php_source: Option<&Path>,
+    image: Option<&Image>,
+) -> Result<Option<Window>, String> {
+    #[cfg(target_os = "linux")]
+    if let Some(image) = image {
+        let display = super::ptrace::attach_window(pids, duration_secs, image)?;
+        return Ok((!display.is_empty()).then_some(Window { display, source: None }));
+    }
+    // Bound so the macOS build does not warn on an argument only Linux reads.
+    let _ = &image;
+    let reports = capture_window(pids, duration_secs);
+    let Some(samples) = samples_from_reports(&reports, binary, php_source) else {
+        return Ok(None);
+    };
+    Ok(Some(Window { display: render_stacks(&samples), source: Some((reports, samples)) }))
 }
 
 /// Samples every pid of one window in parallel and returns the reports that
@@ -242,20 +439,6 @@ pub(crate) fn spawnable_path(path: &str) -> PathBuf {
         // which at least defeats the PATH search.
         Err(_) => PathBuf::from(".").join(path),
     }
-}
-
-/// Compiles a `.php` target with `--debug-info` by re-executing this binary, and
-/// returns the produced executable's path (next to the source, like a normal compile).
-pub(crate) fn compile_php_target(source: &str) -> Result<PathBuf, String> {
-    let exe = std::env::current_exe().map_err(|e| format!("cannot locate elephc: {e}"))?;
-    let status = process::Command::new(exe)
-        .args(["--debug-info", source])
-        .status()
-        .map_err(|e| format!("cannot run elephc: {e}"))?;
-    if !status.success() {
-        return Err(format!("compiling {source} failed"));
-    }
-    Ok(spawnable_path(source.trim_end_matches(".php")))
 }
 
 /// Explains an empty capture by what the run actually did.
@@ -359,7 +542,7 @@ pub(crate) fn run_instrument(cmd: &MonitorCommand) -> i32 {
     // holds the sampler's folded stacks; forwarding those would print raw
     // profiler output as if the program had written it.
     for line in stderr.lines() {
-        if !line.starts_with("elephc-instr") && !line.starts_with("elephc-probe") {
+        if !is_profiler_line(line) {
             eprintln!("{line}");
         }
     }

--- a/src/monitor/local.rs
+++ b/src/monitor/local.rs
@@ -137,6 +137,8 @@ pub(crate) fn run_live(
     // Whether the view ended because the channel broke rather than because the
     // program did.
     let mut lost_channel = false;
+    let mut failed = false;
+    let mut target_finished = false;
     let mut previous: HashMap<String, f64> = HashMap::new();
     let mut windows = 0u32;
     let graph_title = if cmd.target.is_empty() {
@@ -158,6 +160,7 @@ pub(crate) fn run_live(
     loop {
         if let Some(child) = child.as_deref_mut() {
             if child.try_wait().ok().flatten().is_some() {
+                target_finished = true;
                 break;
             }
         }
@@ -219,10 +222,14 @@ pub(crate) fn run_live(
                     // reason to end work the operator is in the middle of.
                     if child.as_deref_mut().is_some_and(|c| c.try_wait().ok().flatten().is_none()) {
                         lost_channel = true;
+                        failed = true;
                         eprintln!(
                             "elephc monitor: lost the channel to the target; it is still running \
                              as pid {root} and is left alone. Reporting what was collected."
                         );
+                    } else {
+                        target_finished = target_has_exited(root);
+                        failed = !target_finished;
                     }
                     break;
                 }
@@ -252,14 +259,22 @@ pub(crate) fn run_live(
         } else {
             let window = match capture_display(&pids, cmd.duration_secs, None, None, image) {
                 Ok(Some(window)) => window,
-                // Attach mode has no child handle: an empty window is how we
-                // learn the target is gone.
-                Ok(None) => break,
+                // An empty window alone cannot establish target termination;
+                // attach mode has no child handle, so check the process itself.
+                Ok(None) => {
+                    target_finished = target_has_exited(root);
+                    if !target_finished {
+                        failed = true;
+                        eprintln!("elephc monitor: no samples captured; the target has not exited");
+                    }
+                    break;
+                }
                 // A refusal is not a target that ended. Ending the view silently
                 // here is what made `yama/ptrace_scope=1` look like a program
                 // that had exited.
                 Err(reason) => {
                     eprintln!("elephc monitor: {reason}");
+                    failed = true;
                     break;
                 }
             };
@@ -293,7 +308,7 @@ pub(crate) fn run_live(
         let merged: Vec<(Vec<(String, Kind)>, u64)> = cumulative.into_iter().collect();
         println!("\n=== cumulative ({windows} windows) ===");
         print!("{}", why_table(&merged, 1));
-    } else {
+    } else if target_finished {
         // A program shorter than one window left NOTHING behind: the loop sleeps
         // first and asks second, so it was already gone by the first question,
         // and the exit dump it wrote to its own stderr is filtered out of a live
@@ -304,7 +319,21 @@ pub(crate) fn run_live(
              to sample. Use a longer-running input, or a shorter --duration."
         );
     }
-    LiveOutcome { code: 0, leave_target_running: lost_channel }
+    LiveOutcome { code: i32::from(failed), leave_target_running: lost_channel }
+}
+
+/// Confirms target termination independently of an empty profile or broken socket.
+fn target_has_exited(pid: u32) -> bool {
+    #[cfg(target_os = "linux")]
+    if let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) {
+        // A zombie still answers kill(pid, 0), but cannot produce another sample.
+        return stat.rsplit_once(')').is_some_and(|(_, tail)| {
+            matches!(tail.split_whitespace().next(), Some("Z" | "X"))
+        });
+    }
+    // SAFETY: signal zero only checks existence; it does not signal the target.
+    let absent = unsafe { libc::kill(pid as libc::pid_t, 0) == -1 };
+    absent && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
 }
 
 /// One window of samples, already named and folded, whichever way it was read.
@@ -767,3 +796,7 @@ pub(crate) fn live_frame(
     *previous = next_previous;
     out
 }
+
+#[cfg(test)]
+#[path = "local_tests.rs"]
+mod review_tests;

--- a/src/monitor/local_tests.rs
+++ b/src/monitor/local_tests.rs
@@ -1,0 +1,84 @@
+//! Purpose:
+//! Verifies live-loop exit codes and diagnostics at the caller boundary.
+//!
+//! Called from:
+//! - `monitor::local` through the Rust test harness.
+//!
+//! Key details:
+//! - Subprocesses capture diagnostics without redirecting the harness's stderr.
+//! - Linux self-attach always refuses, independently of yama or capabilities.
+
+use super::*;
+
+/// Runs the live caller in an isolated harness process and captures its diagnostics.
+fn outcome(mode: &str) -> process::Output {
+    process::Command::new(std::env::current_exe().unwrap())
+        .args(["--exact", "monitor::local::review_tests::live_outcome_child", "--nocapture"])
+        .env("ELEPHC_TEST_LIVE_OUTCOME", mode)
+        .output().unwrap()
+}
+
+/// A kernel refusal must reach the caller as failure without reporting target death.
+#[cfg(target_os = "linux")]
+#[test]
+fn live_attach_refusal_is_failure_without_claiming_target_finished() {
+    let output = outcome("refused");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(1), "{stderr}");
+    assert!(stderr.contains("cannot attach to the target"), "{stderr}");
+    assert!(!stderr.contains("program finished"), "{stderr}");
+}
+
+/// A dead control socket does not imply the launched process has terminated.
+#[test]
+fn live_lost_channel_is_failure_and_leaves_running_target_alone() {
+    let output = outcome("lost");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(1), "{stderr}");
+    assert!(stderr.contains("lost the channel"), "{stderr}");
+    assert!(!stderr.contains("program finished"), "{stderr}");
+}
+
+/// A confirmed early child exit retains the helpful short-lived-program diagnostic.
+#[test]
+fn live_finished_child_reports_short_window_without_failure() {
+    let output = outcome("finished");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(0), "{stderr}");
+    assert!(stderr.contains("program finished before the first window"), "{stderr}");
+}
+
+/// Subprocess entry point; exits with the actual live outcome after fixture cleanup.
+#[test]
+fn live_outcome_child() {
+    let Ok(mode) = std::env::var("ELEPHC_TEST_LIVE_OUTCOME") else { return };
+    let args = ["--attach".to_string(), std::process::id().to_string(), "--live".to_string()];
+    let mut cmd = parse_monitor_args(&args).unwrap();
+    cmd.duration_secs = 0;
+    #[cfg(target_os = "linux")]
+    if mode == "refused" {
+        let pid = std::process::id();
+        let image = super::super::attach::image_for(pid)
+            .unwrap_or_else(|_| panic!("unstripped test executable must have an image"));
+        let result = run_live(&cmd, pid, None, None, Some(&image));
+        assert!(!result.leave_target_running);
+        std::process::exit(result.code);
+    }
+    let mut child = process::Command::new("sh")
+        .args(["-c", if mode == "finished" { "exit 0" } else { "exec sleep 30" }])
+        .spawn().unwrap();
+    let mut channel = open_polled_control_channel().unwrap();
+    // SAFETY: close the owned peer before asking, then prevent a double close.
+    unsafe { libc::close(channel.child) };
+    channel.forget_child();
+    if mode == "finished" {
+        child.wait().unwrap();
+    }
+    let result = run_live(&cmd, child.id(), Some(&mut child), Some(&channel), None);
+    let still_running = child.try_wait().unwrap().is_none();
+    let _ = child.kill();
+    let _ = child.wait();
+    assert_eq!(still_running, mode == "lost");
+    assert_eq!(result.leave_target_running, mode == "lost");
+    std::process::exit(result.code);
+}

--- a/src/monitor/mod.rs
+++ b/src/monitor/mod.rs
@@ -9,7 +9,9 @@
 //! Key details:
 //! - A launched program defaults to exact capture on macOS and Linux. A running
 //!   service defaults to its in-process sampled ring; `--exact` selects one
-//!   completed request. `--live`/`--attach` use macOS's external sampler.
+//!   completed request. `--live` asks the program it launched over a socketpair;
+//!   `--attach` reads a process it did not launch from the outside, with
+//!   `/usr/bin/sample` on macOS and `ptrace` on Linux.
 //! - `sample` splits one function into sibling call-graph nodes per sampled call
 //!   offset; aggregation is by symbol, never by node identity.
 //! - Inlined PHP calls leave no frame, but the inliner preserves callee source
@@ -25,6 +27,27 @@ use std::process;
 
 mod command;
 pub(crate) use command::*;
+// Reading an image from the outside, for the one path that has no channel in.
+// Parsing only, so it is exercised by ordinary tests on any host — which is what
+// makes code whose real use is on another platform reviewable at all.
+//
+// Its CALLER is Linux's, so on any other host every item here is dead outside
+// the tests. Allowed rather than gated away: gating it would take the tests with
+// it, and then the parsing that Linux depends on would be checked nowhere but
+// Linux — which is the opposite of why it was separated.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+mod elf;
+// Naming what an out-of-process sampler read. Also parsing only, allowed dead on
+// non-Linux hosts for the same reason: the syscalls that produce those addresses
+// are the one part a host without `ptrace` cannot run, and they are kept apart
+// from this so that everything except them stays testable.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+mod attach;
+// The syscalls themselves, and the loop that drives them. Linux only, and the
+// one file here no test on this host reaches — which is why it holds nothing
+// but them.
+#[cfg(target_os = "linux")]
+mod ptrace;
 mod channel;
 pub(crate) use channel::*;
 mod local;
@@ -149,7 +172,10 @@ pub(crate) fn run(cmd: MonitorCommand) -> i32 {
     // asking them to know where their program is running, which is exactly the
     // distinction this command exists not to have. A source is compiled with the
     // capability; a binary that carries it is read exactly. `--live` and
-    // `--attach` still need the external sampler, so they keep their own path.
+    // `--attach` are not sampled from the outside any more, but they still keep
+    // their own path: live ASKS the child it launched over a socketpair, and
+    // attach reads a process it never launched, and neither is what
+    // `run_instrument` does.
     if !cmd.live && cmd.attach_pid.is_none() {
         let is_source = cmd.target.ends_with(".php");
         if is_source || carries_monitoring(std::path::Path::new(&cmd.target)) {
@@ -167,39 +193,40 @@ pub(crate) fn run(cmd: MonitorCommand) -> i32 {
             return 1;
         }
     }
-    // `--live` and `--attach` are the only paths left that read a process from
-    // the outside, and the tool that does it ships on macOS alone. Everything
-    // remaining local default — a source or equipped binary — is measured
-    // exactly and needs no sampler, which is why this is the only platform
-    // branch left.
-    if !cfg!(target_os = "macos") {
-        if let Some(pid) = cmd.attach_pid {
-            eprintln!(
-                "elephc monitor: attaching to a running process needs an external sampler, \
-                 which only macOS ships. Read it through its endpoint instead: start it \
-                 with ELEPHC_PROBE_ADDR=127.0.0.1:9411, then `elephc monitor \
-                 127.0.0.1:9411` (pid {pid} is untouched)."
-            );
-            return 1;
-        }
-        if cmd.live {
-            eprintln!(
-                "elephc monitor: --live refreshes from an external sampler, which only macOS \
-                 ships. For a live view here, start the program with \
-                 ELEPHC_PROBE_ADDR=127.0.0.1:9411, then `elephc monitor 127.0.0.1:9411`."
-            );
-            return 1;
-        }
-    }
+    // `--attach` is the only path that reads a process from the OUTSIDE. It used
+    // to be macOS-only, and `--live` was refused beside it for the same stated
+    // reason — wrongly, since `--live` LAUNCHES its target and can hand it a
+    // socketpair and ask. Attach cannot ask: it is handed a pid already running
+    // under someone else's control, so reading it from the outside is not a
+    // shortcut here, it is the whole job. macOS has `/usr/bin/sample` for that;
+    // on Linux this tool does it itself, with `ptrace`.
     if let Some(pid) = cmd.attach_pid {
+        let image = match attach_image(pid) {
+            Ok(image) => image,
+            Err(reason) => {
+                eprintln!("elephc monitor: {reason}");
+                return 1;
+            }
+        };
         return if cmd.live {
-            run_live(&cmd, pid, None)
+            // Attach never launched the target, so it never owns its lifetime
+            // and there is nothing here to leave alone or reap.
+            run_live(&cmd, pid, None, None, image.as_ref()).code
         } else {
-            run_once(&cmd, pid, None, None)
+            run_once(&cmd, pid, None, None, image.as_ref())
         };
     }
+    // With `--with-monitoring`, not `--debug-info`. Reaching here with a `.php`
+    // means `--live`, because the source path returns through `run_instrument`
+    // above and `--attach` never has a path at all — and live asks the child for
+    // its samples, which a binary compiled without the probe cannot answer. It
+    // did not ask for the probe before, so `monitor hot.php --live` launched a
+    // program with nothing listening and then waited out every window for an ACK
+    // that could not come. The test that was meant to cover this compiled the
+    // fixture by hand first and monitored the BINARY, so the one path a user
+    // takes was the one path nothing ran.
     let (binary, php_source) = if cmd.target.ends_with(".php") {
-        match compile_php_target(&cmd.target) {
+        match channel::compile_php_monitored(&cmd.target) {
             Ok(path) => (path, Some(PathBuf::from(&cmd.target))),
             Err(error) => {
                 eprintln!("elephc monitor: {error}");
@@ -214,28 +241,72 @@ pub(crate) fn run(cmd: MonitorCommand) -> i32 {
         // PATH carries an empty entry.
         (spawnable_path(&cmd.target), None)
     };
-    let mut child = match process::Command::new(&binary).spawn() {
+    // The live path launches the target too, so it can ask it directly rather
+    // than read it from the outside. It did not open a channel before, which is
+    // the whole reason `--live` needed an external sampler — for a program this
+    // process had started itself.
+    let mut command = process::Command::new(&binary);
+    let channel = if cmd.live { open_polled_control_channel() } else { None };
+    if let Some(channel) = &channel {
+        attach_control_channel(&mut command, channel);
+        // Asking also wakes the EXACT profiler, which writes its table to stderr
+        // when the program ends. That is the one thing a live table must not
+        // print: the operator would get the raw dump under the view they are
+        // watching, as if the program had written it. Captured and filtered, the
+        // way the exact path has always filtered the sampler's folded stacks out
+        // of a program's own diagnostics.
+        command.stderr(process::Stdio::piped());
+    }
+    let mut child = match command.spawn() {
         Ok(child) => child,
         Err(error) => {
             eprintln!("elephc monitor: cannot run {}: {error}", binary.display());
             return 1;
         }
     };
-    let root = child.id();
-    let code = if cmd.live {
-        run_live(&cmd, root, Some(&mut child))
-    } else {
-        run_once(&cmd, root, Some(&binary), php_source.as_deref())
-    };
-    // A short-lived program is allowed to finish naturally after a successful
-    // one-shot capture. But when sampling failed, or when the live loop ended
-    // with the target still up (it only exits once monitoring is over), waiting
-    // would hang forever on a long-running target — reap it instead.
-    let still_running = child.try_wait().ok().flatten().is_none();
-    if still_running && (code != 0 || cmd.live) {
-        let _ = child.kill();
+    // The spawn gave the program its own copy; ours would keep the socket alive
+    // after it exits and turn the next snapshot request into a permanent wait.
+    let mut channel = channel;
+    if let Some(channel) = channel.as_mut() {
+        channel.release_child();
     }
-    let _ = child.wait();
+    // Drained as it arrives rather than at exit: a live view runs for as long as
+    // the program does, and a pipe nobody reads fills and blocks the program
+    // writing into it.
+    if let Some(stderr) = child.stderr.take() {
+        std::thread::Builder::new()
+            .name("elephc-monitor-stderr".to_string())
+            .spawn(move || {
+                use std::io::BufRead as _;
+                for line in std::io::BufReader::new(stderr).lines().map_while(Result::ok) {
+                    if is_profiler_line(&line) {
+                        continue;
+                    }
+                    eprintln!("{line}");
+                }
+            })
+            .ok();
+    }
+    let root = child.id();
+    let (code, leave_target_running) = if cmd.live {
+        let outcome = run_live(&cmd, root, Some(&mut child), channel.as_ref(), None);
+        (outcome.code, outcome.leave_target_running)
+    } else {
+        (run_once(&cmd, root, Some(&binary), php_source.as_deref(), None), false)
+    };
+    let still_running = child.try_wait().ok().flatten().is_none();
+    match disposition(still_running, code, cmd.live, leave_target_running) {
+        Disposition::Stop => {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        Disposition::Collect => {
+            let _ = child.wait();
+        }
+        // Not even waited for: waiting is what would hang this process on a
+        // program that is still doing its work.
+        Disposition::LeaveAlone => {}
+    }
     code
 }
 
@@ -509,24 +580,63 @@ pub(crate) const CONTROL_FD: i32 = 3;
 /// Marker written into the channel before spawning, so it is already buffered
 /// when the child looks and no handshake can race the program's own start.
 pub(crate) const CONTROL_MAGIC: &[u8] = b"ELEPHC-MONITOR-1";
+/// The same marker, from a monitor that will POLL the child for snapshots.
+///
+/// Deliberately the same length: the child's check peeks a fixed sixteen bytes
+/// and compares, so a second marker costs it nothing. Mirrors
+/// `CONTROL_MAGIC_LIVE` in `elephc-probe`; the two are one protocol and share a
+/// name so a `grep` finds the pair.
+pub(crate) const CONTROL_MAGIC_LIVE: &[u8] = b"ELEPHC-MONITOR-L";
 /// Acknowledgement returned after the child consumed the control marker and
 /// activated its embedded monitoring runtime.
 pub(crate) const CONTROL_ACK: &[u8] = b"ELEPHC-MONITOR-ACK-1";
 
 /// Holds the parent's end of the control channel open for the child's lifetime.
 pub(crate) struct ControlChannel {
-    parent: i32,
+    /// This process's end. `request_snapshot` asks over it; nothing else on the
+    /// machine can, which is what makes it a credential.
+    pub(crate) parent: i32,
     child: i32,
+}
+
+impl ControlChannel {
+    /// Drops the parent's copy of the CHILD end, once the spawn has handed the
+    /// real one to the profiled program.
+    ///
+    /// Only matters to a caller that reads the channel. While this process holds
+    /// a copy, the socket has a writer that never writes — so when the profiled
+    /// program exits, `recv` on the parent end does not report EOF, it blocks
+    /// forever waiting for us. A `--live` loop asking for a snapshot hung there
+    /// instead of noticing the target was gone.
+    /// Marks the child end as no longer ours to close, for a caller that closed
+    /// it itself. Closing a descriptor twice closes whatever was opened on that
+    /// number in between.
+    #[cfg(test)]
+    fn forget_child(&mut self) {
+        self.child = -1;
+    }
+
+    fn release_child(&mut self) {
+        if self.child >= 0 {
+            unsafe {
+                libc::close(self.child);
+            }
+            self.child = -1;
+        }
+    }
 }
 
 impl Drop for ControlChannel {
     /// Closes both ends. The child end is inherited across the spawn, so
     /// leaking either would leave the profiled program holding a channel
-    /// nobody reads.
+    /// nobody reads. Already-released ends are left alone rather than closed
+    /// twice — a second `close` on a recycled number closes somebody else's file.
     fn drop(&mut self) {
         unsafe {
             libc::close(self.parent);
-            libc::close(self.child);
+            if self.child >= 0 {
+                libc::close(self.child);
+            }
         }
     }
 }
@@ -786,6 +896,79 @@ pub(crate) fn parse_hex_key(hex: &str) -> Option<[u8; 32]> {
         key[i] = u8::from_str_radix(std::str::from_utf8(chunk).ok()?, 16).ok()?;
     }
     Some(key)
+}
+
+/// What `--attach` needs to read a process it was only handed a pid for, or the
+/// sentence explaining why this host cannot.
+///
+/// `None` is not a failure: macOS reads a process through `/usr/bin/sample`,
+/// which resolves its own symbols, so there is nothing to prepare. Linux reads
+/// the process itself and needs the image first. Anywhere else there is no way
+/// in at all, and saying so — with the way that DOES work on every host — beats
+/// an `EPERM` from a syscall the reader did not know was being made.
+fn attach_image(pid: u32) -> Result<Option<attach::Image>, String> {
+    #[cfg(target_os = "linux")]
+    {
+        attach::image_for(pid).map(Some).map_err(|error| {
+            // The hint only goes on a refusal. Appended to every failure it named
+            // a cause that had not occurred: an absent pid answered "No such file
+            // or directory (the kernel's yama/ptrace_scope is 1, …)", which sends
+            // an operator to change a setting that was never in the way.
+            match (error.denied, ptrace::attach_refusal_hint()) {
+                (true, Some(hint)) => format!("{} ({hint})", error.reason),
+                _ => error.reason,
+            }
+        })
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let _ = pid;
+        Ok(None)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        Err(format!(
+            "attaching to a running process is not implemented on this platform. Read it \
+             through its endpoint instead: start it with ELEPHC_PROBE_ADDR=127.0.0.1:9411, \
+             then `elephc monitor 127.0.0.1:9411` (pid {pid} is untouched)."
+        ))
+    }
+}
+
+/// What becomes of a target this process launched, now that the capture is over.
+enum Disposition {
+    /// Stop it, then collect it.
+    Stop,
+    /// Collect it: it has finished, or is about to on its own.
+    Collect,
+    /// Leave it running and do not wait for it.
+    LeaveAlone,
+}
+
+/// Decides between them from the four facts that matter, in one place, so the
+/// rule can be read and tested rather than inferred from where it sits.
+///
+/// A short-lived program is allowed to finish on its own after a successful
+/// one-shot capture. A capture that FAILED, and every live view, stops one that
+/// is still up: `--live` runs until monitoring is over, so waiting on a
+/// long-running target would hang forever.
+///
+/// `lost_channel` is the exception that outranks all of it, and the reason is
+/// whose fault it is. The view ended because THIS tool's plumbing stopped
+/// answering, not because the program did anything, and stopping a program over
+/// our own quiet socket ends work the operator never asked us to end. It stays
+/// up, uncollected — they have its pid.
+fn disposition(still_running: bool, code: i32, live: bool, lost_channel: bool) -> Disposition {
+    if !still_running {
+        return Disposition::Collect;
+    }
+    if lost_channel {
+        return Disposition::LeaveAlone;
+    }
+    if code != 0 || live {
+        return Disposition::Stop;
+    }
+    Disposition::Collect
 }
 
 /// A display-ready frame: its user-facing name and what kind of time it is.

--- a/src/monitor/ptrace.rs
+++ b/src/monitor/ptrace.rs
@@ -1,0 +1,721 @@
+//! Purpose:
+//! Reads program counters out of a process this tool did not launch: attach,
+//! stop, read the registers and walk the frame chain, detach. Linux only.
+//!
+//! Called from:
+//! - `monitor::attach`, for `--attach <pid>`, which is handed a pid already
+//!   running under someone else's control and has no channel to ask over.
+//!
+//! Key details:
+//! - This is the one file that cannot be exercised without `ptrace`, which is
+//!   why it holds the syscalls AND the loop that drives them, and nothing else.
+//!   Everything that turns what it read into a profile lives in `elf` and
+//!   `attach`, takes numbers and returns names, and is tested on any host.
+//! - Attaching is INTRUSIVE in a way asking is not: the target is stopped for
+//!   the duration of each sample. Every path out of a stop resumes it, because
+//!   a target left stopped by a profiler that walked away is worse than no
+//!   profile at all.
+//! - A frame walk trusts the frame pointer. Code built without one cannot be
+//!   walked this way, and the walk stops rather than inventing frames.
+
+use std::io;
+
+/// How deep a single frame walk may go.
+///
+/// A chain longer than this is a corrupt frame pointer, not a deep program: a
+/// cycle in the chain would otherwise walk until some unrelated read failed.
+/// Stopping at a fixed depth bounds the time the target is held stopped, which
+/// is the cost every sample charges to the program being profiled.
+const MAX_DEPTH: usize = 256;
+
+/// A thread stopped and read.
+pub(crate) struct Registers {
+    /// Where the thread was interrupted.
+    pub(crate) pc: u64,
+    /// The frame pointer, which is where the chain walk starts.
+    pub(crate) fp: u64,
+}
+
+/// Every thread of a process, as the kernel lists them.
+///
+/// A process is sampled thread by thread: `ptrace` acts on threads, not
+/// processes, and a program whose work happens off the main thread would
+/// otherwise profile as idle. The list is re-read every window because threads
+/// come and go.
+pub(crate) fn thread_ids(pid: u32) -> Vec<u32> {
+    let Ok(entries) = std::fs::read_dir(format!("/proc/{pid}/task")) else {
+        return Vec::new();
+    };
+    let mut tids: Vec<u32> = entries
+        .filter_map(|entry| entry.ok()?.file_name().to_str()?.parse().ok())
+        .collect();
+    // Ascending, so the main thread leads and two windows line up rather than
+    // reshuffling on directory order.
+    tids.sort_unstable();
+    tids
+}
+
+/// The path of the executable behind a pid, as the kernel resolved it.
+///
+/// Read through `/proc`, not from a command line: a program started through a
+/// relative path, a symlink or a `PATH` lookup would otherwise be looked for
+/// where it is not, and a deleted-but-running binary is still readable here.
+pub(crate) fn executable_path(pid: u32) -> io::Result<std::path::PathBuf> {
+    std::fs::read_link(format!("/proc/{pid}/exe"))
+}
+
+/// The kernel's own memory map for a pid, which is what says where the
+/// executable actually landed.
+pub(crate) fn memory_maps(pid: u32) -> io::Result<String> {
+    std::fs::read_to_string(format!("/proc/{pid}/maps"))
+}
+
+/// Why the kernel is likely to refuse an attach, when it is going to.
+///
+/// `ptrace_scope` refuses non-descendants on most distributions, and the
+/// refusal a caller gets is a bare `EPERM` that reads like a bug in this tool.
+/// Naming the knob is the difference between an operator who can fix it in one
+/// line and one who files an issue.
+pub(crate) fn attach_refusal_hint() -> Option<String> {
+    let scope = std::fs::read_to_string("/proc/sys/kernel/yama/ptrace_scope").ok()?;
+    Some(explain_ptrace_scope(scope.trim())?.to_string())
+}
+
+/// What one `ptrace_scope` setting means for attaching, in the operator's
+/// terms. Split out from reading the file so the wording is testable on a host
+/// that does not have one — which includes every macOS developer machine.
+pub(crate) fn explain_ptrace_scope(scope: &str) -> Option<&'static str> {
+    match scope {
+        "0" => None,
+        "1" => Some(
+            "the kernel's yama/ptrace_scope is 1, which allows attaching to descendants only; \
+             run as root, grant CAP_SYS_PTRACE, or set it to 0",
+        ),
+        "2" => Some(
+            "the kernel's yama/ptrace_scope is 2, which allows attaching to CAP_SYS_PTRACE \
+             holders only",
+        ),
+        _ => Some("the kernel's yama/ptrace_scope forbids attaching entirely"),
+    }
+}
+
+/// Attaches to one thread, leaving it running.
+///
+/// `SEIZE` rather than `ATTACH`: seizing does not stop the thread as a side
+/// effect, so each later stop is one this code asked for and can undo exactly.
+/// `ATTACH` conflates the two and leaves a thread stopped by a signal that a
+/// resume then has to guess at.
+pub(crate) fn seize(tid: u32) -> io::Result<()> {
+    // SAFETY: a ptrace request with no memory operands. An invalid tid is the
+    // kernel's to reject, which it does with ESRCH.
+    let result = unsafe { libc::ptrace(libc::PTRACE_SEIZE, tid as libc::pid_t, 0, 0) };
+    if result == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Asks a seized thread to stop. Does not wait for it.
+///
+/// Split from the wait deliberately. Once this SUCCEEDS the thread is stopped or
+/// about to be, and from that moment every exit owes it a resume — so the split
+/// is what lets the caller put the resume where nothing can step around it.
+pub(crate) fn interrupt(tid: u32) -> io::Result<()> {
+    // SAFETY: a ptrace request with no memory operands.
+    let result = unsafe { libc::ptrace(libc::PTRACE_INTERRUPT, tid as libc::pid_t, 0, 0) };
+    if result == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Waits until an interrupted thread is actually stopped.
+///
+/// The wait is not optional. `INTERRUPT` only *requests* the stop; reading
+/// registers before the kernel delivered it returns whatever was there — a
+/// plausible-looking address from an arbitrary moment, which is a wrong profile
+/// rather than a missing one.
+///
+/// `EINTR` is retried rather than reported. A profiler runs with signals about
+/// (its own timers, a Ctrl-C on the way) and an interrupted wait says nothing
+/// about the thread; treating it as a failure would abandon a thread that is
+/// stopped and waiting to be read.
+pub(crate) fn wait_for_stop(tid: u32) -> io::Result<libc::c_int> {
+    loop {
+        let mut status: libc::c_int = 0;
+        // SAFETY: `status` is a live local for the duration of the call. __WALL
+        // is required for threads, which are not children in the waitpid sense.
+        let waited = unsafe { libc::waitpid(tid as libc::pid_t, &mut status, libc::__WALL) };
+        if waited != -1 {
+            return Ok(status);
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
+/// The signal a stop was carrying, which the restart has to hand back.
+///
+/// A seized tracee reports EVERY signal to its tracer and stops until the tracer
+/// restarts it. `PTRACE_CONT` and `PTRACE_DETACH` take that signal as their last
+/// argument, and passing zero — which is what this file used to do — does not
+/// mean "no signal was pending", it means "throw the pending one away". A
+/// profiler that samples at 99 Hz holds a lot of stops, so a target being
+/// profiled quietly lost `SIGCHLD`, `SIGTERM`, timer signals: reaped children
+/// that were never reaped, shutdowns that never arrived, attributable to
+/// nothing. Measuring a program must not change what it receives.
+///
+/// Only a genuine signal-delivery-stop is handed back. The stops this file makes
+/// itself carry a `PTRACE_EVENT_*` in the high bits — `PTRACE_INTERRUPT` reports
+/// `SIGTRAP` with `PTRACE_EVENT_STOP`, and a group-stop under `SEIZE` reports the
+/// stopping signal with the same event. Neither was on its way to the program,
+/// and re-injecting either is how a profiler kills what it measures.
+fn pending_signal(status: libc::c_int) -> libc::c_int {
+    if !libc::WIFSTOPPED(status) || (status >> 16) != 0 {
+        return 0;
+    }
+    let signal = libc::WSTOPSIG(status);
+    if signal == libc::SIGTRAP { 0 } else { signal }
+}
+
+/// Lets a stopped thread run again, delivering whatever signal it stopped on.
+///
+/// Called on every path out of a stop, including the failing ones: a thread
+/// left stopped is a program that has silently hung, and an operator who
+/// attached a profiler to a running service has no reason to suspect the
+/// profiler of it.
+pub(crate) fn resume(tid: u32, signal: libc::c_int) {
+    // SAFETY: no memory operands; a failure here means the thread already
+    // exited, which needs no resuming.
+    unsafe {
+        libc::ptrace(libc::PTRACE_CONT, tid as libc::pid_t, 0, libc::c_long::from(signal));
+    }
+}
+
+/// Stops tracing a thread, leaving it running as it was found.
+///
+/// The stop first is not ceremony: `PTRACE_DETACH` requires a STOPPED tracee and
+/// restarts it as it detaches. Asked of a running one it fails with `ESRCH` and
+/// changes nothing — the thread stays traced, invisibly, because nothing here
+/// reads the result.
+///
+/// That is exactly how a live view died after one window. The seizes happen per
+/// window; the second one was refused, because a thread that is already traced
+/// cannot be seized again. An empty window is how `--attach` learns its target
+/// is gone, so the view reported the program had ended while it was still
+/// running — a wrong answer produced by a failure nobody was told about.
+pub(crate) fn detach(tid: u32) {
+    let _ = interrupt(tid);
+    // The last stop is the last chance to hand a pending signal back: after the
+    // detach there is no tracer left to hold it, and it is gone.
+    let signal = wait_for_stop(tid).map_or(0, pending_signal);
+    // SAFETY: no memory operands; ESRCH for a thread that has gone is fine, and
+    // a tracer that exits detaches whatever it still holds.
+    unsafe {
+        libc::ptrace(libc::PTRACE_DETACH, tid as libc::pid_t, 0, libc::c_long::from(signal));
+    }
+}
+
+/// How many 64-bit words the kernel's register file is on this architecture,
+/// and where the two registers a walk needs sit inside it.
+///
+/// Naming the indices rather than the struct keeps this to one shape and one
+/// `iovec`. The layout is ABI — `user_regs_struct` on x86_64, `user_pt_regs` on
+/// aarch64 — not a detail that drifts.
+#[cfg(target_arch = "x86_64")]
+const REGISTER_WORDS: usize = 27;
+/// rbp, at index 4 of `user_regs_struct`.
+#[cfg(target_arch = "x86_64")]
+const FRAME_POINTER_INDEX: usize = 4;
+/// rip, at index 16.
+#[cfg(target_arch = "x86_64")]
+const PROGRAM_COUNTER_INDEX: usize = 16;
+
+/// x0..x30, then sp, pc, pstate.
+#[cfg(target_arch = "aarch64")]
+const REGISTER_WORDS: usize = 34;
+/// x29 is the frame pointer by the AAPCS.
+#[cfg(target_arch = "aarch64")]
+const FRAME_POINTER_INDEX: usize = 29;
+/// pc follows the 31 general registers and sp.
+#[cfg(target_arch = "aarch64")]
+const PROGRAM_COUNTER_INDEX: usize = 32;
+
+/// Reads the two registers a frame walk starts from.
+///
+/// `GETREGSET` rather than the older `GETREGS`, because `GETREGS` does not
+/// exist on aarch64 — the register file is architecture-shaped and only the
+/// regset interface is common to both.
+pub(crate) fn registers(tid: u32) -> io::Result<Registers> {
+    let mut regs = [0u64; REGISTER_WORDS];
+    let mut iov = libc::iovec {
+        iov_base: regs.as_mut_ptr().cast::<libc::c_void>(),
+        iov_len: std::mem::size_of_val(&regs),
+    };
+    // SAFETY: `iov` describes `regs`, which outlives the call; NT_PRSTATUS is
+    // the regset that layout belongs to, and the kernel writes at most
+    // `iov_len` bytes.
+    let result = unsafe {
+        libc::ptrace(
+            libc::PTRACE_GETREGSET,
+            tid as libc::pid_t,
+            libc::NT_PRSTATUS,
+            &mut iov as *mut libc::iovec,
+        )
+    };
+    if result == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(Registers { pc: regs[PROGRAM_COUNTER_INDEX], fp: regs[FRAME_POINTER_INDEX] })
+}
+
+/// Reads a run of bytes out of the target's address space.
+///
+/// `process_vm_readv` rather than word-at-a-time `PEEKDATA`: a frame is two
+/// words, and a `PEEKDATA` pair is two syscalls for the same bytes — which is
+/// the target held stopped twice as long, every frame of every sample.
+pub(crate) fn read_memory(pid: u32, address: u64, into: &mut [u8]) -> io::Result<()> {
+    let local = libc::iovec {
+        iov_base: into.as_mut_ptr().cast::<libc::c_void>(),
+        iov_len: into.len(),
+    };
+    let remote = libc::iovec {
+        iov_base: address as usize as *mut libc::c_void,
+        iov_len: into.len(),
+    };
+    // SAFETY: `local` describes `into`, which outlives the call. `remote` is an
+    // address in ANOTHER process and is never dereferenced here; an unmapped one
+    // comes back as EFAULT rather than faulting this process.
+    let read = unsafe { libc::process_vm_readv(pid as libc::pid_t, &local, 1, &remote, 1, 0) };
+    if read == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    if read as usize != into.len() {
+        return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "short read from the target"));
+    }
+    Ok(())
+}
+
+/// Reads one frame off the chain: the caller's frame pointer, and the address
+/// to return to.
+///
+/// Split from the walk so the walk's stopping rules can be read — and tested —
+/// without a process to read from.
+pub(crate) fn decode_frame(bytes: [u8; 16]) -> (u64, u64) {
+    let next = u64::from_le_bytes(bytes[0..8].try_into().unwrap_or([0; 8]));
+    let return_address = u64::from_le_bytes(bytes[8..16].try_into().unwrap_or([0; 8]));
+    (next, return_address)
+}
+
+/// Whether a frame pointer can be followed at all.
+///
+/// Three ways it cannot: null, unaligned — no ABI here produces one, so it is a
+/// register holding something that is not a pointer — or not climbing, which is
+/// a cycle. Following any of them invents frames, and an invented frame does not
+/// announce itself: it just names the wrong function as the expensive one. A
+/// short true stack beats a long false one.
+pub(crate) fn can_follow(fp: u64, previous: u64) -> bool {
+    fp != 0 && fp % 8 == 0 && fp > previous
+}
+
+/// Walks the frame chain from an interrupted thread, innermost first.
+///
+/// One frame is two words: at `[fp]` the caller's frame pointer and at `[fp+8]`
+/// the address to return to. The walk stops at the first read that fails, at a
+/// pointer `can_follow` rejects, and at `MAX_DEPTH`.
+pub(crate) fn walk(pid: u32, regs: &Registers) -> Vec<u64> {
+    let mut chain = vec![regs.pc];
+    let mut fp = regs.fp;
+    for _ in 0..MAX_DEPTH {
+        if !can_follow(fp, 0) {
+            break;
+        }
+        let mut frame = [0u8; 16];
+        if read_memory(pid, fp, &mut frame).is_err() {
+            break;
+        }
+        let (next, return_address) = decode_frame(frame);
+        if return_address == 0 {
+            break;
+        }
+        chain.push(return_address);
+        if !can_follow(next, fp) {
+            break;
+        }
+        fp = next;
+    }
+    chain
+}
+
+/// Stops one thread, reads its stack, and lets it go again.
+///
+/// The resume is unconditional past the interrupt, which is the point of the
+/// wrapper: every failure between the stop and the read still has to give the
+/// thread back. It was not always so: the interrupt and the wait were one call,
+/// so a wait that failed returned before any resume and left the thread stopped
+/// until the window ended and the detach released it. A single `EINTR` was
+/// enough, and the symptom would have been a program that stalls for as long as
+/// it is being profiled — which reads as the profiler being slow, not as the
+/// profiler having stopped it.
+pub(crate) fn sample_thread(pid: u32, tid: u32) -> Option<Vec<u64>> {
+    // Below this line the thread is stopped, or on its way to being; above it,
+    // nothing has happened to it.
+    if interrupt(tid).is_err() {
+        return None;
+    }
+    let stopped = wait_for_stop(tid);
+    let signal = stopped.as_ref().map_or(0, |status| pending_signal(*status));
+    // The walk happens HERE, between the stop and the resume, because it READS
+    // THE TARGET'S MEMORY: up to `MAX_DEPTH` frames, a `PEEKDATA` pair each. The
+    // registers are one instant; resuming before the walk made every frame after
+    // them a different one. `can_follow` rejects the gross tears, not the
+    // plausible ones — a stale record sitting above a stack that shrank between
+    // two reads is aligned and still climbing, so it passes both tests and puts
+    // a function on the stack that was not on it. That is the one failure a
+    // profiler cannot afford, because nothing downstream can tell an invented
+    // frame from a real one.
+    let walked = stopped.and_then(|_| registers(tid)).map(|regs| walk(pid, &regs));
+    resume(tid, signal);
+    walked.ok()
+}
+
+/// How often a thread is stopped and read, per second.
+///
+/// Deliberately not a round one: a program doing something on a 100 Hz timer,
+/// sampled at 100 Hz, is caught in the same place every time and reports one
+/// function as the whole profile. 99 is coprime with 100 — and with 50, 20 and
+/// 10 — so the sampler and the program cannot march in step.
+///
+/// It is also a budget. Every sample stops every thread, so the rate is what
+/// the profiled program pays; this is the rate `py-spy` and `perf` default to
+/// for the same reason.
+const SAMPLE_HZ: u64 = 99;
+
+/// Attaches to every thread of every process given, samples them for a window,
+/// and detaches — returning the folded display stacks the rest of `monitor`
+/// renders.
+///
+/// A tree, not one process, because `--attach` is documented to measure a
+/// prefork server across all its workers and the macOS path does. The threads
+/// of every process are read on every tick so each contributes samples in
+/// proportion to the time it actually spent running.
+///
+/// The seizes happen once for the window rather than per sample: seizing is the
+/// expensive half and the threads keep running between samples either way.
+/// Threads and workers that appear mid-window are missed until the next one,
+/// which is the price of not re-reading `/proc` at 99 Hz.
+///
+/// Failure DURING a window is silence, not an error. A thread that exits
+/// mid-window, a stack that cannot be walked, a program that ends early — none
+/// of them are worth refusing a window over, because the samples that DID land
+/// are still true, and the caller learns the target is gone the way it always
+/// has: an empty window.
+///
+/// A REFUSAL is an error, and that distinction is the whole reason this returns
+/// a `Result`. The kernel saying no is not a quiet window: the operator has
+/// something to fix, and both used to arrive as the same empty vector, so the
+/// commonest refusal there is — `yama/ptrace_scope=1`, the default — was
+/// reported as "the program may have exited" about a program still running.
+///
+/// Seizing NOTHING is not by itself a refusal, and reading it as one is the
+/// mistake the first version of this made in the other direction: a live view
+/// over a program that ends closed on "cannot attach to the target", because a
+/// reaped process has an empty `/proc/<pid>/task` and a zombie has no `maps`.
+/// `window_refusal` is what separates the two.
+pub(crate) fn attach_window(
+    pids: &[u32],
+    duration_secs: u32,
+    image: &super::attach::Image,
+) -> Result<Vec<(Vec<(String, super::Kind)>, u64)>, String> {
+    // Each process brings its own bias and its own threads; they share the
+    // symbol table, because a prefork server's workers are forks of one image.
+    // A process whose bias cannot be read is dropped rather than resolved
+    // against a neighbour's, which would not fail — it would name the wrong
+    // functions, and a table that is confidently wrong is worse than a short one.
+    let mut targets: Vec<(u32, u64, Vec<u32>)> = Vec::new();
+    // Kept, because a seize that FAILED is the thing the caller most needs told
+    // apart from a window that sampled nothing, and the two used to arrive as
+    // the same empty vector.
+    let mut refusal: Option<io::Error> = None;
+    for pid in pids {
+        let Some(bias) = super::attach::bias_of(image, *pid) else { continue };
+        let mut seized = Vec::new();
+        for tid in thread_ids(*pid) {
+            match seize(tid) {
+                Ok(()) => seized.push(tid),
+                // An `EPERM` outranks whatever else is held: a thread that
+                // exited between the `/proc` read and the seize is ordinary and
+                // says nothing, a refusal is the whole diagnosis.
+                Err(error) => {
+                    let held_is_refusal = matches!(
+                        &refusal,
+                        Some(held) if held.kind() == io::ErrorKind::PermissionDenied
+                    );
+                    if !held_is_refusal {
+                        refusal = Some(error);
+                    }
+                }
+            }
+        }
+        if !seized.is_empty() {
+            targets.push((*pid, bias, seized));
+        }
+    }
+    if targets.is_empty() {
+        return match window_refusal(refusal) {
+            Some(reason) => Err(reason),
+            // Nothing was REFUSED — the target simply is not there any more, and
+            // that is an empty window, which is how attach has always learnt its
+            // target has gone.
+            None => Ok(Vec::new()),
+        };
+    }
+    let interval = std::time::Duration::from_nanos(1_000_000_000 / SAMPLE_HZ);
+    let deadline =
+        std::time::Instant::now() + std::time::Duration::from_secs(u64::from(duration_secs.max(1)));
+    let mut stacks = Vec::new();
+    while std::time::Instant::now() < deadline {
+        let started = std::time::Instant::now();
+        // Every process every tick, rather than one process for the whole
+        // window each: a worker sampled for a third of the window contributes a
+        // third of the samples, and its share of the table would be a third of
+        // the truth.
+        for (pid, bias, seized) in &targets {
+            for tid in seized {
+                let Some(chain) = sample_thread(*pid, *tid) else { continue };
+                let stack = super::attach::display_stack(&chain, &image.symbols, *bias);
+                if !stack.is_empty() {
+                    stacks.push(stack);
+                }
+            }
+        }
+        // Sleep the remainder of the interval, not the whole of it: the samples
+        // themselves take time, and sleeping a full interval on top of them
+        // would drift the rate below the one documented above.
+        if let Some(rest) = interval.checked_sub(started.elapsed()) {
+            std::thread::sleep(rest);
+        }
+    }
+    for (_, _, seized) in &targets {
+        for tid in seized {
+            detach(*tid);
+        }
+    }
+    Ok(super::attach::fold(stacks))
+}
+
+/// Whether nothing-seized is a refusal worth reporting, and what to say.
+///
+/// `None` means it is not: the target is gone. That distinction is finer than
+/// the first version of this made it, which returned an error whenever nothing
+/// was seized and so turned every ordinary ending into "cannot attach to the
+/// target: it has no threads this tool can read" — a live view over a program
+/// that exits closed on a refusal that never happened. Reaching this with
+/// nothing held happens on the ordinary path: `thread_ids` finds an empty
+/// `/proc/<pid>/task` for a process already reaped, and `bias_of` finds no
+/// `maps` for a zombie, and neither of those is the kernel saying no.
+///
+/// `ESRCH` is the same answer arriving from the seize itself — the thread went
+/// between the `/proc` read and the syscall — so it is a gone target too. What
+/// is left is `EPERM` and the unexpected, and those the operator wants said.
+fn window_refusal(error: Option<io::Error>) -> Option<String> {
+    match error {
+        None => None,
+        Some(error) if error.raw_os_error() == Some(libc::ESRCH) => None,
+        Some(error) => Some(seize_refusal(Some(error))),
+    }
+}
+
+/// Says why nothing could be seized, in the operator's terms.
+///
+/// The default on most distributions is `yama/ptrace_scope=1`, which allows
+/// attaching to descendants only — and `--attach` is handed a pid it did not
+/// launch, so that is exactly the common case. Everything BEFORE the seize
+/// succeeds under it: `/proc/<pid>/maps` and the executable are readable, so the
+/// image is built and the symbols are loaded, and only then does every
+/// `PTRACE_SEIZE` come back `EPERM`.
+///
+/// That refusal used to leave through the same door as an empty window, and the
+/// empty window is how attach learns its target is gone — so the operator was
+/// told "the program may have exited" about a program still running, and the
+/// hint naming the one setting they had to change was never printed, because it
+/// was only ever appended to an image error that had not occurred.
+fn seize_refusal(error: Option<io::Error>) -> String {
+    match error {
+        Some(error) if error.kind() == io::ErrorKind::PermissionDenied => match attach_refusal_hint()
+        {
+            Some(hint) => format!("cannot attach to the target: {hint}"),
+            // No yama file to read, so the refusal came from somewhere else —
+            // a container without `CAP_SYS_PTRACE`, LSM policy, a setuid target.
+            None => "cannot attach to the target: the kernel refused to trace it. Run as root, \
+                     grant CAP_SYS_PTRACE, or start the program under `elephc monitor` instead"
+                .to_string(),
+        },
+        Some(error) => format!("cannot attach to the target: {error}"),
+        None => "cannot attach to the target: it has no threads this tool can read".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds the `waitpid` status word for a stopped tracee, the way the kernel
+    /// encodes one: the signal in the second byte, `0x7f` in the first, and a
+    /// `PTRACE_EVENT_*` — if the stop is one this tracer asked for — above them.
+    fn stopped(signal: libc::c_int, event: libc::c_int) -> libc::c_int {
+        ((signal | (event << 8)) << 8) | 0x7f
+    }
+
+    /// The stop `PTRACE_INTERRUPT` produces is `SIGTRAP` with `PTRACE_EVENT_STOP`
+    /// over it, and every sample makes one. Handing that `SIGTRAP` back is not a
+    /// harmless mistake: an untraced `SIGTRAP` terminates the process, so a
+    /// profiler that re-injected it would kill its target on the first tick.
+    #[test]
+    fn the_stop_the_sampler_asked_for_is_not_a_signal_to_deliver() {
+        assert_eq!(pending_signal(stopped(libc::SIGTRAP, 128)), 0);
+    }
+
+    /// A group-stop under `SEIZE` reports the stopping signal with the same
+    /// event, so the signal in the status is not evidence on its own — the event
+    /// bits are what separate a stop this tracer caused from one the program was
+    /// about to receive.
+    #[test]
+    fn a_group_stop_is_not_a_signal_to_deliver_either() {
+        assert_eq!(pending_signal(stopped(libc::SIGSTOP, 128)), 0);
+    }
+
+    /// The case the zero used to swallow. A seized tracee stops on EVERY signal
+    /// and the tracer decides whether it arrives; passing zero to `PTRACE_CONT`
+    /// throws it away, so a program being profiled lost the children it meant to
+    /// reap and the shutdown it was asked for, with nothing to attribute it to.
+    #[test]
+    fn a_signal_the_program_was_about_to_receive_is_handed_back() {
+        assert_eq!(pending_signal(stopped(libc::SIGCHLD, 0)), libc::SIGCHLD);
+        assert_eq!(pending_signal(stopped(libc::SIGTERM, 0)), libc::SIGTERM);
+    }
+
+    /// A thread that exited between the interrupt and the wait reports an exit,
+    /// not a stop, and there is nothing to deliver to it.
+    #[test]
+    fn an_exit_carries_no_signal() {
+        assert_eq!(pending_signal(0), 0);
+        assert_eq!(pending_signal(1 << 8), 0);
+    }
+
+    /// The wording was split out from reading `/proc` precisely so it could be
+    /// tested, and then was not. Each setting has to name itself and say what to
+    /// do, because a bare `EPERM` reads as a bug in this tool rather than as one
+    /// line of configuration.
+    #[test]
+    fn each_ptrace_scope_names_itself_and_what_to_do() {
+        assert_eq!(
+            explain_ptrace_scope("0"),
+            None,
+            "an unrestricted kernel has nothing to explain, and saying something would send \
+             an operator to change a setting that is already right"
+        );
+        let one = explain_ptrace_scope("1").expect("the default setting must be explained");
+        assert!(one.contains("ptrace_scope is 1"), "{one}");
+        assert!(one.contains("descendants only"), "{one}");
+        assert!(one.contains("CAP_SYS_PTRACE"), "{one}");
+        let two = explain_ptrace_scope("2").expect("the strict setting must be explained");
+        assert!(two.contains("ptrace_scope is 2"), "{two}");
+        assert!(two.contains("CAP_SYS_PTRACE"), "{two}");
+        // 3 is "no attaching, ever, until reboot", and any future value this
+        // tool has not heard of must still produce a refusal rather than silence.
+        assert!(explain_ptrace_scope("3").is_some());
+        assert!(explain_ptrace_scope("").is_some());
+    }
+
+    /// The message an operator gets when NOTHING could be seized. It has to tell
+    /// a refusal apart from a target that went away, because attach reads an
+    /// empty window as proof the program has ended — and reporting a refusal
+    /// that way is how `yama/ptrace_scope=1`, the default nearly everywhere,
+    /// came out as "the program may have exited" about a running program.
+    #[test]
+    fn a_refusal_reads_differently_from_a_target_that_went_away() {
+        let refused = seize_refusal(Some(io::Error::from_raw_os_error(libc::EPERM)));
+        assert!(refused.contains("cannot attach"), "{refused}");
+        assert!(
+            refused.contains("CAP_SYS_PTRACE") || refused.contains("ptrace_scope"),
+            "a refusal must name something the operator can change: {refused}"
+        );
+
+        let gone = seize_refusal(Some(io::Error::from_raw_os_error(libc::ESRCH)));
+        assert!(
+            !gone.contains("CAP_SYS_PTRACE") && !gone.contains("ptrace_scope"),
+            "a thread that exited is not a permission problem: {gone}"
+        );
+
+        let nothing = seize_refusal(None);
+        assert!(nothing.contains("no threads"), "{nothing}");
+    }
+
+    /// Seizing nothing is not by itself a refusal.
+    ///
+    /// The first version of this returned an error whenever `targets` came back
+    /// empty, which reads every ordinary ending as the kernel saying no: a
+    /// reaped process has an empty `/proc/<pid>/task` and a zombie has no
+    /// `maps`, so a live view over a program that exits closed on "cannot
+    /// attach to the target" instead of on the empty window it has always used.
+    /// `ESRCH` from the seize itself is the same target, gone between the
+    /// `/proc` read and the syscall.
+    #[test]
+    fn a_target_that_went_away_is_an_empty_window_not_a_refusal() {
+        assert!(window_refusal(None).is_none(), "nothing held is a gone target");
+        assert!(
+            window_refusal(Some(io::Error::from_raw_os_error(libc::ESRCH))).is_none(),
+            "a thread that exited between the /proc read and the seize is a gone target"
+        );
+
+        let refused = window_refusal(Some(io::Error::from_raw_os_error(libc::EPERM)))
+            .expect("the kernel saying no is worth reporting");
+        assert!(refused.contains("cannot attach"), "{refused}");
+
+        // Neither gone nor a permission problem: unexpected, and the operator
+        // still wants it said rather than shown an empty table.
+        assert!(
+            window_refusal(Some(io::Error::from_raw_os_error(libc::EIO))).is_some(),
+            "an unexpected failure must not be reported as a target that ended"
+        );
+    }
+
+    /// A target that cannot be seized is an ERROR, not an empty window.
+    ///
+    /// This pins the regression itself rather than its wording. Attach reads an
+    /// empty window as proof the target has gone, so a refusal and a quiet
+    /// window must not share a value — they did, and that is how
+    /// `yama/ptrace_scope=1` came out as "the program may have exited".
+    ///
+    /// Driven against a REAL refused seize, deterministically and without any
+    /// capability, by pointing the sampler at THIS process. A task cannot trace
+    /// its own thread group, so everything BEFORE the seize succeeds — the image
+    /// is ours, `/proc/self/maps` is ours, so `bias_of` returns a bias and the
+    /// loop reaches the seize — and only then is every `PTRACE_SEIZE` refused.
+    /// That is the same shape scope 1 produces for a process this tool did not
+    /// launch, which is the case no container flag can stage: `--cap-add=
+    /// SYS_PTRACE` grants exactly what stops it happening.
+    #[test]
+    fn a_target_that_cannot_be_seized_is_an_error_not_an_empty_window() {
+        let me = std::process::id();
+        let Ok(image) = super::super::attach::image_for(me) else {
+            // A host whose own `/proc` this cannot read says nothing about the
+            // branch under test, and failing here would report the wrong thing.
+            return;
+        };
+        match attach_window(&[me], 1, &image) {
+            Err(reason) => assert!(
+                reason.starts_with("cannot attach to the target"),
+                "a refusal has to say it could not attach: {reason}"
+            ),
+            Ok(window) => panic!(
+                "a refused seize came back as a window of {} stacks, which every caller reads \
+                 as a target that has exited",
+                window.len()
+            ),
+        }
+    }
+}

--- a/src/monitor/ptrace.rs
+++ b/src/monitor/ptrace.rs
@@ -156,6 +156,31 @@ pub(crate) fn wait_for_stop(tid: u32) -> io::Result<libc::c_int> {
     }
 }
 
+/// Consumes an already pending stop before asking the kernel for another one.
+/// A signal-delivery stop may arrive between sampling ticks. Interrupting that
+/// stop again can keep producing event stops while the tracee makes no progress.
+/// Checking first also handles an interrupt event left pending behind a signal.
+fn stop_for_sample(tid: u32) -> io::Result<libc::c_int> {
+    loop {
+        let mut status = 0;
+        // SAFETY: status is writable and waitpid targets only this seized tid.
+        let waited = unsafe {
+            libc::waitpid(tid as libc::pid_t, &mut status, libc::__WALL | libc::WNOHANG)
+        };
+        if waited > 0 {
+            return Ok(status);
+        }
+        if waited == 0 {
+            interrupt(tid)?;
+            return wait_for_stop(tid);
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
 /// The signal a stop was carrying, which the restart has to hand back.
 ///
 /// A seized tracee reports EVERY signal to its tracer and stops until the tracer
@@ -176,8 +201,7 @@ fn pending_signal(status: libc::c_int) -> libc::c_int {
     if !libc::WIFSTOPPED(status) || (status >> 16) != 0 {
         return 0;
     }
-    let signal = libc::WSTOPSIG(status);
-    if signal == libc::SIGTRAP { 0 } else { signal }
+    libc::WSTOPSIG(status)
 }
 
 /// Lets a stopped thread run again, delivering whatever signal it stopped on.
@@ -207,10 +231,9 @@ pub(crate) fn resume(tid: u32, signal: libc::c_int) {
 /// is gone, so the view reported the program had ended while it was still
 /// running — a wrong answer produced by a failure nobody was told about.
 pub(crate) fn detach(tid: u32) {
-    let _ = interrupt(tid);
     // The last stop is the last chance to hand a pending signal back: after the
     // detach there is no tracer left to hold it, and it is gone.
-    let signal = wait_for_stop(tid).map_or(0, pending_signal);
+    let signal = stop_for_sample(tid).map_or(0, pending_signal);
     // SAFETY: no memory operands; ESRCH for a thread that has gone is fine, and
     // a tracer that exits detaches whatever it still holds.
     unsafe {
@@ -362,10 +385,7 @@ pub(crate) fn walk(pid: u32, regs: &Registers) -> Vec<u64> {
 pub(crate) fn sample_thread(pid: u32, tid: u32) -> Option<Vec<u64>> {
     // Below this line the thread is stopped, or on its way to being; above it,
     // nothing has happened to it.
-    if interrupt(tid).is_err() {
-        return None;
-    }
-    let stopped = wait_for_stop(tid);
+    let stopped = stop_for_sample(tid);
     let signal = stopped.as_ref().map_or(0, |status| pending_signal(*status));
     // The walk happens HERE, between the stop and the resume, because it READS
     // THE TARGET'S MEMORY: up to `MAX_DEPTH` frames, a `PEEKDATA` pair each. The
@@ -595,6 +615,7 @@ mod tests {
     fn a_signal_the_program_was_about_to_receive_is_handed_back() {
         assert_eq!(pending_signal(stopped(libc::SIGCHLD, 0)), libc::SIGCHLD);
         assert_eq!(pending_signal(stopped(libc::SIGTERM, 0)), libc::SIGTERM);
+        assert_eq!(pending_signal(stopped(libc::SIGTRAP, 0)), libc::SIGTRAP);
     }
 
     /// A thread that exited between the interrupt and the wait reports an exit,
@@ -719,3 +740,7 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "ptrace_process_tests.rs"]
+mod process_tests;

--- a/src/monitor/ptrace_process_tests.rs
+++ b/src/monitor/ptrace_process_tests.rs
@@ -1,0 +1,128 @@
+//! Purpose:
+//! Linux process regressions for sampling across pending signal-delivery stops.
+//!
+//! Called from:
+//! - `monitor::ptrace` through the Rust test harness.
+//!
+//! Key details:
+//! - Uses a real CPU-bound C tracee; requires cc and permission to trace a child.
+//! - Every fixture detaches, kills and reaps its child even after an assertion fails.
+
+use super::*;
+use std::io::Read;
+use std::os::fd::AsRawFd;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+struct Tracee {
+    child: Child,
+    directory: std::path::PathBuf,
+    seized: bool,
+}
+
+impl Tracee {
+    /// Builds and starts a traceable process, waiting for its handlers to be ready.
+    fn start() -> Self {
+        static NEXT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let id = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let directory = std::env::temp_dir().join(format!("elephc-signal-{}-{id}", std::process::id()));
+        std::fs::create_dir(&directory).unwrap();
+        let source = directory.join("tracee.c");
+        let binary = directory.join("tracee");
+        std::fs::write(&source, include_str!("../../tests/fixtures/monitor/signals.c")).unwrap();
+        let compiled = Command::new("cc").args(["-O0", "-fno-omit-frame-pointer"])
+            .arg(&source).arg("-o").arg(&binary).output().unwrap();
+        assert!(compiled.status.success(), "{}", String::from_utf8_lossy(&compiled.stderr));
+        let child = Command::new(binary).stdout(Stdio::piped()).spawn().unwrap();
+        let mut tracee = Self { child, directory, seized: false };
+        let fd = tracee.child.stdout.as_ref().unwrap().as_raw_fd();
+        // SAFETY: this only changes nonblocking mode on our live pipe reader.
+        assert_ne!(unsafe { libc::fcntl(fd, libc::F_SETFL, libc::O_NONBLOCK) }, -1);
+        assert_eq!(tracee.read_marker(), b'R');
+        tracee
+    }
+
+    /// Waits at most two seconds for one async-signal-safe handler notification.
+    fn read_marker(&mut self) -> u8 {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let mut marker = [0];
+            match self.child.stdout.as_mut().unwrap().read(&mut marker) {
+                Ok(1) => return marker[0],
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
+                other => panic!("tracee pipe: {other:?}"),
+            }
+            assert!(Instant::now() < deadline, "tracee did not deliver the signal");
+            std::thread::sleep(Duration::from_millis(1));
+        }
+    }
+
+    /// Sends one handled signal and waits for its delivery stop to become pending.
+    fn signal_stop(&self, signal: libc::c_int) {
+        // SAFETY: the target is our live fixture with handlers installed.
+        assert_eq!(unsafe { libc::kill(self.child.id() as libc::pid_t, signal) }, 0);
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while self.progress().0 != 't' {
+            assert!(Instant::now() < deadline, "signal-delivery stop never arrived");
+            std::thread::sleep(Duration::from_millis(1));
+        }
+    }
+
+    /// Reads task state and CPU ticks without stopping the process being measured.
+    fn progress(&self) -> (char, u64) {
+        let stat = std::fs::read_to_string(format!("/proc/{}/stat", self.child.id())).unwrap();
+        let fields: Vec<_> = stat.rsplit_once(')').unwrap().1.split_whitespace().collect();
+        let ticks = fields[11].parse::<u64>().unwrap() + fields[12].parse::<u64>().unwrap();
+        (fields[0].chars().next().unwrap(), ticks)
+    }
+}
+
+impl Drop for Tracee {
+    /// Releases the trace relationship and reaps the fixture on every exit path.
+    fn drop(&mut self) {
+        if self.seized {
+            detach(self.child.id());
+        }
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = std::fs::remove_dir_all(&self.directory);
+    }
+}
+
+/// Delivers a signal between ticks and verifies CPU progress before detachment.
+fn sampling_preserves_signal_and_progress(signal: libc::c_int, marker: u8) {
+    let mut tracee = Tracee::start();
+    let pid = tracee.child.id();
+    seize(pid).expect("kernel must allow tracing the child for this regression");
+    tracee.seized = true;
+    assert!(sample_thread(pid, pid).is_some());
+    tracee.signal_stop(signal);
+    let before = tracee.progress().1;
+    // Keep tracing throughout. A resume deferred until detach cannot pass this.
+    for _ in 0..40 {
+        assert!(sample_thread(pid, pid).is_some());
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let after = tracee.progress().1;
+    assert!(after > before + 1, "target stopped making progress: {before} -> {after}");
+    assert_eq!(tracee.read_marker(), marker);
+    // Detach must consume a pending delivery stop without manufacturing a new one.
+    tracee.signal_stop(signal);
+    detach(pid);
+    tracee.seized = false;
+    assert_eq!(tracee.read_marker(), marker, "detach must deliver the pending signal");
+    assert_eq!(unsafe { libc::kill(pid as libc::pid_t, signal) }, 0);
+    assert_eq!(tracee.read_marker(), marker, "handlers must also work after detach");
+}
+
+/// A pending handled SIGUSR1 cannot stall a process for the capture window.
+#[test]
+fn handled_signal_keeps_running_during_capture() {
+    sampling_preserves_signal_and_progress(libc::SIGUSR1, b'U');
+}
+
+/// Genuine SIGTRAP delivery reaches its handler while sampler traps stay synthetic.
+#[test]
+fn genuine_sigtrap_reaches_handler_during_capture() {
+    sampling_preserves_signal_and_progress(libc::SIGTRAP, b'T');
+}

--- a/src/monitor/sampled.rs
+++ b/src/monitor/sampled.rs
@@ -1,15 +1,19 @@
 //! Purpose:
-//! The sampled path: `--live` and `--attach`, which read a process from the
-//! outside through `/usr/bin/sample`, and the folded-stack parsing shared with
-//! the endpoint's sampled answer.
+//! The macOS sampled path: `--attach` reading a process from the outside through
+//! `/usr/bin/sample`, and the folded-stack parsing shared with the endpoint's
+//! sampled answer.
 //!
 //! Called from:
-//! - `monitor::main` for `--live`/`--attach`.
+//! - `monitor::main` for `--attach` on macOS. NOT for `--live`, which launches
+//!   its target and asks it over a socketpair instead.
 //! - `remote::run`, to parse what a service's ring returned.
 //!
 //! Key details:
-//! - macOS-only, because no equivalent external sampler ships on Linux; the
-//!   Linux answer is the endpoint.
+//! - macOS-only, because no equivalent external sampler ships on Linux. That is
+//!   no longer the whole story for the modes that used it: `--live` asks the
+//!   child it launched, and Linux `--attach` reads the process itself through
+//!   `ptrace`. This file is what remains of reading one from the outside on
+//!   macOS.
 //! - Sampled shares sharpen as samples accumulate and carry real noise; time
 //!   spent blocked on I/O is not attributed on the CPU-time timer.
 

--- a/src/monitor/tests.rs
+++ b/src/monitor/tests.rs
@@ -105,24 +105,131 @@
         };
         assert_eq!(sent, super::CONTROL_ACK.len() as isize);
         assert!(super::control_channel_activated(&channel));
+        // Asked twice on purpose. The probe peeks, so the second question gets
+        // the same answer as the first; when it consumed, the ACK it reported
+        // was the ACK it had just destroyed, and nobody downstream could see it.
+        assert!(
+            super::control_channel_activated(&channel),
+            "asking must not spend the answer"
+        );
+    }
+
+    /// The activation probe must not eat what it was not looking for.
+    ///
+    /// It shares one stream with `request_snapshot`. While it consumed, a window
+    /// that opened with a reply already queued — a child that answered the
+    /// previous request after that read had given up — had that reply taken by
+    /// the question, and the next length parsed came out of the middle of a
+    /// message. That reads as `Gone`, which ends the live view and reaps a
+    /// program that was replying perfectly well.
+    ///
+    /// The reply here is deliberately LONGER than the twenty bytes the probe
+    /// asks for. The consuming version used `MSG_WAITALL`, which `MSG_DONTWAIT`
+    /// does not override on macOS: given less than twenty bytes it waits for the
+    /// rest, so a shorter reply makes this test HANG instead of fail, and a test
+    /// that hangs reports nothing. At this length the bug returns immediately,
+    /// twenty bytes poorer, and the read-back below says so.
+    #[test]
+    fn asking_whether_the_child_activated_does_not_consume_its_answer() {
+        let channel = super::open_control_channel().expect("control socketpair");
+
+        let payload = b"main 5;__rt_hash_set 3;fn_spin 1";
+        let header = (payload.len() as u32).to_le_bytes();
+        for chunk in [&header[..], &payload[..]] {
+            let sent = unsafe {
+                libc::send(channel.child, chunk.as_ptr() as *const libc::c_void, chunk.len(), 0)
+            };
+            assert_eq!(sent, chunk.len() as isize);
+        }
+
+        assert!(
+            !super::control_channel_activated(&channel),
+            "a snapshot reply is not an activation ACK"
+        );
+
+        let mut back = vec![0u8; header.len() + payload.len()];
+        let read = unsafe {
+            libc::recv(
+                channel.parent,
+                back.as_mut_ptr() as *mut libc::c_void,
+                back.len(),
+                libc::MSG_DONTWAIT,
+            )
+        };
+        assert_eq!(read, back.len() as isize, "the reply was consumed by the question");
+        assert_eq!(&back[..4], &header[..], "its length word must be intact");
+        assert_eq!(&back[4..], &payload[..], "and so must its body");
+    }
+
+    /// A snapshot read must survive an activation ACK that arrives late.
+    ///
+    /// `await_activation` has a deadline. A child that boots slower than it sends
+    /// its ACK into the snapshot read instead, and the reply is length-prefixed:
+    /// the ACK's first four bytes are `ELEP`, which decodes as a 1.3 GB length,
+    /// which the size bound refuses. That answer used to be `Gone`, and `Gone`
+    /// ends a live view on a program that is running perfectly well.
+    ///
+    /// Staged the way the race actually happens — nothing waiting for the ACK
+    /// first, both messages already in the buffer when the read begins — because
+    /// the point is that the reader copes on its own, not that some earlier step
+    /// drained it.
+    #[test]
+    fn a_late_activation_ack_does_not_end_the_snapshot_read() {
+        let channel = super::open_control_channel().expect("control socketpair");
+
+        // The child answers the request, but its ACK is still queued in front.
+        let ack = unsafe {
+            libc::send(
+                channel.child,
+                super::CONTROL_ACK.as_ptr() as *const libc::c_void,
+                super::CONTROL_ACK.len(),
+                0,
+            )
+        };
+        assert_eq!(ack, super::CONTROL_ACK.len() as isize);
+
+        let payload = b"main 5";
+        let header = (payload.len() as u32).to_le_bytes();
+        for chunk in [&header[..], &payload[..]] {
+            let sent = unsafe {
+                libc::send(channel.child, chunk.as_ptr() as *const libc::c_void, chunk.len(), 0)
+            };
+            assert_eq!(sent, chunk.len() as isize);
+        }
+
+        match super::request_snapshot(&channel) {
+            super::Snapshot::Answered(text) => assert_eq!(text, "main 5"),
+            super::Snapshot::Late { .. } => {
+                panic!("a queued ACK must not read as a slow target")
+            }
+            super::Snapshot::Gone => {
+                panic!("a queued ACK must not read as a dead channel — this is the bug")
+            }
+        }
     }
 
     use super::*;
 
-    /// The refusal of an unequipped target must not sit behind a platform
-    /// branch.
+    /// The refusal of an unequipped target must not depend on the platform.
     ///
-    /// It did, once: `require_monitoring` was called after the
+    /// It did, once: `require_monitoring` was called after a
     /// `cfg!(target_os = "macos")` block, so the same binary that was refused on
     /// a laptop was run and quietly under-reported on a Linux server — an
     /// environment-dependent behaviour in the one command whose whole purpose is
     /// not to have any.
     ///
-    /// Nothing that runs can catch this. CI is macOS-only, so a Linux-only
-    /// ordering bug is invisible to every test that executes the binary, and the
-    /// two branches cannot both be taken in one process. What is left is the
-    /// order of the source itself, so that is what this reads — the file as an
-    /// interface, because here it is the only witness.
+    /// Nothing that runs can catch this. A Linux-only ordering bug is invisible
+    /// to every test that executes the binary on macOS, and the two branches
+    /// cannot both be taken in one process. What is left is the order of the
+    /// source itself, so that is what this reads — the file as an interface,
+    /// because here it is the only witness.
+    ///
+    /// The dispatch has no runtime platform branch left: `--attach` was the last
+    /// one, and it is no longer refused off macOS. So the ordering rule is
+    /// vacuous TODAY and the test says so rather than pretending to check it —
+    /// but it stays armed, because the way this broke the first time was
+    /// somebody adding a branch above the gate, and that is precisely the edit
+    /// this still catches.
     #[test]
     fn the_capability_gate_runs_before_any_platform_branch() {
         // `mod.rs`, because that is where `run` lives now: a guard that reads a
@@ -137,14 +244,16 @@
         let gate = body
             .find("require_monitoring(")
             .expect("the dispatch must refuse an unequipped target");
-        let platform = body
-            .find("cfg!(target_os = \"macos\")")
-            .expect("the dispatch must still have its one platform branch");
-        assert!(
-            gate < platform,
-            "the capability check is inside or after the platform branch, so it \
-             would be enforced on macOS and skipped on Linux"
-        );
+        // A compile-time `#[cfg]` picks which code EXISTS and cannot put one
+        // platform's behaviour behind another's branch; only a runtime `cfg!`
+        // inside this one body can, which is why that is what is looked for.
+        if let Some(platform) = body.find("cfg!(target_os") {
+            assert!(
+                gate < platform,
+                "the capability check is inside or after a platform branch, so it \
+                 would be enforced on one platform and skipped on another"
+            );
+        }
     }
 
     /// The exact capture's Speedscope/pprof export must account for the run
@@ -1447,4 +1556,211 @@ echo call_hot(1);
     fn recommends_the_hotspot() {
         let out = instrument_recommendations(&instr_graph());
         assert!(out.contains("leaf is the hotspot"), "{out}");
+    }
+
+    /// A `Late` that took the ACK on its way past says so.
+    ///
+    /// The ACK is sent ONCE. If a read consumes it and then gives up on the
+    /// reply behind it, the caller's `activated` flag is still false over a
+    /// message that no longer exists — so every later window opens by spending
+    /// the whole activation deadline waiting for it again. The read is the only
+    /// thing that knows, so the answer has to carry it.
+    ///
+    /// Staged against a real socketpair with a real deadline: only the ACK is
+    /// sent, and nothing follows it.
+    #[test]
+    fn a_late_answer_reports_the_ack_it_consumed_on_the_way() {
+        let channel = super::open_polled_control_channel().expect("a socketpair");
+        let sent = unsafe {
+            libc::send(
+                channel.child,
+                super::CONTROL_ACK.as_ptr() as *const libc::c_void,
+                super::CONTROL_ACK.len(),
+                0,
+            )
+        };
+        assert_eq!(sent, super::CONTROL_ACK.len() as isize);
+
+        match super::request_snapshot(&channel) {
+            super::Snapshot::Late { activation_seen } => assert!(
+                activation_seen,
+                "the ACK was consumed by this read and nobody will send another"
+            ),
+            super::Snapshot::Answered(text) => {
+                panic!("nothing was sent after the ACK, so there was nothing to answer: {text:?}")
+            }
+            super::Snapshot::Gone => panic!("a lone ACK is not a dead channel"),
+        }
+    }
+
+    /// A window nobody answered in time does not end the view.
+    ///
+    /// The live loop ending is what REAPS the target: the program only outlives
+    /// the view while the view is still running. So a slow answer treated as a
+    /// dead one does not merely lose a window — it stops the healthy program the
+    /// operator was in the middle of profiling.
+    ///
+    /// Driven against a real socketpair with a real receive deadline and nobody
+    /// on the other end, because the distinction being tested is what the KERNEL
+    /// reports, not what this code believes it will.
+    #[test]
+    fn a_window_that_times_out_is_not_a_dead_child() {
+        let channel = super::open_polled_control_channel().expect("a socketpair");
+        // Nothing answers, so the deadline is what ends the read. The marker the
+        // parent wrote is on the child's side and is not read back here.
+        let started = std::time::Instant::now();
+        let outcome = super::request_snapshot(&channel);
+        assert!(
+            matches!(outcome, super::Snapshot::Late { activation_seen: false }),
+            "a target that has not answered YET must not be reported as gone, and nothing \
+             here sent an ACK for the read to have taken"
+        );
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(30),
+            "the read waited far past its own deadline"
+        );
+
+        // And a closed peer is the other answer, from the same call.
+        unsafe { libc::close(channel.child) };
+        let mut closed = channel;
+        closed.forget_child();
+        assert!(
+            matches!(super::request_snapshot(&closed), super::Snapshot::Gone),
+            "a channel whose peer is closed must end the view rather than stall it"
+        );
+    }
+
+    /// What gets stopped when a capture ends, and what does not.
+    ///
+    /// The rule decides the fate of a program this process launched, so getting
+    /// it wrong either orphans work or destroys it. A program that ended on its
+    /// own is never touched; a live view or a failed capture stops one that is
+    /// still up, because both run until monitoring is over and waiting on a
+    /// long-running target would hang forever.
+    ///
+    /// The case this rule deliberately does NOT see is a view whose channel
+    /// broke: that is decided before it, because whose fault it is changes the
+    /// answer.
+    #[test]
+    fn only_a_capture_that_owns_the_target_stops_it() {
+        use super::Disposition::{Collect, LeaveAlone, Stop};
+        // Already exited: nothing to stop, whatever the capture did.
+        assert!(matches!(super::disposition(false, 0, true, false), Collect));
+        assert!(matches!(super::disposition(false, 1, true, false), Collect));
+        assert!(matches!(super::disposition(false, 1, false, false), Collect));
+        // A one-shot capture that worked lets a live program finish by itself.
+        assert!(matches!(super::disposition(true, 0, false, false), Collect));
+        // A live view owns its target; a failed capture stops it too.
+        assert!(matches!(super::disposition(true, 0, true, false), Stop));
+        assert!(matches!(super::disposition(true, 1, false, false), Stop));
+        // …but not when the view ended because OUR channel broke. This is the
+        // one input that reverses the answer, on exactly the case that would
+        // otherwise be stopped: a live view over a program that is still up.
+        assert!(matches!(super::disposition(true, 0, true, true), LeaveAlone));
+        assert!(matches!(super::disposition(true, 1, true, true), LeaveAlone));
+        // A program that already exited is still collected, so a lost channel
+        // never leaves a zombie behind.
+        assert!(matches!(super::disposition(false, 0, true, true), Collect));
+    }
+
+    /// A reply that arrives in pieces is waited for, not cut off mid-sentence.
+    ///
+    /// The deadline resets on every piece, so a child that is merely slow keeps
+    /// the channel. Only a stall with NOTHING arriving mid-message ends it — and
+    /// ending it reaps the target, which is why the difference between "slow"
+    /// and "stopped" is worth spending three deadlines on.
+    ///
+    /// Driven over a real socketpair with a real writer, because what is under
+    /// test is how the kernel delivers a stream, not how this code imagines it.
+    #[test]
+    fn a_reply_arriving_in_pieces_is_waited_for() {
+        let mut channel = super::open_polled_control_channel().expect("a socketpair");
+        // One second, so the pause below genuinely PASSES the deadline. With the
+        // production five, a test short enough to keep would never reach the
+        // path it exists to cover.
+        super::set_receive_deadline(channel.parent, 1);
+        let child = channel.child;
+        let body = b"elephc-probe: {main};hot 12\n";
+        let header = (body.len() as u32).to_le_bytes();
+
+        // A writer that sends the length, pauses, then the body a byte at a
+        // time — the shape a loaded child produces.
+        let writer = std::thread::spawn(move || {
+            // The request byte the caller sends first, taken so it does not sit
+            // in front of anything.
+            let mut request = [0u8; 1];
+            unsafe {
+                libc::recv(child, request.as_mut_ptr() as *mut libc::c_void, 1, 0);
+                libc::send(child, header.as_ptr() as *const libc::c_void, 4, 0);
+            }
+            // Longer than the deadline: the reader stalls mid-message, with the
+            // length already consumed. Retrying is only safe because `filled`
+            // says how much of THIS reply is still owed.
+            std::thread::sleep(std::time::Duration::from_millis(1_800));
+            for byte in body {
+                unsafe {
+                    libc::send(child, byte as *const u8 as *const libc::c_void, 1, 0);
+                }
+                std::thread::sleep(std::time::Duration::from_millis(2));
+            }
+        });
+
+        match super::request_snapshot(&channel) {
+            super::Snapshot::Answered(text) => assert_eq!(text.as_bytes(), body),
+            super::Snapshot::Late { .. } => {
+                panic!("a reply that did arrive was reported as absent")
+            }
+            super::Snapshot::Gone => {
+                panic!("a child sending its reply in pieces was reported as gone, which reaps it")
+            }
+        }
+        writer.join().expect("the writer finished");
+        channel.forget_child();
+        unsafe { libc::close(child) };
+    }
+
+    /// The profiler's own lines are removed from a program's stderr; the
+    /// program's are not.
+    ///
+    /// Both mechanisms write to the same stderr, so a monitor forwarding a
+    /// program's diagnostics has to tell them apart — and a prefix alone is not
+    /// enough. A program that writes `elephc-instrumentation disabled` had that
+    /// line deleted by the tool watching it, silently, which is the failure this
+    /// rule exists to prevent: the author's own message, gone, with nothing to
+    /// say it ever existed.
+    #[test]
+    fn profiler_lines_are_told_from_the_programs_own() {
+        for profiler in [
+            "elephc-instr: hot calls=1 incl_ns=5",
+            "elephc-instr-edge: a -> b count=1 ns=2",
+            "elephc-instr-query: 3 SELECT ?",
+            "elephc-instr-query-dropped: 2",
+            "elephc-instr-trace: wrote /tmp/t.json",
+            "elephc-probe: {main};hot 12",
+            "elephc-probe-io: 4",
+            "elephc-probe-samples: 934",
+            "elephc-probe-alloc: {main};hot 594",
+        ] {
+            assert!(
+                super::is_profiler_line(profiler),
+                "profiler output reached the operator as if the program wrote it: {profiler}"
+            );
+        }
+        for own in [
+            "elephc-instrumentation disabled by config",
+            "elephc-probes are not enabled here",
+            "elephc-instr is what we call it",
+            // A name the profiler does not use, which a prefix-and-colon rule
+            // would still have taken.
+            "elephc-instr-custom: our own channel",
+            "elephc-probe-of-ours: hello",
+            "warning: something the program wanted to say",
+            "",
+            "   ",
+        ] {
+            assert!(
+                !super::is_profiler_line(own),
+                "the program's own diagnostic was deleted by the tool watching it: {own}"
+            );
+        }
     }

--- a/tests/codegen/cli.rs
+++ b/tests/codegen/cli.rs
@@ -1788,6 +1788,144 @@ fn test_cli_monitor_restores_a_coroutine_resumed_into_a_throw() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+/// `--live` works on every platform, because it asks the target it launched.
+///
+/// Deliberately NOT gated on macOS, which is the whole point of the test. The
+/// live view used to read its own child from the outside, through a tool that
+/// ships on macOS alone, and was refused everywhere else — for a program this
+/// process had started ITSELF and could simply have asked. It now hands the
+/// child a socketpair, exactly as the exact path always has, and the probe
+/// answers snapshots on it.
+///
+/// The fixture runs to a wall-clock DEADLINE rather than an iteration count. A
+/// count is a bet on the machine: calibrated here it gave five windows, and on a
+/// faster CI runner the program finished inside the second one, so the loop saw
+/// the child exit before it could redraw and the test failed for a reason that
+/// had nothing to do with what it measures. Six seconds against a one-second
+/// window leaves room on any machine, in both directions.
+///
+/// Three things are asserted, and the third is the one a reader would not think
+/// of. Windows advance, so the loop is really looping. A PHP function is named,
+/// so the answer carries symbolised frames rather than an empty table anyone
+/// could produce. And the program's own output survives while the profiler's
+/// does not: asking wakes the EXACT profiler too, which writes its table to
+/// stderr at exit, and forwarding that would print a raw dump under the live
+/// view as if the program had written it.
+#[test]
+fn test_cli_monitor_live_needs_no_external_sampler() {
+    let dir = make_cli_test_dir("elephc_cli_monitor_live");
+    fs::write(
+        dir.join("hot.php"),
+        "<?php\n\
+         function spin(int $rounds): int { $n = 0; for ($i = 0; $i < $rounds; $i++) { $n = ($n + $i) % 1000003; } return $n; }\n\
+         function descend(int $depth, int $rounds): int {\n\
+         if ($depth <= 0) { return spin($rounds); }\n\
+         return descend($depth - 1, $rounds) % 1000003;\n\
+         }\n\
+         $t = 0;\n\
+         $deadline = microtime(true) + 6.0;\n\
+         while (microtime(true) < $deadline) { $t = ($t + descend(6, 400000)) % 1000003; }\n\
+         echo 'done', $t;\n",
+    )
+    .expect("failed to write the live fixture");
+
+    let compile = elephc_cli_command(&dir)
+        .args(["--with-monitoring", "hot.php"])
+        .output()
+        .expect("failed to compile the live fixture");
+    assert!(
+        compile.status.success(),
+        "compile failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let watched = elephc_cli_command(&dir)
+        .args(["monitor", "./hot", "--live", "--duration", "1"])
+        .output()
+        .expect("failed to run elephc monitor --live");
+    let stdout = String::from_utf8_lossy(&watched.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&watched.stderr).to_string();
+    let report = format!("{stdout}{stderr}");
+
+    assert!(
+        report.contains("window 2"),
+        "the live loop produced no second window:\n{report}"
+    );
+    assert!(
+        report.contains("descend"),
+        "the live table named no PHP function, so the frames were not symbolised:\n{report}"
+    );
+    assert!(
+        report.contains("done"),
+        "the program's own output was swallowed:\n{report}"
+    );
+    for leaked in ["elephc-probe:", "elephc-instr:"] {
+        assert!(
+            !report.contains(leaked),
+            "raw profiler output reached the operator under the live view ({leaked}):\n{report}"
+        );
+    }
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// `--live` on a `.php` SOURCE, which is the way a user actually reaches it.
+///
+/// The live view asks the program it launched, so the program has to carry the
+/// probe — and the live path compiled the source with `--debug-info` instead of
+/// `--with-monitoring`, producing a binary with nothing listening. `monitor`
+/// then opened a channel, waited out every window for an ACK that could not
+/// come, and reported an empty table for a program running perfectly well.
+///
+/// Nothing caught it because the test above compiles the fixture by hand first
+/// and monitors the BINARY. That is a real path, but it is not the one the
+/// documentation puts first, and between them they left the common case
+/// uncovered. This runs `monitor hot.php --live` and nothing else.
+#[test]
+fn test_cli_monitor_live_compiles_the_source_with_the_probe() {
+    let dir = make_cli_test_dir("elephc_cli_monitor_live_source");
+    fs::write(
+        dir.join("hot.php"),
+        "<?php\n\
+         function spin(int $rounds): int { $n = 0; for ($i = 0; $i < $rounds; $i++) { $n = ($n + $i) % 1000003; } return $n; }\n\
+         function descend(int $depth, int $rounds): int {\n\
+         if ($depth <= 0) { return spin($rounds); }\n\
+         return descend($depth - 1, $rounds) % 1000003;\n\
+         }\n\
+         $t = 0;\n\
+         $deadline = microtime(true) + 6.0;\n\
+         while (microtime(true) < $deadline) { $t = ($t + descend(6, 400000)) % 1000003; }\n\
+         echo 'done', $t;\n",
+    )
+    .expect("failed to write the live source fixture");
+
+    // No `--with-monitoring` step. That is the point of the test.
+    let watched = elephc_cli_command(&dir)
+        .args(["monitor", "hot.php", "--live", "--duration", "1"])
+        .output()
+        .expect("failed to run elephc monitor hot.php --live");
+    let stdout = String::from_utf8_lossy(&watched.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&watched.stderr).to_string();
+    let report = format!("{stdout}{stderr}");
+
+    assert!(
+        report.contains("descend"),
+        "the live table named no PHP function, so the source was compiled without the probe \
+         and the child had nothing to answer with:\n{report}"
+    );
+    assert!(
+        !report.contains("did not answer within the window"),
+        "the child never answered, which is what a binary compiled without the probe does:\n{report}"
+    );
+    assert!(
+        report.contains("done"),
+        "the program's own output was swallowed:\n{report}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
 /// End-to-end `--with-monitoring`: a binary that carries the tooling is silent
 /// until asked, and reports fully when `monitor` asks.
 ///

--- a/tests/fixtures/monitor/signals.c
+++ b/tests/fixtures/monitor/signals.c
@@ -1,0 +1,22 @@
+/* A CPU-bound tracee whose signal handlers report delivery through stdout. */
+#include <signal.h>
+#include <unistd.h>
+#include <sys/prctl.h>
+
+static void received(int signal) {
+    const char marker = signal == SIGTRAP ? 'T' : 'U';
+    (void)write(STDOUT_FILENO, &marker, 1);
+}
+
+int main(void) {
+    struct sigaction action = {0};
+    action.sa_handler = received;
+    sigemptyset(&action.sa_mask);
+    sigaction(SIGUSR1, &action, 0);
+    sigaction(SIGTRAP, &action, 0);
+    prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY, 0, 0, 0);
+    (void)write(STDOUT_FILENO, "R", 1);
+    for (;;) {
+        __asm__ volatile("" ::: "memory");
+    }
+}


### PR DESCRIPTION
`--live` was refused on anything but macOS, and the reason given was true and beside the point: reading a process from the outside needs `/usr/bin/sample`, which ships there alone — but **`--live` launches the program**. It never had to read it from outside. It simply never asked.

The exact path has asked since it existed: it hands the child a socketpair before the fork, and that channel is the credential — only this process holds the other end, so there is nothing to copy, find in a log, or replay. The live path built its child with a bare `spawn()`, so the program was never told it was being monitored, its probe stayed dormant, and an external sampler became the only way to see anything.

**The platform limit was a consequence of a missing link, not a property of Linux.**

### What it needed

Nothing new measures anything. The probe already samples itself into a ring and already renders the folded profile the endpoint serves, so `sampled_answer()` is what goes over the channel. A thread serves it, started only when the channel is present — a program nobody asked about spawns nothing — and blocks SIGPIPE and SIGPROF for the two reasons the endpoint thread does.

Snapshots are cumulative, like the endpoint's answer; a window is the difference between two, computed by the caller. A probe that reset on every read would have to decide what a window is, and would lose one to any reader that disconnected.

`--attach` cannot be fixed the same way — it is handed a pid already running under someone else's control, with no channel in, so reading it from the outside is not a shortcut there, it is the whole job. That half is [below](#attach).

### Three defects of my own, all found by running it

- **The parent kept its copy of the CHILD end.** While it holds one, the socket has a writer that never writes — so when the program exits, `recv` does not report EOF, it waits for us forever. The live loop hung there instead of noticing the target was gone.
- **Asking also wakes the exact profiler**, which writes its table to stderr at exit. The live view printed that raw dump under the table, as if the program had written it. A live view has to filter as the lines arrive, since it runs as long as the program does and a pipe nobody reads fills and blocks the writer.
- **The snapshot was collected into a map**, which keeps the *last* of two equal stacks rather than their sum. `folded_text_to_display` emits the same display stack twice when a folded line carries a native leaf, so samples went missing from the window and from every window after it.

`EINTR` is handled on both sides: a signal arriving mid-wait is not the monitor leaving, and treating it as one would stop serving snapshots silently — which the other end reads as "the target is gone".

### Verification

`test_cli_monitor_live_needs_no_external_sampler` is deliberately **not** gated on macOS, which is the point of it. It asserts a second window appears, that a PHP function is named (so frames are symbolised rather than an empty table anyone could produce), that the program's own output survives, and that no `elephc-probe:`/`elephc-instr:` line reaches the operator.

The control that settles whether the new transport is faithful: the **endpoint** path, untouched by this and reading the same `sampled_answer()`, reports the same profile for the same binary.

Four mutations over the whole path — channel never opened, probe never serving, parent keeping the child end, stderr unfiltered — **all four red, each for a different one of the test's four assertions**.

`elephc-probe` 60 · `elephc` lib 1488 · bins 1659 · `error_tests` 1437 · codegen cli 32 · the `--doc` gate. No warnings.

### <a name="attach"></a>The other half: `--attach` on Linux

`--attach` was then the last thing in `monitor` a platform could refuse, and it could not be answered by asking, so elephc reads the process itself: seize each thread, stop it, read `pc` and `fp`, walk the frame chain, resume. The syscalls and the loop driving them are alone in `ptrace.rs`, because they are the one part no test on a macOS host can run; the ELF symbol table, the naming and the folding were separated for that reason and are exercised everywhere.

Four more defects, none of which announced itself, and two of which produced a **wrong answer** rather than an error:

- **`function_symbols` returned the linker's order and `symbolize` binary-searches.** The parameter is named `sorted` and nothing had ever called both. An unsorted binary search does not fail — it answers `None` for nearly every address, and a 12-second spin loop came back as 251 samples of `<native>`, which reads as *this program is not PHP*. The producer now guarantees the order its only consumer requires, asserted where it is produced: a test that sorted first would pass against the bug.
- **`display_stack` published the mangled spelling.** Ordered, not cosmetic: the prefix that says PHP-or-helper is exactly what demangling removes, so classifying after it leaves every PHP function native.
- **The worker tree was one pid.** I shipped `pids.first()` with a comment explaining why one was enough; it was the limitation restated. Workers share the image but not the bias, so each derives its own — reusing the root's names the wrong functions, which is worse than a short table.
- **A detach that never took.** `PTRACE_DETACH` needs a *stopped* tracee and restarts it as it detaches; asked of a running one it fails with `ESRCH` silently. Seizes are per window and a traced thread cannot be seized twice, so window two seized nothing — and an empty window is how `--attach` learns its target is gone. The live view announced the program had ended, eight seconds early. A related one: `interrupt_and_wait` reported one failure for two things, so a failed wait returned before any resume and left the thread stopped.

Reading from the outside asks two things of a target that asking does not, and each refusal names its remedy: a stripped binary says to rebuild with `--keep-symbols` (elephc strips by default, because nothing *inside* a program reads its symbols), and a kernel that forbids tracing names the `yama/ptrace_scope` setting.

### I can now run the Linux path, and did

The earlier version of this said I could only type-check for Linux and that CI's shards were the oracle. That is no longer true: the attach half is exercised against real running processes in a Linux container (`--cap-add=SYS_PTRACE`).

| exercised on Linux | result |
|---|---|
| one-shot capture | `{main}` → `outer_driver` → `inner_hot_loop`, 74.4% |
| worker tree | 672 samples over 2 processes at different bases, both named |
| `--attach --live` | full 8s, 4 windows, ends when the target exits |
| stack depth | a 9-frame chain naming all five levels |
| `--out` / `--html` / `--dot` | all three written, all naming the function |
| absent pid · stripped binary | `exit=1`, each saying which |
| threads left stopped | none; `state=R` throughout, utime climbing |

The two ordering fixes are mutation-verified. The detach and resume fixes are measured before and after instead, since no unit test on this host reaches ptrace: before, the live view exited at 2s having seized 0 of 1 target in its second window with `TracerPid` still set; after, the full duration.

`elephc` bins 1678 · lib 1488 · codegen cli 37 · `elephc-probe` 61 · `elephc-instr` 79; clippy and `fmt` clean. On Linux: `monitor::` 61, clippy clean on `src/monitor`. CI green across 127 jobs.

### Docs

`--attach` was called macOS-only in four places, one of which also still said `--live` reads a process from the outside — untrue as of the first half of this PR.

