### PR TITLE
fix(codegen|types): run an inherited private constructor for the selected class

### DIFF
--- a/src/codegen/lower_inst/objects/dynamic_factory.rs
+++ b/src/codegen/lower_inst/objects/dynamic_factory.rs
@@ -98,7 +98,13 @@ pub(super) fn dynamic_new_candidate(
     }
     let constructor_key = php_symbol_key("__construct");
     let mut padding_thunk = None;
-    let constructor_impl = if let Some(constructor) = class_info.methods.get(&constructor_key) {
+    // Same reason as the fixed-class path: a runtime-selected descendant of a class with a
+    // private constructor carries no `__construct` entry of its own, and PHP still runs the
+    // ancestor's. The owner is the candidate itself for every other constructor.
+    let constructor_owner = crate::types::constructor_owner(&ctx.module.class_infos, class_name);
+    let constructor_impl = if let Some((owner_name, constructor)) = constructor_owner
+        .and_then(|(name, info)| info.methods.get(&constructor_key).map(|sig| (name, sig)))
+    {
         // A site that passes FEWER arguments than the constructor declares is still a candidate
         // when every omitted parameter has a default and `ir_lower` emitted the padding thunk for
         // this (class, argc) pair. `new $c(…)` cannot be padded by the checker — it does not know
@@ -126,11 +132,9 @@ pub(super) fn dynamic_new_candidate(
                 padding_thunk = Some(thunk);
             }
         }
-        let impl_class = class_info
-            .method_impl_classes
-            .get(&constructor_key)
-            .cloned()
-            .unwrap_or_else(|| class_name.to_string());
+        let impl_class = constructor_owner
+            .and_then(|(_, info)| info.method_impl_classes.get(&constructor_key).cloned())
+            .unwrap_or_else(|| owner_name.to_string());
         if !class_method_already_emitted(ctx, &impl_class, &constructor_key, false) {
             return Ok(None);
         }

--- a/src/codegen/lower_inst/objects/fixed_new.rs
+++ b/src/codegen/lower_inst/objects/fixed_new.rs
@@ -57,7 +57,14 @@ pub(in crate::codegen::lower_inst) fn lower_object_new(ctx: &mut FunctionContext
             )));
         }
         let property_defaults = collect_property_defaults(class_info, inst)?;
-        let constructor_impl = if let Some(constructor) = class_info.methods.get(&constructor_key) {
+        // A private constructor is not inherited, so a descendant of a class that declares one
+        // carries no `__construct` entry of its own. PHP still instantiates it through that
+        // ancestor, so resolve the owner; it is the class itself for every other constructor.
+        let constructor_owner =
+            crate::types::constructor_owner(&ctx.module.class_infos, &class_name);
+        let constructor_impl = if let Some((owner_name, constructor)) = constructor_owner
+            .and_then(|(name, info)| info.methods.get(&constructor_key).map(|sig| (name, sig)))
+        {
             if constructor.params.len() != inst.operands.len() {
                 return Err(CodegenIrError::unsupported(format!(
                     "constructor call to {}::__construct with {} args for {} params",
@@ -66,11 +73,9 @@ pub(in crate::codegen::lower_inst) fn lower_object_new(ctx: &mut FunctionContext
                     constructor.params.len()
                 )));
             }
-            let impl_class = class_info
-                .method_impl_classes
-                .get(&constructor_key)
-                .cloned()
-                .unwrap_or_else(|| class_name.clone());
+            let impl_class = constructor_owner
+                .and_then(|(_, info)| info.method_impl_classes.get(&constructor_key).cloned())
+                .unwrap_or_else(|| owner_name.to_string());
             if !class_method_already_emitted(ctx, &impl_class, &constructor_key, false) {
                 return Err(CodegenIrError::unsupported(format!(
                     "constructor call to {}::__construct without an emitted EIR method body",

--- a/src/types/checker/inference/objects/constructors.rs
+++ b/src/types/checker/inference/objects/constructors.rs
@@ -106,13 +106,24 @@ impl Checker {
                     &format!("Cannot instantiate abstract class: {}", class_name),
                 ));
             }
-            if let Some(sig) = class_info.methods.get("__construct") {
-                if let Some(visibility) = class_info.method_visibilities.get("__construct") {
-                    let declaring_class = class_info
+            // A private constructor is not inherited, so a descendant's own method map has
+            // no `__construct` entry. PHP still instantiates the descendant through the
+            // ancestor that declares it, and reports that declaring class when the call site
+            // may not reach it, so resolve the owner before reading the constructor contract.
+            let constructor_owner = crate::types::constructor_owner(&self.classes, class_name.as_str())
+                .and_then(|(owner_name, owner_info)| {
+                    owner_info
+                        .methods
+                        .get("__construct")
+                        .map(|sig| (sig, owner_name, owner_info))
+                });
+            if let Some((sig, owner_name, owner_info)) = constructor_owner {
+                if let Some(visibility) = owner_info.method_visibilities.get("__construct") {
+                    let declaring_class = owner_info
                         .method_declaring_classes
                         .get("__construct")
                         .map(String::as_str)
-                        .unwrap_or(class_name.as_str());
+                        .unwrap_or(owner_name);
                     if !self.can_access_member(declaring_class, visibility)
                         && !self.can_construct_internal_iterator_from_builtin_get_iterator(&class_name)
                         && !self.can_construct_pdo_row_from_prelude_fetch(&class_name)
@@ -122,15 +133,15 @@ impl Checker {
                             &format!(
                                 "Cannot access {} constructor: {}::__construct",
                                 Self::visibility_label(visibility),
-                                class_name
+                                declaring_class
                             ),
                         ));
                     }
                 }
                 let declared_flags =
-                    Self::declared_method_param_flags(class_info, "__construct", false);
+                    Self::declared_method_param_flags(owner_info, "__construct", false);
                 let effective_sig = Self::callable_sig_for_declared_params(sig, &declared_flags);
-                let param_to_prop = class_info.constructor_param_to_prop.clone();
+                let param_to_prop = owner_info.constructor_param_to_prop.clone();
                 let normalized_args = self.normalize_named_call_args(
                     &effective_sig,
                     args,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -75,6 +75,7 @@ pub use checker::CheckOptions;
 #[allow(unused_imports)]
 pub use result::check_with_target;
 pub use result::{check_with_target_and_options, CheckResult, ThrowAccessInfo, ThrowAccessKind};
+pub use schema::constructor_owner;
 pub use schema::{
     AttrArgEntry, AttrArgValue, AttrKey, ClassInfo, EnumCaseInfo, EnumCaseValue, EnumInfo,
     ExternClassInfo, ExternFieldInfo, ExternFunctionSig, InterfaceInfo, PackedClassInfo,

--- a/src/types/schema.rs
+++ b/src/types/schema.rs
@@ -378,6 +378,36 @@ pub struct ClassInfo {
     pub constructor_param_to_prop: Vec<Option<String>>,
 }
 
+/// Returns the class whose `__construct` PHP runs when `class_name` is instantiated.
+///
+/// A private method is not inherited, so `ClassInfo::methods` deliberately carries no
+/// `__construct` entry on a descendant of a class with a private constructor. PHP still
+/// instantiates that descendant through the ancestor's constructor and names the declaring
+/// class when the call site may not reach it, which is also what
+/// `ReflectionClass::getConstructor()` reports while `method_exists()` answers `false`.
+/// Walking to the nearest ancestor that still owns the entry models both halves.
+///
+/// The owner is the instantiated class itself whenever its own map has the entry, so an
+/// inherited public or protected constructor resolves exactly as before.
+pub fn constructor_owner<'a>(
+    classes: &'a HashMap<String, ClassInfo>,
+    class_name: &str,
+) -> Option<(&'a str, &'a ClassInfo)> {
+    let mut current = Some(class_name);
+    let mut seen = HashSet::new();
+    while let Some(name) = current {
+        if !seen.insert(name) {
+            return None;
+        }
+        let (owner_name, info) = classes.get_key_value(name)?;
+        if info.methods.contains_key("__construct") {
+            return Some((owner_name.as_str(), info));
+        }
+        current = info.parent.as_deref();
+    }
+    None
+}
+
 impl ClassInfo {
     /// Resolves the layout index of the property visible by name on this class.
     ///

--- a/tests/codegen/oop/relative_types.rs
+++ b/tests/codegen/oop/relative_types.rs
@@ -86,6 +86,107 @@ fn test_static_return_type() {
     assert_eq!(out, "made");
 }
 
+/// Verifies `new static()` runs an ancestor's private constructor for a selected descendant.
+///
+/// A private method is not inherited, so the descendant's own method map carries no
+/// `__construct`; resolving only there allocated the object and ran nothing at all.
+#[test]
+fn test_new_static_runs_inherited_private_constructor() {
+    let out = compile_and_run(
+        r#"<?php
+class Connection {
+    private function __construct() { echo "connecting "; }
+    public static function make(): static { return new static(); }
+    public function ok(): string { return "ok"; }
+}
+class PooledConnection extends Connection {}
+echo PooledConnection::make()->ok();
+"#,
+    );
+    assert_eq!(out, "connecting ok");
+}
+
+/// Verifies the whole constructor chain runs when the private constructor calls `parent::`.
+#[test]
+fn test_new_static_private_constructor_runs_parent_chain() {
+    let out = compile_and_run(
+        r#"<?php
+class Base {
+    public function __construct() { echo "base "; }
+}
+class Middle extends Base {
+    private function __construct() { parent::__construct(); echo "middle "; }
+    public static function make(): static { return new static(); }
+    public function ok(): string { return "ok"; }
+}
+class Leaf extends Middle {}
+echo Leaf::make()->ok();
+"#,
+    );
+    assert_eq!(out, "base middle ok");
+}
+
+/// Verifies an inherited private constructor still receives its arguments.
+///
+/// With arguments the same missing lookup surfaced as a checker arity error claiming the
+/// descendant takes none, rather than as a silently skipped call.
+#[test]
+fn test_new_static_inherited_private_constructor_takes_arguments() {
+    let out = compile_and_run(
+        r#"<?php
+class Tagged {
+    private function __construct(private int $tag) {}
+    public static function make(int $tag): static { return new static($tag); }
+    public function tag(): int { return $this->tag; }
+}
+class SubTagged extends Tagged {}
+echo SubTagged::make(7)->tag();
+"#,
+    );
+    assert_eq!(out, "7");
+}
+
+/// Verifies naming the descendant directly from the declaring scope also runs the constructor.
+#[test]
+fn test_fixed_new_of_descendant_runs_declaring_private_constructor() {
+    let out = compile_and_run(
+        r#"<?php
+class Owner {
+    private function __construct() { echo "built "; }
+    public static function makeChild(): Owner { return new OwnedChild(); }
+}
+class OwnedChild extends Owner {}
+echo Owner::makeChild() instanceof OwnedChild ? "yes" : "no";
+"#,
+    );
+    assert_eq!(out, "built yes");
+}
+
+/// Verifies the singleton shape this defect actually reached: private constructor, static
+/// accessor, one subclass, and a call through the base type.
+#[test]
+fn test_singleton_subclass_runs_private_constructor_and_dispatches() {
+    let out = compile_and_run(
+        r#"<?php
+class Root {
+    public function __construct() {}
+    public function alpha(): string { return "root-alpha"; }
+    public function beta(): string { return "root-beta"; }
+}
+class Single extends Root {
+    private static ?Single $instance = null;
+    private function __construct() { parent::__construct(); echo "init "; }
+    public static function get(): Single { return self::$instance ??= new self(); }
+    public function alpha(): string { return "single-alpha"; }
+}
+function through_root(Root $value): string { return $value->beta(); }
+$single = Single::get();
+echo $single->alpha(), "|", through_root($single);
+"#,
+    );
+    assert_eq!(out, "init single-alpha|root-beta");
+}
+
 /// Verifies an inherited static factory returning `static` exposes subclass-only methods.
 #[test]
 fn test_inherited_static_factory_return_binds_to_called_class() {

--- a/tests/error_tests/classes_traits.rs
+++ b/tests/error_tests/classes_traits.rs
@@ -604,6 +604,34 @@ fn test_error_reflection_attribute_constructor_is_private() {
     );
 }
 
+/// Verifies instantiating a descendant of a class with a private constructor is rejected, and
+/// that the diagnostic names the class that DECLARES the constructor, as php does.
+#[test]
+fn test_error_private_constructor_blocks_descendant_from_global_scope() {
+    expect_error(
+        "<?php class Owner { private function __construct() {} } class Child extends Owner {} $o = new Child();",
+        "Cannot access private constructor: Owner::__construct",
+    );
+}
+
+/// Verifies `new static()` from a scope that does not declare the private constructor is rejected.
+#[test]
+fn test_error_private_constructor_blocks_new_static_from_other_scope() {
+    expect_error(
+        "<?php class Owner { private function __construct() {} } class Child extends Owner { public static function make(): static { return new static(); } } Child::make();",
+        "Cannot access private constructor: Owner::__construct",
+    );
+}
+
+/// Verifies the declaring class is reported from further up the chain, not the lexical scope.
+#[test]
+fn test_error_private_grandparent_constructor_names_its_declaring_class() {
+    expect_error(
+        "<?php class Root { private function __construct() {} } class Middle extends Root { public static function make(): static { return new static(); } } class Leaf extends Middle {} Leaf::make();",
+        "Cannot access private constructor: Root::__construct",
+    );
+}
+
 /// Verifies that `new ReflectionParameter()` rejects unknown parameter names.
 #[test]
 fn test_error_reflection_parameter_constructor_unknown_name() {


### PR DESCRIPTION
## Summary

Fixes #795. `new static()` allocated the object and ran **no constructor at all** whenever the
runtime-selected class was a descendant and the constructor it inherited was private — the
ordinary singleton / static-factory shape, failing silently:

```php
<?php
class Connection {
    private function __construct() { echo "connecting "; }
    public static function make(): static { return new static(); }
    public function ok(): string { return "ok"; }
}
class PooledConnection extends Connection {}
echo PooledConnection::make()->ok(), "\n";
```

| | before | after | php 8.5.6 |
|---|---|---|---|
| | `ok` | `connecting ok` | `connecting ok` |

## Why it happened

A private method is not inherited, so `ClassState::inherit_methods` deliberately drops it and a
descendant's `ClassInfo::methods` carries no `__construct`. Every consumer then read that as
"this class has no constructor".

PHP draws the line differently for constructors, and its own reflection shows both halves:

```php
class Owner { private function __construct() {} }
class Child extends Owner {}
method_exists('Child', '__construct');                                        // false
get_class_methods('Child');                                                   // []
(new ReflectionClass('Child'))->getConstructor()->getDeclaringClass()->getName();  // "Owner"
(new ReflectionClass('Child'))->hasMethod('__construct');                      // true
```

So the descendant does not *inherit* the private method as a callable member, yet the class still
*has* a constructor, resolved through the chain to its declaring class. This keeps `methods` as it
is and resolves `__construct` through the ancestor chain at each point of use, which models both
halves. Putting the entry into `methods` instead would make `method_exists()` answer `true`, and
would also break `prune_keeps_private_override_vtable_hole_on_descendant`, which asserts the
current shape for a good reason.

## The change

`types::constructor_owner()` walks to the nearest ancestor whose map still owns `__construct`, with
a cycle guard. It returns the class itself whenever that class has the entry, so an inherited
public or protected constructor resolves exactly as before and the common path is unchanged.

Three callers:

- `types/checker/inference/objects/constructors.rs` — owns both the visibility error and the arity
  check, so it fixes the diagnostics and the argument case;
- `codegen/lower_inst/objects/fixed_new.rs` — `new Child()` named directly;
- `codegen/lower_inst/objects/dynamic_factory.rs` — the `new static()` candidate ladder.

## Three further symptoms, same root cause, fixed here too

**Naming the descendant directly also skipped the constructor**, not only `new static()`:

```php
class Owner { private function __construct() { echo "built "; } 
              public static function makeChild(): Owner { return new OwnedChild(); } }
class OwnedChild extends Owner {}
Owner::makeChild();     // before: nothing   after: "built"   php: "built"
```

**Where php raises an `Error`, elephc silently succeeded** — constructing an object php refuses to
build. `new Owner()` was already rejected correctly; only the descendant slipped through:

```php
class Owner { private function __construct() {} }
class Child extends Owner {}
new Child();
// before: constructed
// after:  Cannot access private constructor: Owner::__construct
// php:    Error: Call to private Owner::__construct() from global scope
```

The diagnostic now names the class that **declares** the constructor rather than the one being
instantiated, matching php — including when it comes from further up the chain
(`Root::__construct` for a `Leaf` whose lexical scope is `Middle`).

**With arguments the symptom flipped to a spurious compile error**:

```php
class Tagged { private function __construct(private int $tag) {}
               public static function make(int $tag): static { return new static($tag); } }
class SubTagged extends Tagged {}
SubTagged::make(7);
// before: error: Constructor 'SubTagged::__construct' expects 0 arguments, got 1
// after:  7          php: 7
```

## Testing

Focused per `AGENTS.md`; the full sharded matrix is CI's job.

- 5 new codegen tests in `tests/codegen/oop/relative_types.rs`: the plain case, the
  `parent::__construct` chain, constructor arguments, the fixed `new Child()` path, and the
  realistic singleton shape with dispatch through the base type.
- 3 new error tests in `tests/error_tests/classes_traits.rs`: descendant from global scope,
  `new static()` from a non-declaring scope, and the grandparent case naming its declaring class.

```
cargo build                                       warning-free
cargo test --test error_tests                     1440 passed
cargo test -p elephc --lib                        1488 passed
cargo test --test codegen_tests -- oop::           593 passed
cargo test --test codegen_tests -- objects::       246 passed
cargo test --test codegen_tests -- optimizer::     327 passed
cargo test --test codegen_tests -- eval_constructors        11 passed
cargo test --test codegen_tests -- static_class_features    18 passed
```

Behaviour verified against PHP 8.5.6 on macOS ARM64 across 13 shapes, including the ones that must
**not** change: protected constructors, public constructors, a class with no subclass, `new self()`,
and `new Owner()` from global scope (already an error before).
