### PR TITLE
feat: add monitoring contract and curl telemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,9 +161,20 @@ by EIR lowering and `src/codegen/`.
 Optional, heavyweight functionality that is naturally expressed with Rust
 libraries lives in a workspace crate under `crates/elephc-<name>/`, compiled as a
 `staticlib` and linked into the user program on demand. Every such bridge is
-described by one entry in the `BRIDGES` table in `src/linker.rs`; `link()` and the
+described by one entry in the `BRIDGES` table in `src/linker/bridges.rs`; `link()` and the
 discovery/auto-build helpers are fully table-driven, so adding a bridge is a
 single table entry rather than new linker logic.
+
+Every bridge entry must declare a reviewed `MonitoringPolicy`. Use generic
+timing when ordinary function timing is sufficient, typed I/O policy when the
+bridge performs database or network work, and an infrastructure policy with a
+nonempty reason only for monitor/runtime plumbing. The bridge-catalog gate
+rejects an unspecified policy. Bridge-backed `RuntimeFnId` values must also
+declare their operation policy, and any runtime operation carrying
+`BLOCKING_IO` or `NETWORK_IO` effects must use evented monitoring. I/O bridges
+share the dependency-neutral `elephc-monitoring-contract` helper and distinct
+database/network runtime slots, which must remain dormant outside an active
+capture.
 
 A bridge is linked when its `lib_name` appears in `extra_link_libs`. That set is
 populated automatically by feature detection: the type checker records a needed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -609,7 +609,10 @@ cannot contaminate each other. The event consumer owns its capture-window gate,
 and must publish an active-window callback when that state is not represented
 by the exact-capture word. Bridge-side timing must avoid clock reads outside
 either active window, while trace propagation stays scoped to an exact trace
-context. Steady-state dormant paths must not allocate per operation.
+context. Count only actual external operations, not maintenance calls such as
+connection upkeep. Measured wait must exclude time spent in user callbacks so
+network-bound diagnostics describe the driver boundary rather than PHP work.
+Steady-state dormant paths must not allocate per operation.
 
 Set `whole_archive: true` only when the staticlib has link-time side effects that
 must survive (e.g. a provider registration) or owns the program entry point (like

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -406,6 +406,13 @@ enum), implement it under `src/codegen/lower_inst/runtime_functions/` or
 `runtime_calls.rs`, and keep every supported ABI in the same path. If it needs a
 runtime routine, add it under `src/codegen_support/runtime/<category>/`.
 
+Every bridge-backed `RuntimeFnId` must also return a reviewed
+`MonitoringPolicy` from `RuntimeFnId::monitoring_policy()`. Operations marked
+with `BLOCKING_IO` or `NETWORK_IO` effects must use an evented I/O policy. The
+registry test rejects an unspecified decision, so a new runtime boundary cannot
+land until its generic timing, typed events, wait measurement and trace-context
+behavior have been reviewed explicitly.
+
 For a builtin that is naturally expressed as reusable EIR operations, use
 `BuiltinLowering::Eir(lower)`. The hook receives only `BuiltinLoweringContext` and a
 `NormalizedBuiltinCall`; it may emit typed EIR values/runtime calls, but must not
@@ -569,7 +576,7 @@ Every supported target must build and link the crate: `macos-aarch64`,
 artifacts are libraries cross-compiled from macOS. A bridge that only works on
 one target is not acceptable (see the supported-target policy in `CLAUDE.md`).
 
-### 3. Register the bridge in `BRIDGES` (`src/linker.rs`)
+### 3. Register the bridge in `BRIDGES` (`src/linker/bridges.rs`)
 
 Add one `BridgeStaticlib` entry. This is the only linker change required —
 discovery, on-demand build, search paths, whole-archiving, and macOS frameworks
@@ -584,8 +591,24 @@ BridgeStaticlib {
     whole_archive: false,               // true if link-time side effects / owns entry
     macos_frameworks: &[],              // transitive native deps' frameworks
     needs_libdl: true,                  // Rust runtime/unwinder needs -ldl on Linux
+    php_extension: None,                // canonical PHP extension, when distinct
+    monitoring: MonitoringPolicy::GenericTiming,
 },
 ```
+
+The `monitoring` field is mandatory. Use `GenericTiming` when function timing
+fully describes the bridge, `Io { ... }` when it must publish a distinct I/O
+operation or wait dimension, and `Infrastructure { reason }` only for monitor or
+runtime plumbing that is not a PHP-visible work boundary. The bridge-catalog
+test rejects `Unspecified` and empty infrastructure reasons.
+
+I/O bridges should depend on `elephc-monitoring-contract` and call its
+`EventHooks` helper through category-specific runtime slots. Keep database and
+network slots separate so query budgets, N+1 analysis and network budgets
+cannot contaminate each other. The event consumer owns its capture-window gate,
+while bridge-side timing and trace propagation must stay dormant outside an
+active exact capture, including avoiding clock reads and steady-state
+per-operation allocations.
 
 Set `whole_archive: true` only when the staticlib has link-time side effects that
 must survive (e.g. a provider registration) or owns the program entry point (like

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -606,9 +606,10 @@ I/O bridges should depend on `elephc-monitoring-contract` and call its
 `EventHooks` helper through category-specific runtime slots. Keep database and
 network slots separate so query budgets, N+1 analysis and network budgets
 cannot contaminate each other. The event consumer owns its capture-window gate,
-while bridge-side timing and trace propagation must stay dormant outside an
-active exact capture, including avoiding clock reads and steady-state
-per-operation allocations.
+and must publish an active-window callback when that state is not represented
+by the exact-capture word. Bridge-side timing must avoid clock reads outside
+either active window, while trace propagation stays scoped to an exact trace
+context. Steady-state dormant paths must not allocate per operation.
 
 Set `whole_archive: true` only when the staticlib has link-time side effects that
 must survive (e.g. a provider registration) or owns the program entry point (like

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,6 +674,7 @@ dependencies = [
  "elephc-curl",
  "elephc-image",
  "elephc-magician",
+ "elephc-monitoring-contract",
  "elephc-pdo",
  "elephc-phar",
  "elephc-probe",
@@ -733,6 +734,7 @@ dependencies = [
 name = "elephc-curl"
 version = "0.1.0"
 dependencies = [
+ "elephc-monitoring-contract",
  "libc",
  "serde_json",
 ]
@@ -775,11 +777,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "elephc-monitoring-contract"
+version = "0.1.0"
+
+[[package]]
 name = "elephc-pdo"
 version = "0.1.0"
 dependencies = [
  "bytes",
  "chrono",
+ "elephc-monitoring-contract",
  "futures-util",
  "libloading",
  "libpq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ categories = ["compilers", "command-line-utilities"]
 # see crates/elephc-curl/build.rs for how its own gated tests opt into a real
 # link.
 [workspace]
-members = [".", "crates/elephc-builtin-contract", "crates/elephc-tls", "crates/elephc-pdo", "crates/elephc-crypto", "crates/elephc-bcmath", "crates/elephc-iconv", "crates/elephc-phar", "crates/elephc-tz", "crates/elephc-probe", "crates/elephc-instr", "crates/elephc-image", "crates/elephc-web", "crates/elephc-magician", "crates/elephc-curl"]
-default-members = [".", "crates/elephc-builtin-contract", "crates/elephc-tls", "crates/elephc-pdo", "crates/elephc-crypto", "crates/elephc-bcmath", "crates/elephc-iconv", "crates/elephc-phar", "crates/elephc-tz", "crates/elephc-probe", "crates/elephc-instr", "crates/elephc-image", "crates/elephc-web", "crates/elephc-magician", "crates/elephc-curl"]
+members = [".", "crates/elephc-builtin-contract", "crates/elephc-monitoring-contract", "crates/elephc-tls", "crates/elephc-pdo", "crates/elephc-crypto", "crates/elephc-bcmath", "crates/elephc-iconv", "crates/elephc-phar", "crates/elephc-tz", "crates/elephc-probe", "crates/elephc-instr", "crates/elephc-image", "crates/elephc-web", "crates/elephc-magician", "crates/elephc-curl"]
+default-members = [".", "crates/elephc-builtin-contract", "crates/elephc-monitoring-contract", "crates/elephc-tls", "crates/elephc-pdo", "crates/elephc-crypto", "crates/elephc-bcmath", "crates/elephc-iconv", "crates/elephc-phar", "crates/elephc-tz", "crates/elephc-probe", "crates/elephc-instr", "crates/elephc-image", "crates/elephc-web", "crates/elephc-magician", "crates/elephc-curl"]
 resolver = "2"
 
 [[bin]]
@@ -45,6 +45,7 @@ path = "tools/gen_builtins.rs"
 
 [dependencies]
 elephc-builtin-contract = { path = "crates/elephc-builtin-contract" }
+elephc-monitoring-contract = { path = "crates/elephc-monitoring-contract" }
 inventory = "0.3"
 libc = "0.2"
 # Grows the stack on demand inside the recursive-descent parser so deeply

--- a/README.md
+++ b/README.md
@@ -122,9 +122,11 @@ monitor` reads the binary you ran, or the service already serving traffic at
 `https://host:9411`.
 
 A program you *launch* is measured from inside: exact wall time, allocations,
-retained objects, database wait, SQL queries and call counts, rooted at
-`{main}`, so an N+1 is a certainty rather than a suspicion. File I/O is not yet
-counted or timed. A service you *connect to* answers from its sample ring by
+retained objects, database wait, SQL queries, outgoing network operations and
+network wait, plus call counts, rooted at `{main}`, so an N+1 is a certainty
+rather than a suspicion. Curl requests also propagate the active W3C
+`traceparent` unless user code supplied one. File I/O is not yet counted or
+timed. A service you *connect to* answers from its sample ring by
 default — sampled CPU-time shares, sampled allocation attribution and route
 tags, with no blocked wall time or query/wait summary in a combined monitoring
 build — and `elephc monitor

--- a/crates/elephc-curl/Cargo.toml
+++ b/crates/elephc-curl/Cargo.toml
@@ -21,6 +21,7 @@ publish = false
 crate-type = ["staticlib", "rlib"]
 
 [dependencies]
+elephc-monitoring-contract = { path = "../elephc-monitoring-contract" }
 # The default (non-RETURNTRANSFER) write callback streams the response body
 # straight to fd 1 via `libc::write`, matching PHP CLI's `curl_exec()` output.
 libc = "0.2"

--- a/crates/elephc-curl/src/abi.rs
+++ b/crates/elephc-curl/src/abi.rs
@@ -527,7 +527,6 @@ pub extern "C" fn elephc_curl_easy_perform(id: i64) -> i32 {
             entry.callback_threw = false;
             // Opens a fresh callback-throw scope: the process-wide gate that suppresses
             // further callbacks after a throw must not survive into this transfer.
-            crate::callbacks::begin_transfer();
             // Zero the error buffer first: libcurl is not guaranteed to
             // write it on success (only documented to write it on error).
             entry.error_buf.iter_mut().for_each(|byte| *byte = 0);
@@ -535,12 +534,20 @@ pub extern "C" fn elephc_curl_easy_perform(id: i64) -> i32 {
         };
         let hooks = crate::monitoring::hooks();
         hooks.note_operation();
+        let measure_wait = hooks.is_active();
+        crate::callbacks::begin_transfer(measure_wait);
         // The table lock is NOT held across the blocking transfer: the write
         // callback (crate::php_layer::write_callback) re-locks the table
         // per chunk from the same thread, which would deadlock on a
         // non-reentrant `Mutex` otherwise. See this function's doc comment
         // for the resulting caller contract (no concurrent calls on `id`).
-        let code = hooks.timed(|| unsafe { easy::perform(curl) });
+        let started = measure_wait.then(std::time::Instant::now);
+        let code = unsafe { easy::perform(curl) };
+        let callback_ns = crate::callbacks::finish_transfer(measure_wait);
+        if let Some(started) = started {
+            let elapsed = started.elapsed().as_nanos().min(u64::MAX as u128) as u64;
+            hooks.note_wait_excluding(elapsed, callback_ns);
+        }
         let mut guard = handles::lock_recover(handles::handles());
         let Some(entry) = guard.get_mut(&id) else {
             return 0;
@@ -991,7 +998,6 @@ pub extern "C" fn elephc_curl_easy_upkeep(id: i64) -> i32 {
             return 0;
         };
         let hooks = crate::monitoring::hooks();
-        hooks.note_operation();
         (hooks.timed(|| unsafe { easy::upkeep(entry.curl) }) == easy::CURLE_OK) as i32
     })
 }
@@ -1412,6 +1418,11 @@ pub(crate) unsafe fn refresh_monitor_traceparent(entry: &mut EasyEntry) {
     let Some(list) = (unsafe { build_slist(&headers) }) else {
         return;
     };
+    // An easy handle may already be attached to a multi handle here. Attachment does
+    // not start a transfer or make its options immutable: this refresh runs before
+    // `curl_multi_perform`, while neither libcurl nor a callback can be walking the old
+    // list. The accepted replacement becomes the live option before the old owned list
+    // is freed below.
     let code = unsafe { easy::setopt_slist(entry.curl, easy::CURLOPT_HTTPHEADER, list) };
     if code != easy::CURLE_OK {
         unsafe { easy::slist_free_all(list) };

--- a/crates/elephc-curl/src/abi.rs
+++ b/crates/elephc-curl/src/abi.rs
@@ -400,6 +400,10 @@ pub unsafe extern "C" fn elephc_curl_easy_setopt_slist(
         if let Some(previous) = entry.slists.insert(opt, list) {
             unsafe { easy::slist_free_all(previous) };
         }
+        if opt == easy::CURLOPT_HTTPHEADER {
+            entry.user_http_headers = Some(items.iter().map(|item| item.to_vec()).collect());
+            entry.applied_traceparent = None;
+        }
         1
     })
 }
@@ -518,6 +522,7 @@ pub extern "C" fn elephc_curl_easy_perform(id: i64) -> i32 {
             let Some(entry) = guard.get_mut(&id) else {
                 return 0;
             };
+            unsafe { refresh_monitor_traceparent(entry) };
             entry.body.clear();
             entry.callback_threw = false;
             // Opens a fresh callback-throw scope: the process-wide gate that suppresses
@@ -528,12 +533,14 @@ pub extern "C" fn elephc_curl_easy_perform(id: i64) -> i32 {
             entry.error_buf.iter_mut().for_each(|byte| *byte = 0);
             entry.curl
         };
+        let hooks = crate::monitoring::hooks();
+        hooks.note_operation();
         // The table lock is NOT held across the blocking transfer: the write
         // callback (crate::php_layer::write_callback) re-locks the table
         // per chunk from the same thread, which would deadlock on a
         // non-reentrant `Mutex` otherwise. See this function's doc comment
         // for the resulting caller contract (no concurrent calls on `id`).
-        let code = unsafe { easy::perform(curl) };
+        let code = hooks.timed(|| unsafe { easy::perform(curl) });
         let mut guard = handles::lock_recover(handles::handles());
         let Some(entry) = guard.get_mut(&id) else {
             return 0;
@@ -983,7 +990,9 @@ pub extern "C" fn elephc_curl_easy_upkeep(id: i64) -> i32 {
         let Some(entry) = guard.get(&id) else {
             return 0;
         };
-        (unsafe { easy::upkeep(entry.curl) } == easy::CURLE_OK) as i32
+        let hooks = crate::monitoring::hooks();
+        hooks.note_operation();
+        (hooks.timed(|| unsafe { easy::upkeep(entry.curl) }) == easy::CURLE_OK) as i32
     })
 }
 
@@ -1073,7 +1082,14 @@ pub extern "C" fn elephc_curl_easy_duphandle(id: i64) -> i64 {
             let slist_items: Vec<(i32, Vec<Vec<u8>>)> = source
                 .slists
                 .iter()
-                .map(|(&opt, &list)| (opt, unsafe { easy::read_slist(list) }))
+                .map(|(&opt, &list)| {
+                    let items = if opt == easy::CURLOPT_HTTPHEADER {
+                        source.user_http_headers.clone().unwrap_or_default()
+                    } else {
+                        unsafe { easy::read_slist(list) }
+                    };
+                    (opt, items)
+                })
                 .collect();
             let copied = unsafe { easy::duphandle(source.curl) };
             if copied.is_null() {
@@ -1170,6 +1186,9 @@ pub extern "C" fn elephc_curl_easy_duphandle(id: i64) -> i64 {
             let code = unsafe { easy::setopt_slist(copied, opt as c_int, rebuilt) };
             if code == easy::CURLE_OK {
                 entry.slists.insert(opt, rebuilt);
+                if opt == easy::CURLOPT_HTTPHEADER {
+                    entry.user_http_headers = Some(items);
+                }
             } else {
                 unsafe {
                     easy::slist_free_all(rebuilt);
@@ -1315,6 +1334,131 @@ unsafe fn build_slist(items: &[impl AsRef<[u8]>]) -> Option<*mut easy::CurlSlist
         }
     }
     Some(list)
+}
+
+/// Returns whether a user header explicitly owns the traceparent field.
+fn is_traceparent_header(header: &[u8]) -> bool {
+    let Some(delimiter) = header
+        .iter()
+        .position(|byte| matches!(*byte, b':' | b';'))
+    else {
+        return false;
+    };
+    let name = &header[..delimiter];
+    let start = name
+        .iter()
+        .position(|byte| !byte.is_ascii_whitespace())
+        .unwrap_or(name.len());
+    let end = name
+        .iter()
+        .rposition(|byte| !byte.is_ascii_whitespace())
+        .map_or(start, |index| index + 1);
+    name[start..end].eq_ignore_ascii_case(b"traceparent")
+}
+
+/// Builds the effective HTTP header list and reports the automatic trace value
+/// represented by it. An explicit user traceparent always wins.
+#[cfg(test)]
+fn effective_http_headers(
+    user_headers: &[Vec<u8>],
+    traceparent: Option<String>,
+) -> (Vec<Vec<u8>>, Option<String>) {
+    let injected = automatic_traceparent(user_headers, traceparent);
+    let mut effective = user_headers.to_vec();
+    if let Some(value) = injected.as_deref() {
+        let mut header = b"traceparent: ".to_vec();
+        header.extend_from_slice(value.as_bytes());
+        effective.push(header);
+    }
+    (effective, injected)
+}
+
+/// Resolves the automatic trace value after applying user-header precedence.
+fn automatic_traceparent(
+    user_headers: &[Vec<u8>],
+    traceparent: Option<String>,
+) -> Option<String> {
+    if user_headers
+        .iter()
+        .any(|header| is_traceparent_header(header))
+    {
+        None
+    } else {
+        traceparent
+    }
+}
+
+/// Refreshes the automatic traceparent on an easy handle before a transfer.
+///
+/// The applied slist is rebuilt only when the propagated value changes. User
+/// headers remain authoritative, and a failed allocation or setopt leaves the
+/// previous live list untouched.
+///
+/// # Safety
+/// `entry.curl` must be a live easy handle, and no transfer may be using its
+/// current HTTP header list concurrently.
+pub(crate) unsafe fn refresh_monitor_traceparent(entry: &mut EasyEntry) {
+    let user_headers = entry.user_http_headers.as_deref().unwrap_or(&[]);
+    let injected = automatic_traceparent(user_headers, crate::monitoring::traceparent());
+    if entry.applied_traceparent == injected {
+        return;
+    }
+    let mut headers = user_headers.to_vec();
+    if let Some(value) = injected.as_deref() {
+        let mut header = b"traceparent: ".to_vec();
+        header.extend_from_slice(value.as_bytes());
+        headers.push(header);
+    }
+    let Some(list) = (unsafe { build_slist(&headers) }) else {
+        return;
+    };
+    let code = unsafe { easy::setopt_slist(entry.curl, easy::CURLOPT_HTTPHEADER, list) };
+    if code != easy::CURLE_OK {
+        unsafe { easy::slist_free_all(list) };
+        return;
+    }
+    if let Some(previous) = entry.slists.insert(easy::CURLOPT_HTTPHEADER, list) {
+        unsafe { easy::slist_free_all(previous) };
+    }
+    entry.applied_traceparent = injected;
+}
+
+#[cfg(test)]
+mod monitoring_header_tests {
+    use super::{effective_http_headers, is_traceparent_header};
+
+    /// Verifies traceparent header-name matching is whitespace tolerant and
+    /// case insensitive without accepting similarly prefixed names.
+    #[test]
+    fn detects_explicit_traceparent_headers() {
+        assert!(is_traceparent_header(b"TraceParent: 00-value"));
+        assert!(is_traceparent_header(b" traceparent :"));
+        assert!(is_traceparent_header(b"traceparent;"));
+        assert!(!is_traceparent_header(b"x-traceparent: value"));
+        assert!(!is_traceparent_header(b"traceparent"));
+    }
+
+    /// Verifies automatic propagation appends one header while preserving the
+    /// original user header sequence.
+    #[test]
+    fn appends_automatic_traceparent() {
+        let user = vec![b"accept: application/json".to_vec()];
+        let trace = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01".to_owned();
+        let (headers, injected) = effective_http_headers(&user, Some(trace.clone()));
+        assert_eq!(injected, Some(trace.clone()));
+        assert_eq!(headers[0], user[0]);
+        assert_eq!(headers[1], format!("traceparent: {trace}").into_bytes());
+    }
+
+    /// Verifies an explicit user traceparent suppresses automatic propagation.
+    #[test]
+    fn preserves_explicit_traceparent() {
+        let user = vec![b"TRACEPARENT: user-value".to_vec()];
+        let automatic = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01".to_owned();
+        let (headers, injected) = effective_http_headers(&user, Some(automatic));
+        assert_eq!(headers, user);
+        assert_eq!(injected, None);
+    }
 }
 
 /// Applies `CURLOPT_POSTFIELDS` as libcurl's copying, length-aware pair:

--- a/crates/elephc-curl/src/callbacks.rs
+++ b/crates/elephc-curl/src/callbacks.rs
@@ -43,8 +43,10 @@
 //!   a throw with `curl_errno() === 0`). The runtime re-raises the pending exception
 //!   once `curl_easy_perform` has returned.
 
+use std::cell::{Cell, RefCell};
 use std::ffi::{c_char, c_int, c_void};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
 
 use crate::easy::{self, CURL};
 use crate::handles::{self, EasyEntry};
@@ -198,7 +200,12 @@ unsafe fn invoke(
     // SAFETY: the address came from `__elephc_curl_adapter_addr()`, whose only possible
     // value is the codegen adapter emitted with exactly this signature.
     let adapter: CallbackAdapter = std::mem::transmute(slot.adapter);
+    let started = callback_timing_active().then(Instant::now);
     let result = adapter(slot.descriptor, slot.self_obj, &mut spec);
+    if let Some(started) = started {
+        let elapsed = started.elapsed().as_nanos().min(u64::MAX as u128) as u64;
+        note_callback_time(elapsed);
+    }
     (result, spec.out_len, spec.status != 0)
 }
 
@@ -218,6 +225,13 @@ unsafe fn invoke(
 /// (`__rt_curl_multi_exec`) is handed a MULTI id and the flag is raised on an EASY one;
 /// compiled PHP is effectively single-threaded, so at most one transfer is in flight.
 static CALLBACK_THREW: AtomicBool = AtomicBool::new(false);
+
+thread_local! {
+    /// Per-transfer PHP callback time, nested so a callback may run curl on another handle.
+    static CALLBACK_TIMING: RefCell<Vec<u64>> = const { RefCell::new(Vec::new()) };
+    /// Inactive nested transfers suppress an active outer scope without allocating.
+    static CALLBACK_TIMING_SUPPRESSED: Cell<u32> = const { Cell::new(0) };
+}
 
 /// Reads the slot at `index` for `id` out of the handle table and drops the guard.
 /// Returns `None` for an unknown id, an empty slot, or a moment at which a PHP callback
@@ -260,8 +274,39 @@ fn take_slot(id: i64, index: usize) -> Option<CallbackSlot> {
 /// re-raise hook normally consumes the flag the moment either returns, so this is belt and
 /// braces — but it is what guarantees the flag can never wedge a later transfer if the
 /// bridge is ever driven without that hook.
-pub(crate) fn begin_transfer() {
+pub(crate) fn begin_transfer(measure_callback_time: bool) {
     CALLBACK_THREW.store(false, Ordering::SeqCst);
+    if measure_callback_time {
+        CALLBACK_TIMING.with(|timing| timing.borrow_mut().push(0));
+    } else {
+        CALLBACK_TIMING_SUPPRESSED.with(|depth| depth.set(depth.get().saturating_add(1)));
+    }
+}
+
+/// Closes the current transfer timing scope and returns PHP callback nanoseconds.
+pub(crate) fn finish_transfer(measure_callback_time: bool) -> u64 {
+    if measure_callback_time {
+        CALLBACK_TIMING.with(|timing| timing.borrow_mut().pop().unwrap_or(0))
+    } else {
+        CALLBACK_TIMING_SUPPRESSED.with(|depth| depth.set(depth.get().saturating_sub(1)));
+        0
+    }
+}
+
+/// Returns whether the current transfer needs PHP callback timing.
+fn callback_timing_active() -> bool {
+    CALLBACK_TIMING_SUPPRESSED.with(|suppressed| {
+        suppressed.get() == 0 && CALLBACK_TIMING.with(|timing| !timing.borrow().is_empty())
+    })
+}
+
+/// Adds one completed PHP callback duration to the current transfer scope.
+fn note_callback_time(ns: u64) {
+    CALLBACK_TIMING.with(|timing| {
+        if let Some(total) = timing.borrow_mut().last_mut() {
+            *total = total.saturating_add(ns);
+        }
+    });
 }
 
 /// Records that a PHP callback threw: process-wide, which is what suppresses further
@@ -611,4 +656,44 @@ pub(crate) fn clear_all(entry: &mut EasyEntry) {
     entry.write_user = false;
     // SAFETY: as in `apply_callback`.
     unsafe { apply_registration(entry.curl, entry.id, &entry.callbacks) };
+}
+
+#[cfg(test)]
+mod timing_tests {
+    use super::{
+        begin_transfer, callback_timing_active, finish_transfer, note_callback_time,
+    };
+
+    /// Nested curl calls keep their own callback exclusions without erasing the caller's.
+    #[test]
+    fn callback_timing_scopes_are_nested() {
+        begin_transfer(true);
+        note_callback_time(40);
+        begin_transfer(true);
+        note_callback_time(7);
+        assert_eq!(finish_transfer(true), 7);
+        note_callback_time(3);
+        assert_eq!(finish_transfer(true), 43);
+    }
+
+    /// Dormant transfers retain no callback duration and still balance their scope.
+    #[test]
+    fn dormant_callback_timing_is_inert() {
+        begin_transfer(false);
+        note_callback_time(99);
+        assert_eq!(finish_transfer(false), 0);
+    }
+
+    /// An inactive nested transfer cannot leak callback time into its active caller.
+    #[test]
+    fn dormant_nested_transfer_suppresses_outer_callback_timing() {
+        begin_transfer(true);
+        assert!(callback_timing_active());
+        begin_transfer(false);
+        assert!(!callback_timing_active());
+        assert_eq!(finish_transfer(false), 0);
+        assert!(callback_timing_active());
+        note_callback_time(11);
+        assert_eq!(finish_transfer(true), 11);
+    }
 }

--- a/crates/elephc-curl/src/easy.rs
+++ b/crates/elephc-curl/src/easy.rs
@@ -44,6 +44,10 @@ pub(crate) const CURL_ERROR_SIZE: usize = 256;
 
 /// `CURLOPT_URL` (10002): the request URL. `CURLOPTTYPE_STRINGPOINT`.
 pub(crate) const CURLOPT_URL: c_int = 10002;
+/// `CURLOPT_HTTPHEADER` (10023): the caller-owned request header list.
+/// Monitoring may rebuild this list immediately before a transfer to add a
+/// validated traceparent while preserving all user-provided headers.
+pub(crate) const CURLOPT_HTTPHEADER: c_int = 10023;
 /// `CURLOPT_ERRORBUFFER` (10010): a caller-owned `>= CURL_ERROR_SIZE` byte
 /// buffer libcurl writes a human-readable error message into. Internal only;
 /// never PHP-visible (PHP surfaces this through `curl_error()` instead).

--- a/crates/elephc-curl/src/handles.rs
+++ b/crates/elephc-curl/src/handles.rs
@@ -72,6 +72,14 @@ pub(crate) struct EasyEntry {
     /// replacement, and `free_slists` releases whatever is left when the
     /// handle is reset or cleaned up.
     pub(crate) slists: HashMap<i32, *mut CurlSlist>,
+    /// The HTTP headers supplied by the PHP program, excluding any temporary
+    /// monitoring trace header. Keeping this source list separate lets the
+    /// bridge refresh or remove automatic propagation without losing user
+    /// headers or copying an injected header into duplicated handles.
+    pub(crate) user_http_headers: Option<Vec<Vec<u8>>>,
+    /// The traceparent value currently injected into `CURLOPT_HTTPHEADER`.
+    /// `None` means the applied list contains only user-provided headers.
+    pub(crate) applied_traceparent: Option<String>,
     /// A borrowed-until-overwritten byte buffer for the string-shaped operations
     /// (`curl_getinfo()`'s string/list/array forms, and Wave D's
     /// `curl_escape`/`curl_unescape`), the same convention `taken_body` uses for
@@ -194,6 +202,8 @@ impl EasyEntry {
             last_errno: 0,
             last_error: Vec::new(),
             slists: HashMap::new(),
+            user_http_headers: None,
+            applied_traceparent: None,
             scratch: Vec::new(),
             share_id: None,
             mime: None,
@@ -216,6 +226,8 @@ impl EasyEntry {
             // is freed, so no double free is reachable.
             unsafe { easy::slist_free_all(list) };
         }
+        self.user_http_headers = None;
+        self.applied_traceparent = None;
     }
 
     /// Frees this handle's ATTACHED and PENDING `curl_mime` structures (if any) and forgets

--- a/crates/elephc-curl/src/lib.rs
+++ b/crates/elephc-curl/src/lib.rs
@@ -42,6 +42,7 @@ mod handles;
 mod info;
 mod mime;
 mod multi;
+mod monitoring;
 mod options;
 mod php_layer;
 mod share;

--- a/crates/elephc-curl/src/monitoring.rs
+++ b/crates/elephc-curl/src/monitoring.rs
@@ -1,0 +1,49 @@
+//! Purpose:
+//! Connects curl transfer boundaries to elephc's pay-for-use network monitoring slots.
+//!
+//! Called from:
+//! - `crate::abi` for easy transfers and connection upkeep.
+//! - `crate::multi` for multi-handle progress and blocking selection.
+//!
+//! Key details:
+//! - Slot reads are inert unless a monitor capture is active right now.
+//! - Trace context is read only through the validated shared contract helper.
+
+use elephc_monitoring_contract::{active_traceparent, EventHooks};
+
+extern "C" {
+    static elephc_instr_network_fn: usize;
+    static elephc_instr_network_wait_fn: usize;
+    static elephc_monitor_active: u64;
+}
+
+/// Reads the network-event slots published by the compiled runtime.
+pub(crate) fn hooks() -> EventHooks {
+    EventHooks::new(
+        active(),
+        unsafe { std::ptr::addr_of!(elephc_instr_network_fn).read() },
+        unsafe { std::ptr::addr_of!(elephc_instr_network_wait_fn).read() },
+    )
+}
+
+/// Returns whether a monitor capture is active right now.
+pub(crate) fn active() -> bool {
+    unsafe { std::ptr::addr_of!(elephc_monitor_active).read() != 0 }
+}
+
+/// Returns the current validated traceparent only while monitoring is active.
+pub(crate) fn traceparent() -> Option<String> {
+    active_traceparent(active())
+}
+
+// Standalone bridge tests do not link a compiled elephc runtime, so they provide
+// inert slots in their own executable. Production staticlibs never define them.
+#[cfg(test)]
+mod slot_stub {
+    #[no_mangle]
+    static elephc_instr_network_fn: usize = 0;
+    #[no_mangle]
+    static elephc_instr_network_wait_fn: usize = 0;
+    #[no_mangle]
+    static elephc_monitor_active: u64 = 0;
+}

--- a/crates/elephc-curl/src/monitoring.rs
+++ b/crates/elephc-curl/src/monitoring.rs
@@ -38,6 +38,12 @@ pub(crate) fn traceparent() -> Option<String> {
     active_traceparent(active())
 }
 
+/// Sets the standalone test runtime's exact-monitor activity flag.
+#[cfg(all(test, elephc_curl_native))]
+pub(crate) fn set_test_active(active: bool) {
+    slot_stub::set_active(active);
+}
+
 // Standalone bridge tests do not link a compiled elephc runtime, so they provide
 // inert slots in their own executable. Production staticlibs never define them.
 #[cfg(test)]
@@ -49,5 +55,13 @@ mod slot_stub {
     #[no_mangle]
     static elephc_instr_network_wait_fn: usize = 0;
     #[no_mangle]
-    static elephc_monitor_active: u64 = 0;
+    static mut elephc_monitor_active: u64 = 0;
+
+    /// Updates the test-only activity symbol read by the production helper.
+    #[cfg(elephc_curl_native)]
+    pub(super) fn set_active(active: bool) {
+        unsafe {
+            std::ptr::addr_of_mut!(elephc_monitor_active).write(u64::from(active));
+        }
+    }
 }

--- a/crates/elephc-curl/src/monitoring.rs
+++ b/crates/elephc-curl/src/monitoring.rs
@@ -12,6 +12,7 @@
 use elephc_monitoring_contract::{active_traceparent, EventHooks};
 
 extern "C" {
+    static elephc_monitor_event_active_fn: usize;
     static elephc_instr_network_fn: usize;
     static elephc_instr_network_wait_fn: usize;
     static elephc_monitor_active: u64;
@@ -21,6 +22,7 @@ extern "C" {
 pub(crate) fn hooks() -> EventHooks {
     EventHooks::new(
         active(),
+        unsafe { std::ptr::addr_of!(elephc_monitor_event_active_fn).read() },
         unsafe { std::ptr::addr_of!(elephc_instr_network_fn).read() },
         unsafe { std::ptr::addr_of!(elephc_instr_network_wait_fn).read() },
     )
@@ -40,6 +42,8 @@ pub(crate) fn traceparent() -> Option<String> {
 // inert slots in their own executable. Production staticlibs never define them.
 #[cfg(test)]
 mod slot_stub {
+    #[no_mangle]
+    static elephc_monitor_event_active_fn: usize = 0;
     #[no_mangle]
     static elephc_instr_network_fn: usize = 0;
     #[no_mangle]

--- a/crates/elephc-curl/src/multi.rs
+++ b/crates/elephc-curl/src/multi.rs
@@ -36,7 +36,7 @@
 //!   for the same reason: without it, a handle reused across two multi runs would
 //!   report the concatenation of both bodies from `curl_multi_getcontent()`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ffi::{c_char, c_int, c_long, c_uint, c_void};
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::{Mutex, OnceLock};
@@ -146,6 +146,10 @@ pub(crate) struct MultiEntry {
     /// Used ONLY to detach them before `curl_multi_cleanup`; the PHP-visible
     /// add-order list lives on the `CurlMultiHandle` object.
     attached: Vec<i64>,
+    /// Easy handles already counted as network operations for their current
+    /// attachment. Completion or removal clears the id so a later transfer is
+    /// counted independently.
+    monitored_easy: HashSet<i64>,
     /// The `CURLMcode` from the most recent multi operation on this handle,
     /// backing PHP's `curl_multi_errno()`.
     last_errno: CURLMcode,
@@ -268,6 +272,7 @@ pub extern "C" fn elephc_curl_multi_init() -> i64 {
             MultiEntry {
                 multi,
                 attached: Vec::new(),
+                monitored_easy: HashSet::new(),
                 last_errno: CURLM_OK,
                 last_message: InfoMessage::default(),
             },
@@ -330,6 +335,7 @@ pub extern "C" fn elephc_curl_multi_remove(multi_id: i64, easy_id: i64) -> i32 {
         entry.last_errno = code;
         if code == CURLM_OK {
             entry.attached.retain(|&id| id != easy_id);
+            entry.monitored_easy.remove(&easy_id);
         }
         code
     })
@@ -351,13 +357,30 @@ pub extern "C" fn elephc_curl_multi_remove(multi_id: i64, easy_id: i64) -> i32 {
 #[no_mangle]
 pub extern "C" fn elephc_curl_multi_perform(multi_id: i64) -> i64 {
     handles::ffi_guard(pack_perform(0, CURLM_BAD_HANDLE), || {
-        let multi = {
-            let guard = handles::lock_recover(multis());
-            let Some(entry) = guard.get(&multi_id) else {
+        let (multi, attached, new_operations) = {
+            let mut guard = handles::lock_recover(multis());
+            let Some(entry) = guard.get_mut(&multi_id) else {
                 return pack_perform(0, CURLM_BAD_HANDLE);
             };
-            entry.multi
+            let attached = entry.attached.clone();
+            let new_operations = attached
+                .iter()
+                .filter(|easy_id| entry.monitored_easy.insert(**easy_id))
+                .count();
+            (entry.multi, attached, new_operations)
         };
+        {
+            let mut guard = handles::lock_recover(handles::handles());
+            for easy_id in attached {
+                if let Some(entry) = guard.get_mut(&easy_id) {
+                    unsafe { crate::abi::refresh_monitor_traceparent(entry) };
+                }
+            }
+        }
+        let hooks = crate::monitoring::hooks();
+        for _ in 0..new_operations {
+            hooks.note_operation();
+        }
         // Opens a fresh callback-throw scope, exactly as `elephc_curl_easy_perform` does.
         // Without it the process-wide gate raised by a throw in an EARLIER
         // `curl_multi_exec()` call would still be set here and would silently suppress
@@ -403,7 +426,8 @@ pub extern "C" fn elephc_curl_multi_select(multi_id: i64, timeout_ms: i64) -> i3
         // while never handing libcurl a truncated wrap-around.
         let timeout = timeout_ms.clamp(c_int::MIN as i64, c_int::MAX as i64) as c_int;
         let mut numfds: c_int = 0;
-        let code = unsafe {
+        let hooks = crate::monitoring::hooks();
+        let code = hooks.timed(|| unsafe {
             curl_multi_wait(
                 multi,
                 std::ptr::null_mut(),
@@ -411,7 +435,7 @@ pub extern "C" fn elephc_curl_multi_select(multi_id: i64, timeout_ms: i64) -> i3
                 timeout,
                 &mut numfds as *mut c_int,
             )
-        };
+        });
         record_errno(multi_id, code);
         if code != CURLM_OK {
             return -1;
@@ -483,6 +507,9 @@ pub extern "C" fn elephc_curl_multi_info_read(multi_id: i64, field: i64) -> i64 
         let Some(entry) = guard.get_mut(&multi_id) else {
             return 0;
         };
+        if easy_id != 0 {
+            entry.monitored_easy.remove(&easy_id);
+        }
         entry.last_message = InfoMessage {
             // libcurl's own `msg` verbatim, exactly as php-src's `add_assoc_long(…, "msg",
             // tmp_msg->msg)` reports it. `CURLMSG_DONE` is the only value libcurl has ever

--- a/crates/elephc-curl/src/multi.rs
+++ b/crates/elephc-curl/src/multi.rs
@@ -147,8 +147,8 @@ pub(crate) struct MultiEntry {
     /// add-order list lives on the `CurlMultiHandle` object.
     attached: Vec<i64>,
     /// Easy handles already counted as network operations for their current
-    /// attachment. Completion or removal clears the id so a later transfer is
-    /// counted independently.
+    /// attachment. Only removal clears the id, because reading a completion
+    /// message does not detach the handle from libcurl.
     monitored_easy: HashSet<i64>,
     /// The `CURLMcode` from the most recent multi operation on this handle,
     /// backing PHP's `curl_multi_errno()`.
@@ -169,6 +169,14 @@ unsafe impl Send for MultiEntry {}
 fn multis() -> &'static Mutex<HashMap<i64, MultiEntry>> {
     static MULTIS: OnceLock<Mutex<HashMap<i64, MultiEntry>>> = OnceLock::new();
     MULTIS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Reports whether a test fixture's easy attachment has already emitted its operation.
+#[cfg(all(test, elephc_curl_native))]
+pub(crate) fn test_operation_was_counted(multi_id: i64, easy_id: i64) -> bool {
+    handles::lock_recover(multis())
+        .get(&multi_id)
+        .is_some_and(|entry| entry.monitored_easy.contains(&easy_id))
 }
 
 /// Allocates the next multi id. Monotonic, positive, never reused.
@@ -357,26 +365,28 @@ pub extern "C" fn elephc_curl_multi_remove(multi_id: i64, easy_id: i64) -> i32 {
 #[no_mangle]
 pub extern "C" fn elephc_curl_multi_perform(multi_id: i64) -> i64 {
     handles::ffi_guard(pack_perform(0, CURLM_BAD_HANDLE), || {
-        let (multi, attached, new_operations) = {
-            let mut guard = handles::lock_recover(multis());
-            let Some(entry) = guard.get_mut(&multi_id) else {
+        let (multi, new_operations) = {
+            // Lock easy handles before the multi table. This order lets trace headers be
+            // refreshed in place without cloning `attached`, and matches every path that
+            // needs both tables. Neither guard survives into libcurl, whose callbacks
+            // re-enter the easy table.
+            let mut easy_guard = handles::lock_recover(handles::handles());
+            let mut multi_guard = handles::lock_recover(multis());
+            let Some(entry) = multi_guard.get_mut(&multi_id) else {
                 return pack_perform(0, CURLM_BAD_HANDLE);
             };
-            let attached = entry.attached.clone();
-            let new_operations = attached
+            for easy_id in &entry.attached {
+                if let Some(easy_entry) = easy_guard.get_mut(easy_id) {
+                    unsafe { crate::abi::refresh_monitor_traceparent(easy_entry) };
+                }
+            }
+            let new_operations = entry
+                .attached
                 .iter()
                 .filter(|easy_id| entry.monitored_easy.insert(**easy_id))
                 .count();
-            (entry.multi, attached, new_operations)
+            (entry.multi, new_operations)
         };
-        {
-            let mut guard = handles::lock_recover(handles::handles());
-            for easy_id in attached {
-                if let Some(entry) = guard.get_mut(&easy_id) {
-                    unsafe { crate::abi::refresh_monitor_traceparent(entry) };
-                }
-            }
-        }
         let hooks = crate::monitoring::hooks();
         for _ in 0..new_operations {
             hooks.note_operation();
@@ -385,9 +395,10 @@ pub extern "C" fn elephc_curl_multi_perform(multi_id: i64) -> i64 {
         // Without it the process-wide gate raised by a throw in an EARLIER
         // `curl_multi_exec()` call would still be set here and would silently suppress
         // every callback on every attached handle for the rest of the program.
-        crate::callbacks::begin_transfer();
+        crate::callbacks::begin_transfer(false);
         let mut running: c_int = 0;
         let code = unsafe { curl_multi_perform(multi, &mut running as *mut c_int) };
+        let _ = crate::callbacks::finish_transfer(false);
         record_errno(multi_id, code);
         pack_perform(running.max(0) as i64, code)
     })
@@ -507,9 +518,6 @@ pub extern "C" fn elephc_curl_multi_info_read(multi_id: i64, field: i64) -> i64 
         let Some(entry) = guard.get_mut(&multi_id) else {
             return 0;
         };
-        if easy_id != 0 {
-            entry.monitored_easy.remove(&easy_id);
-        }
         entry.last_message = InfoMessage {
             // libcurl's own `msg` verbatim, exactly as php-src's `add_assoc_long(…, "msg",
             // tmp_msg->msg)` reports it. `CURLMSG_DONE` is the only value libcurl has ever

--- a/crates/elephc-curl/src/tests.rs
+++ b/crates/elephc-curl/src/tests.rs
@@ -771,7 +771,7 @@ mod native {
         elephc_curl_easy_setopt_slist, elephc_curl_easy_setopt_str, elephc_curl_easy_take_body,
         elephc_curl_global_info, elephc_curl_version_abi,
     };
-    use crate::handles;
+    use crate::{easy, handles, monitoring};
     use crate::php_layer::CURLOPT_RETURNTRANSFER;
 
     /// Whether `id` is currently present in the shared handle table. Used
@@ -780,6 +780,91 @@ mod native {
     /// same process-wide table.
     fn handle_exists(id: i64) -> bool {
         handles::lock_recover(handles::handles()).contains_key(&id)
+    }
+
+    /// Exercises automatic trace injection, removal, and user precedence through the
+    /// real handle table and libcurl slist path used immediately before a transfer.
+    #[test]
+    fn perform_refreshes_the_real_traceparent_slist() {
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        const TRACE: &str =
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        const CURLOPT_HTTPHEADER: i32 = 10_023;
+        let _environment = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let previous = std::env::var_os("ELEPHC_TRACEPARENT");
+        unsafe { std::env::set_var("ELEPHC_TRACEPARENT", TRACE) };
+
+        let id = elephc_curl_easy_init();
+        assert_ne!(id, 0);
+        let url = b"file:///dev/null";
+        assert_eq!(
+            unsafe { elephc_curl_easy_set_url(id, url.as_ptr(), url.len()) },
+            1
+        );
+
+        monitoring::set_test_active(true);
+        assert_eq!(elephc_curl_easy_perform(id), 1);
+        {
+            let guard = handles::lock_recover(handles::handles());
+            let entry = guard.get(&id).expect("live handle");
+            assert_eq!(entry.applied_traceparent.as_deref(), Some(TRACE));
+            let list = *entry
+                .slists
+                .get(&CURLOPT_HTTPHEADER)
+                .expect("automatic HTTP header list");
+            assert_eq!(
+                unsafe { easy::read_slist(list) },
+                vec![format!("traceparent: {TRACE}").into_bytes()]
+            );
+        }
+
+        monitoring::set_test_active(false);
+        assert_eq!(elephc_curl_easy_perform(id), 1);
+        {
+            let guard = handles::lock_recover(handles::handles());
+            let entry = guard.get(&id).expect("live handle");
+            assert_eq!(entry.applied_traceparent, None);
+            let list = *entry
+                .slists
+                .get(&CURLOPT_HTTPHEADER)
+                .expect("cleared HTTP header list");
+            assert!(unsafe { easy::read_slist(list) }.is_empty());
+        }
+
+        let user_header = b"TraceParent: user-owned\0";
+        assert_eq!(
+            unsafe {
+                elephc_curl_easy_setopt_slist(
+                    id,
+                    CURLOPT_HTTPHEADER,
+                    user_header.as_ptr(),
+                    user_header.len(),
+                )
+            },
+            1
+        );
+        monitoring::set_test_active(true);
+        assert_eq!(elephc_curl_easy_perform(id), 1);
+        {
+            let guard = handles::lock_recover(handles::handles());
+            let entry = guard.get(&id).expect("live handle");
+            assert_eq!(entry.applied_traceparent, None);
+            let list = *entry
+                .slists
+                .get(&CURLOPT_HTTPHEADER)
+                .expect("user HTTP header list");
+            assert_eq!(
+                unsafe { easy::read_slist(list) },
+                vec![b"TraceParent: user-owned".to_vec()]
+            );
+        }
+
+        monitoring::set_test_active(false);
+        elephc_curl_easy_free(id);
+        match previous {
+            Some(value) => unsafe { std::env::set_var("ELEPHC_TRACEPARENT", value) },
+            None => unsafe { std::env::remove_var("ELEPHC_TRACEPARENT") },
+        }
     }
 
     /// `elephc_curl_easy_init`/`elephc_curl_easy_free` leave the
@@ -1716,7 +1801,7 @@ mod native_multi {
         elephc_curl_multi_remove, elephc_curl_multi_select, elephc_curl_multi_setopt,
         elephc_curl_multi_strerror, INFO_FIELD_ADVANCE, INFO_FIELD_EASY_ID, INFO_FIELD_MSG,
         INFO_FIELD_QUEUED, INFO_FIELD_RESULT, MULTI_SETOPT_APPLIED, MULTI_SETOPT_INVALID,
-        MULTI_SETOPT_UNSUPPORTED,
+        MULTI_SETOPT_UNSUPPORTED, test_operation_was_counted,
     };
     use crate::php_layer::CURLOPT_RETURNTRANSFER;
 
@@ -1785,6 +1870,7 @@ mod native_multi {
             guard += 1;
         }
         assert_eq!(running, 0, "the transfer must finish");
+        assert!(test_operation_was_counted(multi, easy));
 
         assert_eq!(
             elephc_curl_multi_info_read(multi, INFO_FIELD_ADVANCE),
@@ -1804,6 +1890,13 @@ mod native_multi {
             0,
             "the queue is drained after one message"
         );
+        assert!(
+            test_operation_was_counted(multi, easy),
+            "reading completion must not make an attached transfer count again"
+        );
+        let packed = elephc_curl_multi_perform(multi);
+        assert_eq!((packed & 0xFFFF_FFFF) as u32 as i32, 0);
+        assert!(test_operation_was_counted(multi, easy));
 
         let mut body_ptr: *mut u8 = std::ptr::null_mut();
         let mut body_len = 0usize;
@@ -1818,6 +1911,7 @@ mod native_multi {
         assert_eq!(second_len, body_len, "the capture buffer survives being read");
 
         assert_eq!(elephc_curl_multi_remove(multi, easy), 0);
+        assert!(!test_operation_was_counted(multi, easy));
         elephc_curl_multi_free(multi);
         elephc_curl_easy_free(easy);
         std::fs::remove_dir_all(&dir).ok();

--- a/crates/elephc-instr/src/lib.rs
+++ b/crates/elephc-instr/src/lib.rs
@@ -108,6 +108,10 @@ struct FnAcc {
     /// Self time minus this wait is an unclassified non-DB remainder.
     incl_wait: u64,
     excl_wait: u64,
+    /// Outgoing network operations attributed directly to the active function.
+    network_ops: u64,
+    /// Nanoseconds blocked in outgoing network work by the active function.
+    network_wait: u64,
     /// Live activations on the stack — inclusive is credited only when this
     /// returns to zero, so recursion is not double counted.
     depth: u32,
@@ -972,6 +976,26 @@ impl State {
         }
     }
 
+    /// Attributes one outgoing network operation to the active PHP function.
+    fn note_network(&mut self) {
+        let Some(id) = self.stack.last().map(|frame| frame.id) else {
+            return;
+        };
+        if let Some(acc) = self.fns.get_mut(id as usize) {
+            acc.network_ops = acc.network_ops.wrapping_add(1);
+        }
+    }
+
+    /// Attributes blocked outgoing-network time to the active PHP function.
+    fn note_network_wait(&mut self, ns: u64) {
+        let Some(id) = self.stack.last().map(|frame| frame.id) else {
+            return;
+        };
+        if let Some(acc) = self.fns.get_mut(id as usize) {
+            acc.network_wait = acc.network_wait.wrapping_add(ns);
+        }
+    }
+
     /// Drops every accumulator so the next dump reports only what follows it.
     /// The live stack is cleared too: a dump happens at a point where nothing
     /// of this slice is still running, and carrying frames across the boundary
@@ -1084,7 +1108,7 @@ impl State {
             let incl_ret = acc.incl_allocs as i64 - acc.incl_frees as i64;
             let excl_ret = acc.excl_allocs as i64 - acc.excl_frees as i64;
             out.push_str(&format!(
-                "elephc-instr: {} calls={} incl_ns={} excl_ns={} incl_allocs={} excl_allocs={} incl_io={} excl_io={} incl_ret={} excl_ret={} incl_wait={} excl_wait={}\n",
+                "elephc-instr: {} calls={} incl_ns={} excl_ns={} incl_allocs={} excl_allocs={} incl_io={} excl_io={} incl_ret={} excl_ret={} incl_wait={} excl_wait={} network_ops={} network_wait={}\n",
                 name_of(id),
                 acc.calls,
                 // Ticks became nanoseconds here, once, rather than twice per
@@ -1099,7 +1123,9 @@ impl State {
                 incl_ret,
                 excl_ret,
                 acc.incl_wait,
-                acc.excl_wait
+                acc.excl_wait,
+                acc.network_ops,
+                acc.network_wait,
             ));
         }
         let mut edges: Vec<(&(u32, u32), &(u64, u64))> = self.edges.iter().collect();
@@ -1158,6 +1184,24 @@ pub extern "C" fn elephc_instr_wait(ns: u64) {
         return;
     }
     WAIT_NS.fetch_add(ns, Ordering::Relaxed);
+}
+
+/// Records one outgoing network operation against the active function.
+#[no_mangle]
+pub extern "C" fn elephc_instr_network() {
+    if !ENABLED.load(Ordering::Relaxed) {
+        return;
+    }
+    STATE.with(|state| state.borrow_mut().note_network());
+}
+
+/// Records blocked outgoing-network nanoseconds against the active function.
+#[no_mangle]
+pub extern "C" fn elephc_instr_network_wait(ns: u64) {
+    if !ENABLED.load(Ordering::Relaxed) {
+        return;
+    }
+    STATE.with(|state| state.borrow_mut().note_network_wait(ns));
 }
 
 /// How many distinct statement shapes one slice may record.
@@ -5106,6 +5150,8 @@ mod tests {
         let mut s = State::default();
         s.enter_sim(0, 0, 0, 0, 0, 0);
         s.enter_sim(1, 0, 0, 0, 0, 0);
+        s.note_network();
+        s.note_network_wait(2_000);
         s.exit_sim(1, 40, 7, 5, 3, 0); // hot: 7 allocs, 5 frees, 3 io ops
         s.exit_sim(0, 50, 8, 5, 3, 0);
         let names = vec!["{main}".to_string(), "hot".to_string()];
@@ -5114,6 +5160,11 @@ mod tests {
         // never freed, so the run retains 3 in total.
         assert!(out.contains("elephc-instr: {main} calls=1 incl_ns=50 excl_ns=10 incl_allocs=8 excl_allocs=1 incl_io=3 excl_io=0 incl_ret=3 excl_ret=1"), "{out}");
         assert!(out.contains("elephc-instr: hot calls=1 incl_ns=40 excl_ns=40 incl_allocs=7 excl_allocs=7 incl_io=3 excl_io=3 incl_ret=2 excl_ret=2"), "{out}");
+        let hot = out
+            .lines()
+            .find(|line| line.starts_with("elephc-instr: hot "))
+            .expect("hot row");
+        assert!(hot.contains("network_ops=1 network_wait=2000"), "{out}");
         assert!(out.contains("elephc-instr-edge: {main} -> hot count=1 ns=40"), "{out}");
     }
 

--- a/crates/elephc-instr/src/lib.rs
+++ b/crates/elephc-instr/src/lib.rs
@@ -108,10 +108,12 @@ struct FnAcc {
     /// Self time minus this wait is an unclassified non-DB remainder.
     incl_wait: u64,
     excl_wait: u64,
-    /// Outgoing network operations attributed directly to the active function.
-    network_ops: u64,
-    /// Nanoseconds blocked in outgoing network work by the active function.
-    network_wait: u64,
+    /// Outgoing network operations, inclusive and exclusive like DB queries.
+    incl_network: u64,
+    excl_network: u64,
+    /// Nanoseconds blocked in outgoing network work, inclusive and exclusive.
+    incl_network_wait: u64,
+    excl_network_wait: u64,
     /// Live activations on the stack — inclusive is credited only when this
     /// returns to zero, so recursion is not double counted.
     depth: u32,
@@ -155,6 +157,12 @@ struct Frame {
     children_frees: u64,
     children_io: u64,
     children_wait: u64,
+    /// Network work issued directly by this activation.
+    network: u64,
+    network_wait: u64,
+    /// Network work issued by direct and transitive callees.
+    children_network: u64,
+    children_network_wait: u64,
 }
 
 /// One suspended coroutine's activations, off the shadow stack until it resumes.
@@ -286,6 +294,12 @@ struct Throw {
     children_frees: u64,
     children_io: u64,
     children_wait: u64,
+    /// Network work performed directly by the handler before its catcher is known.
+    network: u64,
+    network_wait: u64,
+    /// Network work performed by functions called from the handler.
+    children_network: u64,
+    children_network_wait: u64,
     /// `(callee, calls, summed inclusive ns)` for what this handler called.
     edges: Vec<(u32, u64, u64)>,
 }
@@ -490,6 +504,10 @@ impl State {
             children_frees: 0,
             children_io: 0,
             children_wait: 0,
+            network: 0,
+            network_wait: 0,
+            children_network: 0,
+            children_network_wait: 0,
         });
     }
 
@@ -667,6 +685,10 @@ impl State {
                 children_frees: 0,
                 children_io: 0,
                 children_wait: 0,
+                network: 0,
+                network_wait: 0,
+                children_network: 0,
+                children_network_wait: 0,
             });
         }
     }
@@ -779,6 +801,14 @@ impl State {
                 frame.children_frees = frame.children_frees.wrapping_add(throw.children_frees);
                 frame.children_io = frame.children_io.wrapping_add(throw.children_io);
                 frame.children_wait = frame.children_wait.wrapping_add(throw.children_wait);
+                frame.network = frame.network.wrapping_add(throw.network);
+                frame.network_wait = frame.network_wait.wrapping_add(throw.network_wait);
+                frame.children_network = frame
+                    .children_network
+                    .wrapping_add(throw.children_network);
+                frame.children_network_wait = frame
+                    .children_network_wait
+                    .wrapping_add(throw.children_network_wait);
                 for (callee, calls, ns) in throw.edges {
                     let entry = self.edges.entry((id, callee)).or_insert((0, 0));
                     entry.0 = entry.0.wrapping_add(calls);
@@ -914,6 +944,10 @@ impl State {
         let elapsed_frees = f.wrapping_sub(frame.f_enter);
         let elapsed_io = io.wrapping_sub(frame.io_enter);
         let elapsed_wait = w.wrapping_sub(frame.w_enter);
+        let inclusive_network = frame.network.wrapping_add(frame.children_network);
+        let inclusive_network_wait = frame
+            .network_wait
+            .wrapping_add(frame.children_network_wait);
         // Children can only exceed their parent's own span if the accounting
         // has gone wrong somewhere, and no sequence found so far reaches this —
         // the two that did were both fixed at their cause. It stays because of
@@ -939,6 +973,8 @@ impl State {
         acc.excl_wait = acc
             .excl_wait
             .wrapping_add(elapsed_wait.wrapping_sub(frame.children_wait));
+        acc.excl_network = acc.excl_network.wrapping_add(frame.network);
+        acc.excl_network_wait = acc.excl_network_wait.wrapping_add(frame.network_wait);
         acc.depth = acc.depth.saturating_sub(1);
         if acc.depth == 0 {
             acc.incl_ns = acc.incl_ns.wrapping_add(t.wrapping_sub(acc.t_outer));
@@ -946,6 +982,10 @@ impl State {
             acc.incl_frees = acc.incl_frees.wrapping_add(f.wrapping_sub(acc.f_outer));
             acc.incl_io = acc.incl_io.wrapping_add(io.wrapping_sub(acc.io_outer));
             acc.incl_wait = acc.incl_wait.wrapping_add(w.wrapping_sub(acc.w_outer));
+            acc.incl_network = acc.incl_network.wrapping_add(inclusive_network);
+            acc.incl_network_wait = acc
+                .incl_network_wait
+                .wrapping_add(inclusive_network_wait);
         }
         // Charging this to the frame below would hand the handler's cost to a
         // function the exception had already stopped. It waits with the unwind
@@ -956,6 +996,10 @@ impl State {
             u.children_frees = u.children_frees.wrapping_add(elapsed_frees);
             u.children_io = u.children_io.wrapping_add(elapsed_io);
             u.children_wait = u.children_wait.wrapping_add(elapsed_wait);
+            u.children_network = u.children_network.wrapping_add(inclusive_network);
+            u.children_network_wait = u
+                .children_network_wait
+                .wrapping_add(inclusive_network_wait);
             match u.edges.iter_mut().find(|(c, ..)| *c == id) {
                 Some(edge) => edge.2 = edge.2.wrapping_add(elapsed_ns),
                 None => u.edges.push((id, 0, elapsed_ns)),
@@ -969,6 +1013,10 @@ impl State {
             top.children_frees = top.children_frees.wrapping_add(elapsed_frees);
             top.children_io = top.children_io.wrapping_add(elapsed_io);
             top.children_wait = top.children_wait.wrapping_add(elapsed_wait);
+            top.children_network = top.children_network.wrapping_add(inclusive_network);
+            top.children_network_wait = top
+                .children_network_wait
+                .wrapping_add(inclusive_network_wait);
         }
         if let Some(pid) = parent {
             let entry = self.edges.entry((pid, id)).or_insert((0, 0));
@@ -976,23 +1024,21 @@ impl State {
         }
     }
 
-    /// Attributes one outgoing network operation to the active PHP function.
+    /// Attributes one outgoing network operation to the active PHP activation.
     fn note_network(&mut self) {
-        let Some(id) = self.stack.last().map(|frame| frame.id) else {
-            return;
-        };
-        if let Some(acc) = self.fns.get_mut(id as usize) {
-            acc.network_ops = acc.network_ops.wrapping_add(1);
+        if let Some(unwind) = self.pending_charge() {
+            unwind.network = unwind.network.wrapping_add(1);
+        } else if let Some(frame) = self.stack.last_mut() {
+            frame.network = frame.network.wrapping_add(1);
         }
     }
 
-    /// Attributes blocked outgoing-network time to the active PHP function.
+    /// Attributes blocked outgoing-network time to the active PHP activation.
     fn note_network_wait(&mut self, ns: u64) {
-        let Some(id) = self.stack.last().map(|frame| frame.id) else {
-            return;
-        };
-        if let Some(acc) = self.fns.get_mut(id as usize) {
-            acc.network_wait = acc.network_wait.wrapping_add(ns);
+        if let Some(unwind) = self.pending_charge() {
+            unwind.network_wait = unwind.network_wait.wrapping_add(ns);
+        } else if let Some(frame) = self.stack.last_mut() {
+            frame.network_wait = frame.network_wait.wrapping_add(ns);
         }
     }
 
@@ -1108,7 +1154,7 @@ impl State {
             let incl_ret = acc.incl_allocs as i64 - acc.incl_frees as i64;
             let excl_ret = acc.excl_allocs as i64 - acc.excl_frees as i64;
             out.push_str(&format!(
-                "elephc-instr: {} calls={} incl_ns={} excl_ns={} incl_allocs={} excl_allocs={} incl_io={} excl_io={} incl_ret={} excl_ret={} incl_wait={} excl_wait={} network_ops={} network_wait={}\n",
+                "elephc-instr: {} calls={} incl_ns={} excl_ns={} incl_allocs={} excl_allocs={} incl_io={} excl_io={} incl_ret={} excl_ret={} incl_wait={} excl_wait={} incl_network={} excl_network={} incl_network_wait={} excl_network_wait={}\n",
                 name_of(id),
                 acc.calls,
                 // Ticks became nanoseconds here, once, rather than twice per
@@ -1124,8 +1170,10 @@ impl State {
                 excl_ret,
                 acc.incl_wait,
                 acc.excl_wait,
-                acc.network_ops,
-                acc.network_wait,
+                acc.incl_network,
+                acc.excl_network,
+                acc.incl_network_wait,
+                acc.excl_network_wait,
             ));
         }
         let mut edges: Vec<(&(u32, u32), &(u64, u64))> = self.edges.iter().collect();
@@ -5164,8 +5212,53 @@ mod tests {
             .lines()
             .find(|line| line.starts_with("elephc-instr: hot "))
             .expect("hot row");
-        assert!(hot.contains("network_ops=1 network_wait=2000"), "{out}");
+        assert!(
+            hot.contains(
+                "incl_network=1 excl_network=1 incl_network_wait=2000 \
+                 excl_network_wait=2000"
+            ),
+            "{out}"
+        );
+        let main = out
+            .lines()
+            .find(|line| line.starts_with("elephc-instr: {main} "))
+            .expect("main row");
+        assert!(
+            main.contains(
+                "incl_network=1 excl_network=0 incl_network_wait=2000 \
+                 excl_network_wait=0"
+            ),
+            "{out}"
+        );
         assert!(out.contains("elephc-instr-edge: {main} -> hot count=1 ns=40"), "{out}");
+    }
+
+    /// Network work in an exception handler stays on the catcher and its live callees.
+    #[test]
+    fn network_metrics_survive_exception_resynchronization() {
+        let mut s = State::default();
+        let root = s.enter_sim(0, 0, 0, 0, 0, 0);
+        let catcher = s.enter_sim(1, 10, 0, 0, 0, 0);
+        s.enter_sim(2, 20, 0, 0, 0, 0);
+        s.note_throw(30, 0, 0, 0, 0);
+
+        s.note_network();
+        s.note_network_wait(5);
+        let child = s.enter_sim(3, 40, 0, 0, 0, 0);
+        s.note_network();
+        s.note_network_wait(7);
+        s.exit_at(3, child, 50, 0, 0, 0, 0);
+
+        s.exit_at(1, catcher, 100, 0, 0, 0, 0);
+        s.exit_at(0, root, 110, 0, 0, 0, 0);
+
+        assert_eq!((s.fns[2].incl_network, s.fns[2].excl_network), (0, 0));
+        assert_eq!((s.fns[3].incl_network, s.fns[3].excl_network), (1, 1));
+        assert_eq!((s.fns[1].incl_network, s.fns[1].excl_network), (2, 1));
+        assert_eq!((s.fns[0].incl_network, s.fns[0].excl_network), (2, 0));
+        assert_eq!(s.fns[1].incl_network_wait, 12);
+        assert_eq!(s.fns[1].excl_network_wait, 5);
+        assert_eq!(s.fns[0].incl_network_wait, 12);
     }
 
     #[test]

--- a/crates/elephc-monitoring-contract/Cargo.toml
+++ b/crates/elephc-monitoring-contract/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "elephc-monitoring-contract"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Typed monitoring policy and bridge-side event helpers for elephc"
+publish = false
+
+[lib]
+crate-type = ["rlib"]

--- a/crates/elephc-monitoring-contract/src/lib.rs
+++ b/crates/elephc-monitoring-contract/src/lib.rs
@@ -81,19 +81,40 @@ impl MonitoringPolicy {
 pub struct EventHooks {
     /// Whether bridge-side timing and trace work is active right now.
     active: bool,
+    /// Optional consumer callback for a monitoring window not represented by `active`.
+    active_fn: usize,
     operation_fn: usize,
     wait_fn: usize,
 }
 
 impl EventHooks {
     /// Builds hooks from runtime slot addresses already read by the bridge.
-    pub const fn new(active: bool, operation_fn: usize, wait_fn: usize) -> Self {
-        Self { active, operation_fn, wait_fn }
+    pub const fn new(
+        active: bool,
+        active_fn: usize,
+        operation_fn: usize,
+        wait_fn: usize,
+    ) -> Self {
+        Self {
+            active,
+            active_fn,
+            operation_fn,
+            wait_fn,
+        }
     }
 
     /// Returns whether a monitor capture is active right now.
-    pub const fn is_active(self) -> bool {
-        self.active
+    pub fn is_active(self) -> bool {
+        if self.active {
+            return true;
+        }
+        if self.active_fn == 0 {
+            return false;
+        }
+        let function = unsafe {
+            std::mem::transmute::<usize, unsafe extern "C" fn() -> u32>(self.active_fn)
+        };
+        unsafe { function() != 0 }
     }
 
     /// Sends one category-specific operation to the installed event consumer.
@@ -113,7 +134,7 @@ impl EventHooks {
 
     /// Runs `body` and reports its elapsed nanoseconds only while monitoring is active.
     pub fn timed<T>(self, body: impl FnOnce() -> T) -> T {
-        if !self.active || self.wait_fn == 0 {
+        if self.wait_fn == 0 || !self.is_active() {
             return body();
         }
         let started = Instant::now();
@@ -162,6 +183,13 @@ mod tests {
 
     static OPERATIONS: AtomicU64 = AtomicU64::new(0);
     static WAIT: AtomicU64 = AtomicU64::new(0);
+    static WINDOW_ACTIVE: std::sync::atomic::AtomicBool =
+        std::sync::atomic::AtomicBool::new(false);
+
+    /// Reports the fixture's consumer-owned monitoring window state.
+    unsafe extern "C" fn window_active() -> u32 {
+        u32::from(WINDOW_ACTIVE.load(Ordering::Relaxed))
+    }
 
     /// Records one fixture operation through the same C ABI shape as the runtime slot.
     unsafe extern "C" fn note() {
@@ -180,6 +208,7 @@ mod tests {
         WAIT.store(0, Ordering::Relaxed);
         let hooks = EventHooks::new(
             false,
+            0,
             note as *const () as usize,
             wait as *const () as usize,
         );
@@ -196,6 +225,7 @@ mod tests {
         WAIT.store(0, Ordering::Relaxed);
         let hooks = EventHooks::new(
             true,
+            0,
             note as *const () as usize,
             wait as *const () as usize,
         );
@@ -203,6 +233,22 @@ mod tests {
         assert_eq!(hooks.timed(|| 11), 11);
         assert_eq!(OPERATIONS.load(Ordering::Relaxed), 1);
         assert!(WAIT.load(Ordering::Relaxed) > 0);
+    }
+
+    /// Verifies a consumer-owned window enables timing without the exact-capture flag.
+    #[test]
+    fn consumer_window_enables_timing() {
+        WAIT.store(0, Ordering::Relaxed);
+        WINDOW_ACTIVE.store(true, Ordering::Relaxed);
+        let hooks = EventHooks::new(
+            false,
+            window_active as *const () as usize,
+            0,
+            wait as *const () as usize,
+        );
+        assert_eq!(hooks.timed(|| 13), 13);
+        assert!(WAIT.load(Ordering::Relaxed) > 0);
+        WINDOW_ACTIVE.store(false, Ordering::Relaxed);
     }
 
     /// Verifies traceparent validation rejects injection and zero-identity shapes.

--- a/crates/elephc-monitoring-contract/src/lib.rs
+++ b/crates/elephc-monitoring-contract/src/lib.rs
@@ -1,0 +1,225 @@
+//! Purpose:
+//! Defines the typed monitoring policy shared by the compiler and bridge crates,
+//! plus dependency-free helpers for calling runtime event slots safely.
+//!
+//! Called from:
+//! - `crate::linker::bridges` and `crate::ir::runtime_fn` for CI-audited policy metadata.
+//! - Bridge crates that report database or network operations to `elephc monitor`.
+//!
+//! Key details:
+//! - Bridges supply slot addresses, so this crate never creates unresolved runtime symbols.
+//! - Event consumers gate their own capture windows; timing reads the clock only while active.
+
+use std::time::Instant;
+
+/// The externally visible I/O category attributed by the monitor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IoKind {
+    /// Database statements, kept separate for query budgets and N+1 analysis.
+    Database,
+    /// Outgoing network transfers such as curl requests.
+    Network,
+}
+
+/// Whether an I/O boundary propagates the active W3C trace context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TraceContextPolicy {
+    /// The operation has no outgoing trace-context boundary.
+    NotApplicable,
+    /// User code may propagate the context, but the runtime does not inject it.
+    Manual,
+    /// The runtime injects the active context unless the user supplied one.
+    Automatic,
+}
+
+/// Whether an I/O boundary reports its blocked duration separately from self time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WaitPolicy {
+    /// Generic function timing is the only duration signal.
+    GenericTiming,
+    /// The bridge reports the actual blocking span through a monitor event slot.
+    Measured,
+}
+
+/// Required observability decision for a bridge or typed runtime operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MonitoringPolicy {
+    /// No policy has been reviewed. Audits reject this on bridge-backed and I/O operations.
+    Unspecified,
+    /// Ordinary function enter/exit timing fully describes this operation.
+    GenericTiming,
+    /// The operation reports typed I/O events and declares its trace behavior.
+    Io {
+        /// Category kept distinct in monitor reports and budgets.
+        kind: IoKind,
+        /// Whether blocked time is measured explicitly.
+        wait: WaitPolicy,
+        /// W3C Trace Context behavior at the external boundary.
+        trace_context: TraceContextPolicy,
+    },
+    /// Compiler/runtime infrastructure rather than a PHP-visible work boundary.
+    Infrastructure {
+        /// Machine-visible justification required by the policy audit.
+        reason: &'static str,
+    },
+}
+
+impl MonitoringPolicy {
+    /// Returns whether the policy records a reviewed monitoring decision.
+    pub const fn is_reviewed(self) -> bool {
+        !matches!(self, Self::Unspecified)
+    }
+
+    /// Returns whether the policy emits typed I/O events.
+    pub const fn is_evented(self) -> bool {
+        matches!(self, Self::Io { .. })
+    }
+}
+
+/// Runtime function-pointer slots used by one bridge-side event category.
+#[derive(Debug, Clone, Copy)]
+pub struct EventHooks {
+    /// Whether bridge-side timing and trace work is active right now.
+    active: bool,
+    operation_fn: usize,
+    wait_fn: usize,
+}
+
+impl EventHooks {
+    /// Builds hooks from runtime slot addresses already read by the bridge.
+    pub const fn new(active: bool, operation_fn: usize, wait_fn: usize) -> Self {
+        Self { active, operation_fn, wait_fn }
+    }
+
+    /// Returns whether a monitor capture is active right now.
+    pub const fn is_active(self) -> bool {
+        self.active
+    }
+
+    /// Sends one category-specific operation to the installed event consumer.
+    ///
+    /// The consumer owns its capture-window gate. This callback must therefore
+    /// remain reachable while bridge-side exact timing is dormant, because the
+    /// sampled probe tracks its active window in shared process state instead.
+    pub fn note_operation(self) {
+        if self.operation_fn == 0 {
+            return;
+        }
+        let function = unsafe {
+            std::mem::transmute::<usize, unsafe extern "C" fn()>(self.operation_fn)
+        };
+        unsafe { function() };
+    }
+
+    /// Runs `body` and reports its elapsed nanoseconds only while monitoring is active.
+    pub fn timed<T>(self, body: impl FnOnce() -> T) -> T {
+        if !self.active || self.wait_fn == 0 {
+            return body();
+        }
+        let started = Instant::now();
+        let output = body();
+        let elapsed = started.elapsed().as_nanos().min(u64::MAX as u128) as u64;
+        let function = unsafe {
+            std::mem::transmute::<usize, unsafe extern "C" fn(u64)>(self.wait_fn)
+        };
+        unsafe { function(elapsed) };
+        output
+    }
+}
+
+/// Returns the active, syntactically valid W3C `traceparent` value for an outgoing request.
+pub fn active_traceparent(active: bool) -> Option<String> {
+    if !active {
+        return None;
+    }
+    let value = std::env::var("ELEPHC_TRACEPARENT").ok()?;
+    valid_traceparent(&value).then_some(value)
+}
+
+/// Validates the strict lowercase W3C traceparent shape emitted by the monitor runtime.
+pub fn valid_traceparent(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.len() != 55 || bytes[2] != b'-' || bytes[35] != b'-' || bytes[52] != b'-' {
+        return false;
+    }
+    if &bytes[..2] != b"00" || &bytes[53..] == b"00" {
+        return false;
+    }
+    let trace_id = &bytes[3..35];
+    let span_id = &bytes[36..52];
+    trace_id.iter().all(u8::is_ascii_hexdigit)
+        && span_id.iter().all(u8::is_ascii_hexdigit)
+        && bytes[53..].iter().all(u8::is_ascii_hexdigit)
+        && trace_id.iter().any(|byte| *byte != b'0')
+        && span_id.iter().any(|byte| *byte != b'0')
+        && bytes.iter().all(|byte| !byte.is_ascii_uppercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static OPERATIONS: AtomicU64 = AtomicU64::new(0);
+    static WAIT: AtomicU64 = AtomicU64::new(0);
+
+    /// Records one fixture operation through the same C ABI shape as the runtime slot.
+    unsafe extern "C" fn note() {
+        OPERATIONS.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Records one fixture wait duration through the runtime slot shape.
+    unsafe extern "C" fn wait(ns: u64) {
+        WAIT.fetch_add(ns, Ordering::Relaxed);
+    }
+
+    /// Verifies inactive hooks still forward events but avoid timed callbacks.
+    #[test]
+    fn dormant_hooks_leave_window_gating_to_the_event_consumer() {
+        OPERATIONS.store(0, Ordering::Relaxed);
+        WAIT.store(0, Ordering::Relaxed);
+        let hooks = EventHooks::new(
+            false,
+            note as *const () as usize,
+            wait as *const () as usize,
+        );
+        hooks.note_operation();
+        assert_eq!(hooks.timed(|| 7), 7);
+        assert_eq!(OPERATIONS.load(Ordering::Relaxed), 1);
+        assert_eq!(WAIT.load(Ordering::Relaxed), 0);
+    }
+
+    /// Verifies active hooks report one operation and one nonzero timed span.
+    #[test]
+    fn active_hooks_report_operation_and_wait() {
+        OPERATIONS.store(0, Ordering::Relaxed);
+        WAIT.store(0, Ordering::Relaxed);
+        let hooks = EventHooks::new(
+            true,
+            note as *const () as usize,
+            wait as *const () as usize,
+        );
+        hooks.note_operation();
+        assert_eq!(hooks.timed(|| 11), 11);
+        assert_eq!(OPERATIONS.load(Ordering::Relaxed), 1);
+        assert!(WAIT.load(Ordering::Relaxed) > 0);
+    }
+
+    /// Verifies traceparent validation rejects injection and zero-identity shapes.
+    #[test]
+    fn traceparent_validation_accepts_only_monitor_shape() {
+        assert!(valid_traceparent(
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        ));
+        assert!(!valid_traceparent(
+            "00-4BF92F3577B34DA6A3CE929D0E0E4736-00f067aa0ba902b7-01"
+        ));
+        assert!(!valid_traceparent(
+            "00-00000000000000000000000000000000-00f067aa0ba902b7-01"
+        ));
+        assert!(!valid_traceparent(
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01"
+        ));
+        assert!(!valid_traceparent("00-good\r\nx-bad: yes"));
+    }
+}

--- a/crates/elephc-monitoring-contract/src/lib.rs
+++ b/crates/elephc-monitoring-contract/src/lib.rs
@@ -132,6 +132,25 @@ impl EventHooks {
         unsafe { function() };
     }
 
+    /// Sends one measured wait duration to the installed event consumer.
+    ///
+    /// Callers use this when part of a larger timed boundary must be excluded,
+    /// such as PHP callback execution nested inside a curl transfer.
+    pub fn note_wait(self, ns: u64) {
+        if self.wait_fn == 0 {
+            return;
+        }
+        let function = unsafe {
+            std::mem::transmute::<usize, unsafe extern "C" fn(u64)>(self.wait_fn)
+        };
+        unsafe { function(ns) };
+    }
+
+    /// Reports a measured boundary after removing nested user-code time.
+    pub fn note_wait_excluding(self, elapsed_ns: u64, user_code_ns: u64) {
+        self.note_wait(elapsed_ns.saturating_sub(user_code_ns));
+    }
+
     /// Runs `body` and reports its elapsed nanoseconds only while monitoring is active.
     pub fn timed<T>(self, body: impl FnOnce() -> T) -> T {
         if self.wait_fn == 0 || !self.is_active() {
@@ -140,10 +159,7 @@ impl EventHooks {
         let started = Instant::now();
         let output = body();
         let elapsed = started.elapsed().as_nanos().min(u64::MAX as u128) as u64;
-        let function = unsafe {
-            std::mem::transmute::<usize, unsafe extern "C" fn(u64)>(self.wait_fn)
-        };
-        unsafe { function(elapsed) };
+        self.note_wait(elapsed);
         output
     }
 }
@@ -183,6 +199,7 @@ mod tests {
 
     static OPERATIONS: AtomicU64 = AtomicU64::new(0);
     static WAIT: AtomicU64 = AtomicU64::new(0);
+    static EXCLUDED_WAIT: AtomicU64 = AtomicU64::new(0);
     static WINDOW_ACTIVE: std::sync::atomic::AtomicBool =
         std::sync::atomic::AtomicBool::new(false);
 
@@ -199,6 +216,11 @@ mod tests {
     /// Records one fixture wait duration through the runtime slot shape.
     unsafe extern "C" fn wait(ns: u64) {
         WAIT.fetch_add(ns, Ordering::Relaxed);
+    }
+
+    /// Records wait for the callback-exclusion fixture without sharing test state.
+    unsafe extern "C" fn excluded_wait(ns: u64) {
+        EXCLUDED_WAIT.fetch_add(ns, Ordering::Relaxed);
     }
 
     /// Verifies inactive hooks still forward events but avoid timed callbacks.
@@ -249,6 +271,17 @@ mod tests {
         assert_eq!(hooks.timed(|| 13), 13);
         assert!(WAIT.load(Ordering::Relaxed) > 0);
         WINDOW_ACTIVE.store(false, Ordering::Relaxed);
+    }
+
+    /// User callback time is removed without allowing an oversized value to wrap.
+    #[test]
+    fn wait_exclusion_is_saturating() {
+        EXCLUDED_WAIT.store(0, Ordering::Relaxed);
+        let hooks = EventHooks::new(false, 0, 0, excluded_wait as *const () as usize);
+        hooks.note_wait_excluding(1_000, 400);
+        assert_eq!(EXCLUDED_WAIT.load(Ordering::Relaxed), 600);
+        hooks.note_wait_excluding(100, 200);
+        assert_eq!(EXCLUDED_WAIT.load(Ordering::Relaxed), 600);
     }
 
     /// Verifies traceparent validation rejects injection and zero-identity shapes.

--- a/crates/elephc-pdo/Cargo.toml
+++ b/crates/elephc-pdo/Cargo.toml
@@ -12,6 +12,7 @@ description = "Multi-driver database bridge staticlib for the elephc PHP-to-nati
 crate-type = ["staticlib", "rlib"]
 
 [dependencies]
+elephc-monitoring-contract = { path = "../elephc-monitoring-contract" }
 # `bundled` compiles the SQLite amalgamation into the staticlib, so compiled
 # PHP binaries stay standalone (no system -lsqlite3 runtime dependency). Cost:
 # a C compile of sqlite at crate build time (cc is already required to build

--- a/crates/elephc-pdo/src/lib.rs
+++ b/crates/elephc-pdo/src/lib.rs
@@ -47,6 +47,7 @@ mod instr_io {
     use elephc_monitoring_contract::EventHooks;
 
     extern "C" {
+        static elephc_monitor_event_active_fn: usize;
         static elephc_instr_io_fn: usize;
         static elephc_instr_query_fn: usize;
         static elephc_instr_wait_fn: usize;
@@ -60,6 +61,7 @@ mod instr_io {
     fn hooks() -> EventHooks {
         EventHooks::new(
             asked(),
+            unsafe { std::ptr::addr_of!(elephc_monitor_event_active_fn).read() },
             unsafe { std::ptr::addr_of!(elephc_instr_io_fn).read() },
             unsafe { std::ptr::addr_of!(elephc_instr_wait_fn).read() },
         )
@@ -114,6 +116,8 @@ mod instr_io {
     // never in the staticlib, so a real program's `.comm` is not duplicated.
     #[cfg(test)]
     mod slot_stub {
+        #[no_mangle]
+        static elephc_monitor_event_active_fn: usize = 0;
         #[no_mangle]
         static elephc_instr_io_fn: usize = 0;
         #[no_mangle]

--- a/crates/elephc-pdo/src/lib.rs
+++ b/crates/elephc-pdo/src/lib.rs
@@ -44,6 +44,8 @@
 /// non-null makes query counting pay-for-use — a non-instrument binary leaves
 /// the slot zero — with no dlsym and no compile-time coupling to the instr crate.
 mod instr_io {
+    use elephc_monitoring_contract::EventHooks;
+
     extern "C" {
         static elephc_instr_io_fn: usize;
         static elephc_instr_query_fn: usize;
@@ -52,17 +54,20 @@ mod instr_io {
         /// every compiled program carries, so reading it here needs no new slot.
         static elephc_monitor_active: u64;
     }
-    type IoFn = unsafe extern "C" fn();
     type QueryFn = unsafe extern "C" fn(*const u8, usize);
-    type WaitFn = unsafe extern "C" fn(u64);
+
+    /// Reads the database event slots into the shared bridge-side helper.
+    fn hooks() -> EventHooks {
+        EventHooks::new(
+            asked(),
+            unsafe { std::ptr::addr_of!(elephc_instr_io_fn).read() },
+            unsafe { std::ptr::addr_of!(elephc_instr_wait_fn).read() },
+        )
+    }
 
     /// Records one query with the exact profiler, if `--instrument` is linked.
     pub fn note() {
-        let addr = unsafe { std::ptr::addr_of!(elephc_instr_io_fn).read() };
-        if addr != 0 {
-            let f = unsafe { std::mem::transmute::<usize, IoFn>(addr) };
-            unsafe { f() };
-        }
+        hooks().note_operation();
     }
 
     /// Whether an exact slice is being recorded RIGHT NOW.
@@ -101,18 +106,7 @@ mod instr_io {
     /// is not linked the slot is zero and `body` runs without even reading the
     /// clock — the measurement costs nothing in a normal binary.
     pub fn timed<T>(body: impl FnOnce() -> T) -> T {
-        let addr = unsafe { std::ptr::addr_of!(elephc_instr_wait_fn).read() };
-        if addr == 0 || !asked() {
-            // Not linked, or linked and dormant: either way the clock stays
-            // unread. Two `Instant` reads per statement is not "costs nothing".
-            return body();
-        }
-        let started = std::time::Instant::now();
-        let out = body();
-        let ns = started.elapsed().as_nanos().min(u64::MAX as u128) as u64;
-        let f = unsafe { std::mem::transmute::<usize, WaitFn>(addr) };
-        unsafe { f(ns) };
-        out
+        hooks().timed(body)
     }
 
     // Standalone `cargo test -p elephc-pdo` has no compiled elephc program to

--- a/crates/elephc-probe/src/lib.rs
+++ b/crates/elephc-probe/src/lib.rs
@@ -135,12 +135,9 @@ const SPEND_ATTEMPTS: usize = 3;
 /// never seen it.
 const REPLAY_TABLE_BYTES: usize = REPLAY_SLOTS * REPLAY_SLOT_BYTES;
 /// Shared-region byte size: the ring, then the route table, then the per-route
-/// event counters, then the control word, then the replay table — all inherited
-/// across a `--web` fork, so route ids stay consistent, every worker's counters
-/// land in one place, and a signature spent on one worker is spent on all.
-///
-/// Each new area is appended LAST so adding it moves no existing offset: every
-/// other area is addressed from the constants above it.
+/// event counters, then the control word, then the replay table. All offsets are
+/// derived from the sizes above, and the whole internal layout is inherited
+/// across a `--web` fork so route ids, counters, and replay state stay shared.
 const REGION_BYTES: usize =
     RING_BYTES + ROUTE_TABLE_BYTES + EVENT_TABLE_BYTES + CONTROL_BYTES + REPLAY_TABLE_BYTES;
 

--- a/crates/elephc-probe/src/lib.rs
+++ b/crates/elephc-probe/src/lib.rs
@@ -71,8 +71,8 @@ const ROUTE_NAME_MAX: usize = ROUTE_SLOT_BYTES - 1;
 const RING_BYTES: usize = 8 + RING_SLOTS * SLOT_WORDS * 8;
 /// Route-table bytes: an 8-byte count followed by the fixed route slots.
 const ROUTE_TABLE_BYTES: usize = 8 + MAX_ROUTES * ROUTE_SLOT_BYTES;
-/// Words per route in the event table: `[io_ops, wait_ns]`.
-const EVENT_WORDS: usize = 2;
+/// Words per route: `[db_ops, db_wait_ns, network_ops, network_wait_ns]`.
+const EVENT_WORDS: usize = 4;
 /// One extra bucket for id 0, which the route table reserves for "untagged" —
 /// a CLI run, or a `--web` request whose route did not fit the table. Dropping
 /// those events would understate the totals silently, which is worse than a row
@@ -317,7 +317,19 @@ pub extern "C" fn elephc_probe_note_wait(ns: u64) {
     note_event(1, ns);
 }
 
-/// Renders the per-route event counters, one line per route that saw DB activity.
+/// Records one outgoing network operation against the current request.
+#[no_mangle]
+pub extern "C" fn elephc_probe_note_network() {
+    note_event(2, 1);
+}
+
+/// Records nanoseconds blocked in an outgoing network operation.
+#[no_mangle]
+pub extern "C" fn elephc_probe_note_network_wait(ns: u64) {
+    note_event(3, ns);
+}
+
+/// Renders database and network event counters for every route that saw activity.
 ///
 /// Deliberately its own line prefix rather than extra columns on the folded
 /// samples: a consumer must not be able to mistake an exact count for a sampled
@@ -333,7 +345,9 @@ pub fn event_report(base: usize) -> String {
     for route_id in 0..EVENT_BUCKETS {
         let io = unsafe { event_word(base, route_id, 0) }.load(Ordering::Relaxed);
         let wait = unsafe { event_word(base, route_id, 1) }.load(Ordering::Relaxed);
-        if io == 0 && wait == 0 {
+        let network = unsafe { event_word(base, route_id, 2) }.load(Ordering::Relaxed);
+        let network_wait = unsafe { event_word(base, route_id, 3) }.load(Ordering::Relaxed);
+        if io == 0 && wait == 0 && network == 0 && network_wait == 0 {
             continue;
         }
         let name = if route_id == 0 {
@@ -341,7 +355,14 @@ pub fn event_report(base: usize) -> String {
         } else {
             unsafe { read_route_slot(base, route_id - 1) }
         };
-        out.push_str(&format!("elephc-probe-io: {name} ops={io} wait_ns={wait}\n"));
+        if io != 0 || wait != 0 {
+            out.push_str(&format!("elephc-probe-io: {name} ops={io} wait_ns={wait}\n"));
+        }
+        if network != 0 || network_wait != 0 {
+            out.push_str(&format!(
+                "elephc-probe-network: {name} ops={network} wait_ns={network_wait}\n"
+            ));
+        }
     }
     out
 }
@@ -3315,6 +3336,9 @@ mod tests {
             elephc_probe_note_io();
         }
         elephc_probe_note_wait(2_290_874);
+        elephc_probe_note_network();
+        elephc_probe_note_network();
+        elephc_probe_note_network_wait(33);
 
         let id = unsafe { intern_route("GET /orders") };
         assert!(id > 0, "the route table must hand out a 1-based id");
@@ -3322,6 +3346,8 @@ mod tests {
         elephc_probe_note_io();
         elephc_probe_note_io();
         elephc_probe_note_wait(1_000);
+        elephc_probe_note_network();
+        elephc_probe_note_network_wait(9);
 
         let report = event_report(base);
         assert!(
@@ -3332,8 +3358,16 @@ mod tests {
             report.contains("elephc-probe-io: GET /orders ops=2 wait_ns=1000"),
             "{report}"
         );
-        // Routes that saw no I/O must not produce an empty row.
-        assert_eq!(report.lines().count(), 2, "{report}");
+        assert!(
+            report.contains("elephc-probe-network: <untagged> ops=2 wait_ns=33"),
+            "{report}"
+        );
+        assert!(
+            report.contains("elephc-probe-network: GET /orders ops=1 wait_ns=9"),
+            "{report}"
+        );
+        // Routes that saw no monitored event must not produce an empty row.
+        assert_eq!(report.lines().count(), 4, "{report}");
 
         REGION.store(0, Ordering::Relaxed);
         CURRENT_ROUTE.store(0, Ordering::Relaxed);
@@ -3341,6 +3375,8 @@ mod tests {
         // With no region mapped the entry points are inert rather than unsafe.
         elephc_probe_note_io();
         elephc_probe_note_wait(1);
+        elephc_probe_note_network();
+        elephc_probe_note_network_wait(1);
         assert!(event_report(0).is_empty());
     }
 
@@ -3374,14 +3410,19 @@ mod tests {
         // publishes ACTIVE, so legacy/stale bytes cannot leak into this window.
         unsafe { event_word(base, 0, 0) }.store(11, Ordering::Relaxed);
         unsafe { event_word(base, 0, 1) }.store(1_100, Ordering::Relaxed);
+        unsafe { event_word(base, 0, 2) }.store(12, Ordering::Relaxed);
+        unsafe { event_word(base, 0, 3) }.store(1_200, Ordering::Relaxed);
         activate_shared_window(base);
         elephc_probe_note_io();
         elephc_probe_note_io();
         elephc_probe_note_wait(23);
+        elephc_probe_note_network();
+        elephc_probe_note_network_wait(29);
         let report = event_report(base);
         assert_eq!(
             report,
-            "elephc-probe-io: <untagged> ops=2 wait_ns=23\n",
+            "elephc-probe-io: <untagged> ops=2 wait_ns=23\n\
+             elephc-probe-network: <untagged> ops=1 wait_ns=29\n",
             "the first report must contain only the active window"
         );
 

--- a/crates/elephc-probe/src/lib.rs
+++ b/crates/elephc-probe/src/lib.rs
@@ -271,6 +271,17 @@ fn event_window_active(base: usize) -> bool {
     ASKED.load(Ordering::Relaxed)
         || unsafe { region_asked(base) }.load(Ordering::Acquire) == ASK_ACTIVE
 }
+
+/// Reports whether bridge-side event timing belongs to the probe's active window.
+///
+/// Reached through a runtime slot because a remote ask is shared across worker
+/// processes and is therefore not represented by each worker's exact-capture word.
+#[no_mangle]
+pub extern "C" fn elephc_probe_event_active() -> u32 {
+    let base = REGION.load(Ordering::Relaxed);
+    u32::from(base != 0 && event_window_active(base))
+}
+
 /// I/O events are **not sampled**. A driver call fires exactly one, so these
 /// counts are exact — the sampler's statistical nature applies to *time*, which
 /// it observes 1000x/second, not to events it is told about. Keeping the two
@@ -3390,6 +3401,7 @@ mod tests {
         REGION.store(base, Ordering::Relaxed);
         CURRENT_ROUTE.store(0, Ordering::Relaxed);
         let was_asked = ASKED.swap(false, Ordering::Relaxed);
+        assert_eq!(elephc_probe_event_active(), 0);
 
         for _ in 0..7 {
             elephc_probe_note_io();
@@ -3398,6 +3410,7 @@ mod tests {
         assert!(event_report(base).is_empty(), "pre-ask callbacks must be inert");
 
         unsafe { region_asked(base) }.store(ASK_INITIALIZING, Ordering::Release);
+        assert_eq!(elephc_probe_event_active(), 0);
         elephc_probe_note_io();
         elephc_probe_note_wait(100);
         assert!(
@@ -3413,6 +3426,7 @@ mod tests {
         unsafe { event_word(base, 0, 2) }.store(12, Ordering::Relaxed);
         unsafe { event_word(base, 0, 3) }.store(1_200, Ordering::Relaxed);
         activate_shared_window(base);
+        assert_eq!(elephc_probe_event_active(), 1);
         elephc_probe_note_io();
         elephc_probe_note_io();
         elephc_probe_note_wait(23);
@@ -3429,6 +3443,7 @@ mod tests {
         ASKED.store(was_asked, Ordering::Relaxed);
         CURRENT_ROUTE.store(0, Ordering::Relaxed);
         REGION.store(0, Ordering::Relaxed);
+        assert_eq!(elephc_probe_event_active(), 0);
     }
 
     #[test]

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,7 +80,7 @@ Compiler-specific extensions that go beyond standard PHP. These features have no
 - [Shared Libraries (cdylib)](beyond-php/cdylib.md) — --emit cdylib, #[Export] C-ABI functions, dlopen lifecycle
 - [Web Server (--web)](beyond-php/web.md) — compile a PHP file into a standalone HTTP server with worker, pool, or per-request process isolation
 - [zval Bridge](beyond-php/zval-bridge.md) — zval_pack/unpack/type/free convert elephc values to/from PHP zval structs
-- [Profiling](beyond-php/profiling.md) — PHP-level profiling with one command in every environment: a launched program reports exact wall time, allocations, retained objects, database wait, SQL queries and calls; a running service is sampled by default and exact only for a requested completed request. Includes per-`--web`-route tags, `.elephc` performance budgets, W3C distributed traces, and a self-contained interactive call-graph page
+- [Profiling](beyond-php/profiling.md) - PHP-level profiling with one command in every environment: a launched program reports exact wall time, allocations, retained objects, database and outgoing-network wait, SQL queries, network operations and calls; a running service is sampled by default and exact only for a requested completed request. Includes per-`--web`-route tags, `.elephc` performance budgets, automatic curl trace propagation, W3C distributed traces, and a self-contained interactive call-graph page
 
 ## Compiler Internals
 

--- a/docs/beyond-php/profiling.md
+++ b/docs/beyond-php/profiling.md
@@ -29,8 +29,9 @@ program or connects to one already running.
 
 A target this command **launches** — a source or a binary — is measured for its
 whole run and reports the full table: per-function calls, inclusive and self
-wall time, allocations, retained objects, DB queries and DB-driver wait. File
-I/O is not yet counted or timed. Every export follows:
+wall time, allocations, retained objects, DB queries, DB-driver wait, outgoing
+network operations and network wait. File I/O is not yet counted or timed.
+Every export follows:
 [Speedscope](https://www.speedscope.app), [pprof](https://github.com/google/pprof),
 Graphviz, the HTML call graph.
 
@@ -53,18 +54,18 @@ end of this page). Ask for those with `--exact`, or with a signed
 
 The capability matrix is explicit about each dimension:
 
-| Capture | CPU | Wall time | Calls | Allocations / retained | DB queries | File I/O | Wait | Routes |
-|---|---|---|---|---|---|---|---|---|
-| local `monitor` | not measured as an OS CPU clock; the UI can show wall minus recorded DB wait | exact enter/exit time, rooted at `{main}` | exact | exact / exact | exact | not available | exact DB-driver wait only | untagged local run |
-| service default | sampled CPU-time ring | unavailable; blocked time is invisible | unavailable | exact deltas only between samples, with sampled attribution; no retained count | unavailable in combined `--with-monitoring` | unavailable | unavailable in combined `--with-monitoring` | sampled stacks carry the exact route tag |
-| service `--exact` or signed request | not measured separately; wall minus recorded DB wait is only a derived remainder | exact for one completed request, rooted at `{main}` | exact | exact / exact | exact | not available | exact DB-driver wait only | exact request route/trace context |
-| `--live` | sampled externally | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable |
-| `--attach` | sampled externally | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable |
+| Capture | CPU | Wall time | Calls | Allocations / retained | DB queries | Network | File I/O | Wait | Routes |
+|---|---|---|---|---|---|---|---|---|---|
+| local `monitor` | not measured as an OS CPU clock; the UI can show wall minus recorded waits | exact enter/exit time, rooted at `{main}` | exact | exact / exact | exact | exact curl operations and wait | not available | exact DB-driver and network wait | untagged local run |
+| service default | sampled CPU-time ring | unavailable; blocked time is invisible | unavailable | exact deltas only between samples, with sampled attribution; no retained count | unavailable in combined `--with-monitoring` | unavailable in combined `--with-monitoring` | unavailable | unavailable in combined `--with-monitoring` | sampled stacks carry the exact route tag |
+| service `--exact` or signed request | not measured separately; wall minus recorded waits is only a derived remainder | exact for one completed request, rooted at `{main}` | exact | exact / exact | exact | exact curl operations and wait | not available | exact DB-driver and network wait | exact request route/trace context |
+| `--live` | sampled externally | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable |
+| `--attach` | sampled externally | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable | unavailable |
 
-A probe-only binary can emit exact per-route DB-operation and DB-wait counters
-beside its sampled stacks. `--with-monitoring` links both runtimes, and the exact
-runtime owns those callbacks, so the combined service-default row above is the
-one users of the public flag receive.
+A probe-only binary can emit exact per-route DB and outgoing-network operation
+and wait counters beside its sampled stacks. `--with-monitoring` links both
+runtimes, and the exact runtime owns those callbacks, so the combined
+service-default row above is the one users of the public flag receive.
 
 What *is* the same across all four is the mechanism. Profiling in production is
 normally a *different tool* answering a *smaller question*, an approximation you
@@ -509,9 +510,10 @@ that samples itself from boot whether or not anyone ever looks.
 
 The **exact** answer is the same measurement a local run gives:
 per-function calls, self and inclusive time, allocations, retained objects,
-DB queries and DB-driver wait, for one request, rooted at `{main}`. It does not
-count or time file I/O. It exists only once a request completes, so `--exact`
-waits up to thirty seconds for the next one.
+DB queries, DB-driver wait, outgoing network operations and network wait, for
+one request, rooted at `{main}`. It does not count or time file I/O. It exists
+only once a request completes, so `--exact` waits up to thirty seconds for the
+next one.
 
 One exact capture runs at a time. The rendezvous the worker leaves its slice in
 is a single slot, so a second `--exact` while one is in flight is told so rather
@@ -658,7 +660,7 @@ every call from a real enter/exit shadow stack, and writes the result to stderr
 at exit.
 
 ```text
-elephc-instr: {fn} calls=<n> incl_ns=<ns> excl_ns=<ns> incl_allocs=<n> excl_allocs=<n> incl_io=<n> excl_io=<n> incl_ret=<n> excl_ret=<n> incl_wait=<ns> excl_wait=<ns>
+elephc-instr: {fn} calls=<n> incl_ns=<ns> excl_ns=<ns> incl_allocs=<n> excl_allocs=<n> incl_io=<n> excl_io=<n> incl_ret=<n> excl_ret=<n> incl_wait=<ns> excl_wait=<ns> network_ops=<n> network_wait=<ns>
 elephc-instr-edge: {caller} -> {callee} count=<n> ns=<callee ns under caller>
 elephc-instr-query: <count> <normalized SQL text>   (one per distinct statement, if any DB ran)
 ```
@@ -802,8 +804,14 @@ callee many times and that callee issues one query each, the recommendation says
 so outright — "*N+1: `list_all` calls `get_user` 200 times and `get_user`
 issues 200 DB queries — batch them into one query*". `monitor`
 shows a `queries` column and per-function query counts in the graph tooltips.
-(HTTP has no client bridge in elephc yet; filesystem I/O can be added on the same
-runtime hook, but is not counted today.)
+
+**And outgoing network work.** `network_ops` counts curl transfers against the
+PHP function that starts them, while `network_wait` records the elapsed time in
+blocking curl transfer or multi-wait calls. These counters are separate from
+the PDO dimensions, so an HTTP-heavy request cannot inflate query budgets or
+trigger a false N+1 diagnosis. The stdout table, interactive graph, distributed
+trace waterfall, OTLP export and performance assertions all carry the network
+dimensions. Filesystem I/O is still not counted.
 
 **And what stays behind.** `incl_ret` / `excl_ret` are **retained** objects —
 allocated minus freed — attributed per function the same exact way, by reading
@@ -828,9 +836,9 @@ spent **blocked inside a driver call** rather than running PHP. The PDO bridge
 times the database work — statement execution and `PDO::exec`, across every
 driver — and reports the elapsed time through the same pay-for-use slot
 mechanism, so the profiler can split every function's self time into recorded DB
-wait and a non-DB remainder. Note the scope: *database* work. File and network
-I/O outside PDO are not timed, so `wall - DB wait` is not an OS measurement of
-actual on-CPU time.
+wait and a non-DB remainder. Network wait is reported in its own curl-backed
+dimension, while file I/O remains unmeasured. Neither remainder is an OS
+measurement of actual on-CPU time.
 
 ```
 PDO::exec              self 1.8 ms   wait 1.4 ms   non-DB 363.7 µs
@@ -923,8 +931,10 @@ an island only elephc tooling can read. When a request arrives with a valid
 starts a new one. A malformed header always starts a fresh trace, so a caller
 cannot inject text into your profile output.
 
-To carry the trace onward, read the value the profiler publishes for the
-current request and pass it on:
+Curl carries the trace onward automatically while a monitoring capture is
+active. It injects the value the profiler publishes for the current request
+unless the program already supplied a `traceparent` header. Explicit user
+headers always win. The same value remains available for other HTTP clients:
 
 ```php
 $ctx = stream_context_create(['http' => [
@@ -933,7 +943,7 @@ $ctx = stream_context_create(['http' => [
 $fh = fopen('http://inventory.internal/stock', 'r', false, $ctx);
 ```
 
-`ELEPHC_TRACEPARENT` is refreshed at the start of every request and already
+`ELEPHC_TRACEPARENT` is refreshed at the start of every captured request and already
 carries *this* slice's span id, so the callee records it as its parent. Nothing
 else is needed — no extra flag, no new builtin, and non-instrument binaries
 carry none of this machinery (the runtime slot stays zero).
@@ -946,10 +956,10 @@ caller (any OTel service)  trace=1111…8888  span=aaaabbbbccccdddd
     service B              trace=1111…8888  span=13b8fb9994026a78  parent=604e39a69a8d26e2
 ```
 
-Propagation currently reaches the HTTP stream layer (`fopen("http://…")` with a
-stream context). elephc has no `curl` yet, so an application that calls out
-through curl cannot propagate; that is the practical limit today, not the
-mechanism.
+Propagation reaches curl automatically and the HTTP stream layer manually
+(`fopen("http://…")` with a stream context). Automatic curl propagation is
+dormant outside an active capture and removes a previously injected header when
+the handle is reused later.
 
 #### Correlating the services
 
@@ -1032,8 +1042,8 @@ elephc monitor --stitch gateway.log --stitch inventory.log \
 `--otlp` posts the slices as **OpenTelemetry spans**. elephc already carried the
 W3C trace identity — the service belonged to its caller's trace whether or not
 anything was exported — so what this adds is that the hop stops being a *gap* in
-that trace and starts being a span with its own duration, route, query count and
-time spent waiting.
+that trace and starts being a span with its own duration, route, query count,
+network-operation count and time spent waiting.
 
 Plain HTTP to a local agent is the intended deployment, so an https endpoint is
 refused with that advice rather than a socket error: a remote or authenticated
@@ -1106,7 +1116,8 @@ elephc monitor app.php \
 ```
 
 Every measured dimension is assertable — `calls`, `allocs`, `retained`,
-`queries`, `self_ms`, `incl_ms`, `wait_ms`, `time_pct` — with the operators
+`queries`, `self_ms`, `incl_ms`, `wait_ms`, `network`, `network_wait_ms`,
+`time_pct` - with the operators
 `<= >= == < >`. Use `*` as the function to assert on the **whole run**:
 
 ```bash

--- a/docs/beyond-php/profiling.md
+++ b/docs/beyond-php/profiling.md
@@ -660,7 +660,7 @@ every call from a real enter/exit shadow stack, and writes the result to stderr
 at exit.
 
 ```text
-elephc-instr: {fn} calls=<n> incl_ns=<ns> excl_ns=<ns> incl_allocs=<n> excl_allocs=<n> incl_io=<n> excl_io=<n> incl_ret=<n> excl_ret=<n> incl_wait=<ns> excl_wait=<ns> network_ops=<n> network_wait=<ns>
+elephc-instr: {fn} calls=<n> incl_ns=<ns> excl_ns=<ns> incl_allocs=<n> excl_allocs=<n> incl_io=<n> excl_io=<n> incl_ret=<n> excl_ret=<n> incl_wait=<ns> excl_wait=<ns> incl_network=<n> excl_network=<n> incl_network_wait=<ns> excl_network_wait=<ns>
 elephc-instr-edge: {caller} -> {callee} count=<n> ns=<callee ns under caller>
 elephc-instr-query: <count> <normalized SQL text>   (one per distinct statement, if any DB ran)
 ```
@@ -805,13 +805,16 @@ so outright — "*N+1: `list_all` calls `get_user` 200 times and `get_user`
 issues 200 DB queries — batch them into one query*". `monitor`
 shows a `queries` column and per-function query counts in the graph tooltips.
 
-**And outgoing network work.** `network_ops` counts curl transfers against the
-PHP function that starts them, while `network_wait` records the elapsed time in
-blocking curl transfer or multi-wait calls. These counters are separate from
+**And outgoing network work.** `incl_network` / `excl_network` count curl
+transfers with the same inclusive/exclusive attribution as DB queries, while
+`incl_network_wait` / `excl_network_wait` record blocking curl transfer,
+connection-upkeep, or multi-wait time. `curl_upkeep()` contributes maintenance
+wait but not a transfer operation, and PHP callback execution nested inside
+`curl_exec()` is subtracted from network wait. These counters are separate from
 the PDO dimensions, so an HTTP-heavy request cannot inflate query budgets or
 trigger a false N+1 diagnosis. The stdout table, interactive graph, distributed
-trace waterfall, OTLP export and performance assertions all carry the network
-dimensions. Filesystem I/O is still not counted.
+trace waterfall, OTLP and Prometheus exports, and performance assertions all
+carry the network dimensions. Filesystem I/O is still not counted.
 
 **And what stays behind.** `incl_ret` / `excl_ret` are **retained** objects —
 allocated minus freed — attributed per function the same exact way, by reading
@@ -1073,7 +1076,9 @@ service:
 textfile collector. A file rather than an endpoint, because `monitor` runs and
 exits and leaves nothing to poll; percentiles are a `summary` rather than a
 histogram, because we hold exact per-request values and buckets would invent a
-resolution the capture does not have.
+resolution the capture does not have. Network data is exported as the
+`elephc_network_operations_per_request` and
+`elephc_network_wait_seconds_per_request` gauges.
 
 ### Timeline (Perfetto)
 

--- a/docs/compiling/cli-reference.md
+++ b/docs/compiling/cli-reference.md
@@ -207,7 +207,8 @@ service:
 format for a textfile collector — a file rather than an endpoint, because
 `monitor` runs and exits and leaves nothing to scrape. Percentiles are exposed as
 a `summary`, not a histogram: we hold exact per-request values, and buckets would
-invent a resolution the capture does not have.
+invent a resolution the capture does not have. It also writes mean network
+operations and network-wait seconds per request as gauges.
 
 `--serve <addr>` serves the HTML page over HTTP instead of writing it to disk,
 rewriting it in place as new captures arrive — the page updates without a
@@ -783,11 +784,13 @@ The other 44 directives of the PHP 8.5 set are runtime-overridable.
 | `--print-capabilities` | — | off | List the optional capabilities **this** binary accepts and the bridge archives each one needs, then exit successfully. One tab-separated line per capability: `<kind>\t<name>[\t<archive>...]`, where `kind` is `bridge` for a capability backed by one archive of its own and `capability` for one that is not — because it needs no archive (`regex`, whose provider is a managed native package) or because it is built out of several (`monitoring`). Every field is derived from the compiler's own bridge table, so this is the authoritative answer for the binary you are holding, not for the version the documentation was written against. A bridge archive is resolved from the directory the binary lives in or its sibling `lib/`, so `scripts/verify-release-artifact.sh` uses this to check a packaged tarball actually carries everything the compiler inside it advertises. |
 | `--mascotte` | — | off | Print the embedded ASCII mascot and a randomly selected quote before normal output. |
 
-Exact monitoring rows also append `network_ops` and `network_wait`. Curl reports
-those dimensions through network-specific runtime slots, separate from PDO
-query and wait counters, and propagates the active W3C `traceparent` unless the
-program supplied that header explicitly. The network dimensions are available
-to `--assert` as `network` and `network_wait_ms`.
+Exact monitoring rows also append inclusive/exclusive network operations and
+network wait. Curl reports those dimensions through network-specific runtime
+slots, separate from PDO query and wait counters, and propagates the active W3C
+`traceparent` unless the program supplied that header explicitly. Transfer
+operations exclude connection upkeep, and network wait excludes PHP callback
+execution nested inside `curl_exec()`. The exclusive network dimensions are
+available to `--assert` as `network` and `network_wait_ms`.
 
 See [Output formats and diagnostics](output-and-diagnostics.md).
 

--- a/docs/compiling/cli-reference.md
+++ b/docs/compiling/cli-reference.md
@@ -55,7 +55,7 @@ selection, toolchain overrides, and transactional behavior.
 
 | Command | Arguments and flags | Description |
 |---|---|---|
-| `monitor` | `<program\|source.php> [--html <file>] [--trace <file>] [--assert <expr>] [--assert-file <file>] [--save <file>] [--baseline <file>] [--out <file.speedscope.json>]` | Profile a program built with `--with-monitoring` (a `.php` source is built first): exact per-function wall time, allocations, retained objects, DB-driver wait, SQL queries and calls, rooted at `{main}`. File I/O is not measured. A service endpoint answers from the sampled CPU-time ring instead unless `--exact` requests one completed request. A binary without the capability is refused. |
+| `monitor` | `<program\|source.php> [--html <file>] [--trace <file>] [--assert <expr>] [--assert-file <file>] [--save <file>] [--baseline <file>] [--out <file.speedscope.json>]` | Profile a program built with `--with-monitoring` (a `.php` source is built first): exact per-function wall time, allocations, retained objects, DB-driver wait, SQL queries, outgoing network operations and network wait, plus calls, rooted at `{main}`. File I/O is not measured. A service endpoint answers from the sampled CPU-time ring instead unless `--exact` requests one completed request. A binary without the capability is refused. |
 | `monitor <address>` | `<host:port\|http://host\|https://host\|/path/to.sock> [--key <file>] [--out <file>] [--pprof <file>] [--dot <file>] [--html <file>]` | Profile a service already running. Sampled CPU time, allocation attribution and route tags by default; no blocked wall time or combined-build SQL/wait summary. `--exact` returns the measured table for the next completed request. Needs the build key. |
 | `monitor --attach` | `<pid> [--live] [--duration <seconds>]` | Monitor an already-running local process (and its worker children) instead of spawning one. Sampled, and macOS-only. |
 | `monitor --live` | `<program\|source.php> [--duration <seconds>] [--html <file>] [--serve <host:port>]` | Top-style table refreshed once per window. Sampled, and macOS-only. |
@@ -82,11 +82,11 @@ completes, at that request's expense. A binary built without `--with-monitoring`
 is **refused**, with both remedies printed — there is no reduced fallback,
 because a degraded profile that looks like the real one is worse than none.
 
-| Capture | CPU / wall | Calls | Allocation | Queries / file I/O / wait | Routes |
+| Capture | CPU / wall | Calls | Allocation | Queries / network / file I/O / wait | Routes |
 |---|---|---|---|---|---|
-| launched default | exact wall; `wall - DB wait` is a derived remainder, not OS CPU | exact | exact plus exact retained | exact DB queries; no file-I/O metrics; exact DB wait | untagged |
+| launched default | exact wall; recorded waits are derived dimensions, not OS CPU | exact | exact plus exact retained | exact DB queries and curl operations; no file-I/O metrics; exact DB and network wait | untagged |
 | service default | sampled CPU; no blocked wall time | none | exact inter-sample deltas with sampled attribution; no retained | none in combined `--with-monitoring`; no file-I/O metrics | sampled stacks carry route tags |
-| service `--exact` / signed request | exact request wall; no separate OS CPU | exact | exact plus exact retained | exact DB queries; no file-I/O metrics; exact DB wait | exact request route/trace |
+| service `--exact` / signed request | exact request wall; no separate OS CPU | exact | exact plus exact retained | exact DB queries and curl operations; no file-I/O metrics; exact DB and network wait | exact request route/trace |
 | `--live` / `--attach` | external sampled CPU only | none | none | none | none |
 
 Reading a running service (`monitor <address>`) needs the build key: from
@@ -155,11 +155,12 @@ call boundary. This recovery is best-effort and silently degrades to plain
 frames without the source or the dSYM.
 
 What the capability buys is **measuring** rather than sampling: exact numbers,
-six dimensions, and true edge counts instead of statistical shares.
+eight dimensions, and true edge counts instead of statistical shares.
 `--assert '<metric>:<function><op><value>'` gates the run — for example
 `--assert 'queries:load_price<=1'` or `--assert 'self_ms:*<250'`. Metrics are
-`calls`, `allocs`, `retained`, `queries`, `self_ms`, `incl_ms`, `wait_ms` and
-`time_pct`; the operator is one of `<=`, `>=`, `==`, `<`, `>`; `*` as the
+`calls`, `allocs`, `retained`, `queries`, `self_ms`, `incl_ms`, `wait_ms`,
+`network`, `network_wait_ms` and `time_pct`; the operator is one of `<=`, `>=`,
+`==`, `<`, `>`; `*` as the
 function name means the whole run. Any failure exits 2. Repeat the flag for several budgets. A project's
 standing budget lives in a `.elephc` file found by walking up from the source,
 so `--assert` is for one-off checks and the file is for the ones you keep; both
@@ -781,6 +782,12 @@ The other 44 directives of the PHP 8.5 set are runtime-overridable.
 | `--version` / `-V` | — | off | Print the elephc compiler version and exit successfully. |
 | `--print-capabilities` | — | off | List the optional capabilities **this** binary accepts and the bridge archives each one needs, then exit successfully. One tab-separated line per capability: `<kind>\t<name>[\t<archive>...]`, where `kind` is `bridge` for a capability backed by one archive of its own and `capability` for one that is not — because it needs no archive (`regex`, whose provider is a managed native package) or because it is built out of several (`monitoring`). Every field is derived from the compiler's own bridge table, so this is the authoritative answer for the binary you are holding, not for the version the documentation was written against. A bridge archive is resolved from the directory the binary lives in or its sibling `lib/`, so `scripts/verify-release-artifact.sh` uses this to check a packaged tarball actually carries everything the compiler inside it advertises. |
 | `--mascotte` | — | off | Print the embedded ASCII mascot and a randomly selected quote before normal output. |
+
+Exact monitoring rows also append `network_ops` and `network_wait`. Curl reports
+those dimensions through network-specific runtime slots, separate from PDO
+query and wait counters, and propagates the active W3C `traceparent` unless the
+program supplied that header explicitly. The network dimensions are available
+to `--assert` as `network` and `network_wait_ms`.
 
 See [Output formats and diagnostics](output-and-diagnostics.md).
 

--- a/docs/internals/builtins/_internal/__elephc_curl_easy_perform.md
+++ b/docs/internals/builtins/_internal/__elephc_curl_easy_perform.md
@@ -26,7 +26,7 @@ sidebar:
 - **Validation**: `signature`
 - **Result type source**: `declared`
 - **Result ownership**: `non_heap`
-- **Effects**: `static (7 declared effects)`
+- **Effects**: `static (18 declared effects)`
 - **Requirements**: `static (1 requirements)`
 - **Callable policy**: `static_only`
 - **Target support**: `macos-aarch64`, `ios-arm64`, `ios-sim-arm64`, `linux-aarch64`, `linux-x86_64`

--- a/docs/internals/builtins/_internal/__elephc_curl_easy_perform.md
+++ b/docs/internals/builtins/_internal/__elephc_curl_easy_perform.md
@@ -26,7 +26,7 @@ sidebar:
 - **Validation**: `signature`
 - **Result type source**: `declared`
 - **Result ownership**: `non_heap`
-- **Effects**: `static (16 declared effects)`
+- **Effects**: `static (7 declared effects)`
 - **Requirements**: `static (1 requirements)`
 - **Callable policy**: `static_only`
 - **Target support**: `macos-aarch64`, `ios-arm64`, `ios-sim-arm64`, `linux-aarch64`, `linux-x86_64`

--- a/docs/internals/builtins/_internal/__elephc_curl_easy_upkeep.md
+++ b/docs/internals/builtins/_internal/__elephc_curl_easy_upkeep.md
@@ -26,7 +26,7 @@ sidebar:
 - **Validation**: `signature`
 - **Result type source**: `declared`
 - **Result ownership**: `non_heap`
-- **Effects**: `static (16 declared effects)`
+- **Effects**: `static (7 declared effects)`
 - **Requirements**: `static (1 requirements)`
 - **Callable policy**: `static_only`
 - **Target support**: `macos-aarch64`, `ios-arm64`, `ios-sim-arm64`, `linux-aarch64`, `linux-x86_64`

--- a/docs/internals/builtins/_internal/__elephc_curl_multi_exec.md
+++ b/docs/internals/builtins/_internal/__elephc_curl_multi_exec.md
@@ -26,7 +26,7 @@ sidebar:
 - **Validation**: `signature`
 - **Result type source**: `declared`
 - **Result ownership**: `non_heap`
-- **Effects**: `static (6 declared effects)`
+- **Effects**: `static (17 declared effects)`
 - **Requirements**: `static (1 requirements)`
 - **Callable policy**: `static_only`
 - **Target support**: `macos-aarch64`, `ios-arm64`, `ios-sim-arm64`, `linux-aarch64`, `linux-x86_64`

--- a/docs/internals/builtins/_internal/__elephc_curl_multi_exec.md
+++ b/docs/internals/builtins/_internal/__elephc_curl_multi_exec.md
@@ -26,7 +26,7 @@ sidebar:
 - **Validation**: `signature`
 - **Result type source**: `declared`
 - **Result ownership**: `non_heap`
-- **Effects**: `static (16 declared effects)`
+- **Effects**: `static (6 declared effects)`
 - **Requirements**: `static (1 requirements)`
 - **Callable policy**: `static_only`
 - **Target support**: `macos-aarch64`, `ios-arm64`, `ios-sim-arm64`, `linux-aarch64`, `linux-x86_64`

--- a/docs/internals/builtins/_internal/__elephc_curl_multi_select.md
+++ b/docs/internals/builtins/_internal/__elephc_curl_multi_select.md
@@ -26,7 +26,7 @@ sidebar:
 - **Validation**: `signature`
 - **Result type source**: `declared`
 - **Result ownership**: `non_heap`
-- **Effects**: `static (16 declared effects)`
+- **Effects**: `static (7 declared effects)`
 - **Requirements**: `static (1 requirements)`
 - **Callable policy**: `static_only`
 - **Target support**: `macos-aarch64`, `ios-arm64`, `ios-sim-arm64`, `linux-aarch64`, `linux-x86_64`

--- a/docs/internals/builtins/_internal/__elephc_initialize_pdo_statement.md
+++ b/docs/internals/builtins/_internal/__elephc_initialize_pdo_statement.md
@@ -25,7 +25,7 @@ sidebar:
 - **Validation**: `signature`
 - **Result type source**: `declared`
 - **Result ownership**: `non_heap`
-- **Effects**: `static (17 declared effects)`
+- **Effects**: `static (19 declared effects)`
 - **Requirements**: `static (0 requirements)`
 - **Callable policy**: `static_only`
 - **Target support**: `macos-aarch64`, `ios-arm64`, `ios-sim-arm64`, `linux-aarch64`, `linux-x86_64`

--- a/docs/internals/builtins/_internal/__elephc_invoke_pdo_statement_constructor.md
+++ b/docs/internals/builtins/_internal/__elephc_invoke_pdo_statement_constructor.md
@@ -25,7 +25,7 @@ sidebar:
 - **Validation**: `signature`
 - **Result type source**: `declared`
 - **Result ownership**: `non_heap`
-- **Effects**: `static (17 declared effects)`
+- **Effects**: `static (19 declared effects)`
 - **Requirements**: `static (0 requirements)`
 - **Callable policy**: `static_only`
 - **Target support**: `macos-aarch64`, `ios-arm64`, `ios-sim-arm64`, `linux-aarch64`, `linux-x86_64`

--- a/docs/php/curl.md
+++ b/docs/php/curl.md
@@ -78,8 +78,12 @@ In a binary built with `--with-monitoring`, an active exact capture counts curl
 transfers separately from database queries and records their elapsed network
 wait. Easy transfers count once per `curl_exec()`; multi transfers count once
 per attached easy handle, while `curl_multi_select()` contributes its blocked
-duration. The monitor table, HTML graph, performance assertions and
-OpenTelemetry span attributes expose those network dimensions.
+duration. `curl_upkeep()` contributes maintenance wait without counting a new
+transfer, and time spent executing PHP callbacks inside `curl_exec()` is
+excluded from network wait. Network operation and wait counters use the same
+inclusive/exclusive attribution as query counters. The monitor table, HTML
+graph, performance assertions, Prometheus gauges and OpenTelemetry span
+attributes expose those network dimensions.
 
 During a captured web request, curl also injects the current W3C `traceparent`
 into `CURLOPT_HTTPHEADER` immediately before the transfer. A header supplied by

--- a/docs/php/curl.md
+++ b/docs/php/curl.md
@@ -72,6 +72,25 @@ elephc app.php --with-curl
 `false` for a curl-free program. AOT code and `eval()` inside the same binary can
 never disagree about it.
 
+## Monitoring and trace propagation
+
+In a binary built with `--with-monitoring`, an active exact capture counts curl
+transfers separately from database queries and records their elapsed network
+wait. Easy transfers count once per `curl_exec()`; multi transfers count once
+per attached easy handle, while `curl_multi_select()` contributes its blocked
+duration. The monitor table, HTML graph, performance assertions and
+OpenTelemetry span attributes expose those network dimensions.
+
+During a captured web request, curl also injects the current W3C `traceparent`
+into `CURLOPT_HTTPHEADER` immediately before the transfer. A header supplied by
+the program, with any letter case, always wins. Automatic propagation performs
+no allocation or clock read in steady-state dormant execution, is not copied as
+a user header by `curl_copy_handle()`, and is removed when a reused handle runs
+outside the capture that introduced it.
+
+See [Profiling](../beyond-php/profiling.md) for the `network` and
+`network_wait_ms` gates and distributed-trace stitching.
+
 ## Protocol matrix
 
 The pinned libcurl carries 25 schemes — everything a stock distribution libcurl

--- a/scripts/docs/builtin_registry.json
+++ b/scripts/docs/builtin_registry.json
@@ -1497,22 +1497,13 @@
       "effects": {
         "kind": "static",
         "names": [
-          "reads_local",
-          "writes_local",
           "reads_heap",
           "writes_heap",
-          "reads_global",
-          "reads_fs",
-          "writes_fs",
           "reads_process",
           "writes_process",
-          "output",
-          "alloc_heap",
-          "alloc_concat",
-          "may_throw",
-          "may_fatal",
           "may_warn",
-          "may_deopt"
+          "blocking_io",
+          "network_io"
         ]
       },
       "lowering": {
@@ -2685,22 +2676,13 @@
       "effects": {
         "kind": "static",
         "names": [
-          "reads_local",
-          "writes_local",
           "reads_heap",
           "writes_heap",
-          "reads_global",
-          "reads_fs",
-          "writes_fs",
           "reads_process",
           "writes_process",
-          "output",
-          "alloc_heap",
-          "alloc_concat",
-          "may_throw",
-          "may_fatal",
           "may_warn",
-          "may_deopt"
+          "blocking_io",
+          "network_io"
         ]
       },
       "lowering": {
@@ -3719,22 +3701,12 @@
       "effects": {
         "kind": "static",
         "names": [
-          "reads_local",
-          "writes_local",
           "reads_heap",
           "writes_heap",
-          "reads_global",
-          "reads_fs",
-          "writes_fs",
           "reads_process",
           "writes_process",
-          "output",
-          "alloc_heap",
-          "alloc_concat",
-          "may_throw",
-          "may_fatal",
           "may_warn",
-          "may_deopt"
+          "network_io"
         ]
       },
       "lowering": {
@@ -4234,22 +4206,13 @@
       "effects": {
         "kind": "static",
         "names": [
-          "reads_local",
-          "writes_local",
           "reads_heap",
           "writes_heap",
-          "reads_global",
-          "reads_fs",
-          "writes_fs",
           "reads_process",
           "writes_process",
-          "output",
-          "alloc_heap",
-          "alloc_concat",
-          "may_throw",
-          "may_fatal",
           "may_warn",
-          "may_deopt"
+          "blocking_io",
+          "network_io"
         ]
       },
       "lowering": {
@@ -6625,7 +6588,9 @@
           "may_throw",
           "may_fatal",
           "may_warn",
-          "may_deopt"
+          "may_deopt",
+          "blocking_io",
+          "network_io"
         ]
       },
       "lowering": {
@@ -6783,7 +6748,9 @@
           "may_throw",
           "may_fatal",
           "may_warn",
-          "may_deopt"
+          "may_deopt",
+          "blocking_io",
+          "network_io"
         ]
       },
       "lowering": {

--- a/scripts/docs/builtin_registry.json
+++ b/scripts/docs/builtin_registry.json
@@ -1497,11 +1497,22 @@
       "effects": {
         "kind": "static",
         "names": [
+          "reads_local",
+          "writes_local",
           "reads_heap",
           "writes_heap",
+          "reads_global",
+          "reads_fs",
+          "writes_fs",
           "reads_process",
           "writes_process",
+          "output",
+          "alloc_heap",
+          "alloc_concat",
+          "may_throw",
+          "may_fatal",
           "may_warn",
+          "may_deopt",
           "blocking_io",
           "network_io"
         ]
@@ -3701,11 +3712,22 @@
       "effects": {
         "kind": "static",
         "names": [
+          "reads_local",
+          "writes_local",
           "reads_heap",
           "writes_heap",
+          "reads_global",
+          "reads_fs",
+          "writes_fs",
           "reads_process",
           "writes_process",
+          "output",
+          "alloc_heap",
+          "alloc_concat",
+          "may_throw",
+          "may_fatal",
           "may_warn",
+          "may_deopt",
           "network_io"
         ]
       },

--- a/src/builtins/registry.rs
+++ b/src/builtins/registry.rs
@@ -818,6 +818,7 @@ mod tests {
                 assert_eq!(descriptor.effects, runtime_fn.effects());
                 assert_eq!(descriptor.result_ownership, runtime_fn.result_ownership());
                 assert_eq!(descriptor.requirements, runtime_fn.requirements());
+                assert_eq!(descriptor.monitoring, runtime_fn.monitoring_policy());
                 assert_eq!(
                     descriptor.backend_mapping,
                     crate::ir::RuntimeFnBackendMapping::TargetAwareEmitter,
@@ -826,6 +827,66 @@ mod tests {
                     descriptor.target_support,
                     crate::ir::RuntimeFnTargetSupport::AllSupported,
                 );
+                let bridge_backed = descriptor.requirements.iter().any(|requirement| {
+                    matches!(
+                        requirement,
+                        crate::builtins::semantics::BuiltinRequirement::Bridge(_)
+                    )
+                });
+                let io_effects = crate::ir::Effects::from_bits_retain(
+                    crate::ir::Effects::BLOCKING_IO.bits()
+                        | crate::ir::Effects::NETWORK_IO.bits(),
+                );
+                if bridge_backed || descriptor.effects.intersects(io_effects) {
+                    assert!(
+                        descriptor.monitoring.is_reviewed(),
+                        "{} runtime target {} needs an explicit monitoring policy",
+                        name,
+                        descriptor.eir_name,
+                    );
+                }
+                if descriptor.effects.intersects(io_effects) {
+                    assert!(
+                        descriptor.monitoring.is_evented(),
+                        "{} runtime target {} declares I/O effects without evented monitoring",
+                        name,
+                        descriptor.eir_name,
+                    );
+                }
+                if descriptor
+                    .effects
+                    .contains(crate::ir::Effects::NETWORK_IO)
+                {
+                    assert!(
+                        matches!(
+                            descriptor.monitoring,
+                            elephc_monitoring_contract::MonitoringPolicy::Io {
+                                kind: elephc_monitoring_contract::IoKind::Network,
+                                ..
+                            }
+                        ),
+                        "{} runtime target {} must classify network effects as network events",
+                        name,
+                        descriptor.eir_name,
+                    );
+                }
+                if descriptor
+                    .effects
+                    .contains(crate::ir::Effects::BLOCKING_IO)
+                {
+                    assert!(
+                        matches!(
+                            descriptor.monitoring,
+                            elephc_monitoring_contract::MonitoringPolicy::Io {
+                                wait: elephc_monitoring_contract::WaitPolicy::Measured,
+                                ..
+                            }
+                        ),
+                        "{} runtime target {} must measure declared blocking I/O",
+                        name,
+                        descriptor.eir_name,
+                    );
+                }
             }
         }
     }

--- a/src/call_graph.rs
+++ b/src/call_graph.rs
@@ -53,12 +53,16 @@ pub(crate) struct GraphNode {
     pub wait_inclusive: u64,
     #[serde(default)]
     pub wait_exclusive: u64,
-    /// Exact outgoing network operation count attributed to this function.
+    /// Exact inclusive/exclusive outgoing network operation counts.
     #[serde(default)]
-    pub network_ops: u64,
-    /// Exact nanoseconds blocked in outgoing network work by this function.
+    pub network_inclusive: u64,
+    #[serde(default, alias = "network_ops")]
+    pub network_exclusive: u64,
+    /// Exact inclusive/exclusive nanoseconds blocked in outgoing network work.
     #[serde(default)]
-    pub network_wait: u64,
+    pub network_wait_inclusive: u64,
+    #[serde(default, alias = "network_wait")]
+    pub network_wait_exclusive: u64,
     /// Runtime-cause breakdown of this function's exclusive time, most first.
     pub causes: Vec<(String, u64)>,
 }
@@ -385,11 +389,20 @@ pub(crate) fn render_dot(graph: &CallGraph) -> String {
         if node.alloc_inclusive > 0 {
             let _ = write!(label, "\\n{} allocs self", node.alloc_exclusive);
         }
-        if node.network_ops > 0 {
-            let _ = write!(label, "\\n{} network ops", node.network_ops);
+        if node.network_inclusive > 0 {
+            let _ = write!(
+                label,
+                "\\n{} network ops self, {} incl",
+                node.network_exclusive, node.network_inclusive
+            );
         }
-        if node.network_wait > 0 {
-            let _ = write!(label, "\\n{} network wait", fmt_ns_short(node.network_wait));
+        if node.network_wait_inclusive > 0 {
+            let _ = write!(
+                label,
+                "\\n{} network wait self, {} incl",
+                fmt_ns_short(node.network_wait_exclusive),
+                fmt_ns_short(node.network_wait_inclusive)
+            );
         }
         if let Some((cause, samples)) = node.causes.first() {
             let _ = write!(label, "\\n{}: {:.0}%", cause, graph.share(*samples));
@@ -471,8 +484,10 @@ pub(crate) fn render_html_frames(
                         "retExclN": node.retained_exclusive,
                         "waitInclN": node.wait_inclusive,
                         "waitExclN": node.wait_exclusive,
-                        "networkN": node.network_ops,
-                        "networkWaitN": node.network_wait,
+                        "networkInclN": node.network_inclusive,
+                        "networkExclN": node.network_exclusive,
+                        "networkWaitInclN": node.network_wait_inclusive,
+                        "networkWaitExclN": node.network_wait_exclusive,
                         "causes": node.causes.iter()
                             .map(|(c, s)| serde_json::json!({"name": c, "pct": g.share(*s)}))
                             .collect::<Vec<_>>(),
@@ -1171,8 +1186,8 @@ const DATA = __DATA_JSON__;
   const hasIo = !!DATA.exact && FRAMES.some(f => f.nodes.some(n => (n.ioInclN || 0) > 0));
   const hasRet = !!DATA.exact && FRAMES.some(f => f.nodes.some(n => (n.retInclN || 0) !== 0));
   const hasWait = !!DATA.exact && FRAMES.some(f => f.nodes.some(n => (n.waitInclN || 0) > 0));
-  const hasNetwork = !!DATA.exact && FRAMES.some(f => f.nodes.some(n => (n.networkN || 0) > 0));
-  const hasNetworkWait = !!DATA.exact && FRAMES.some(f => f.nodes.some(n => (n.networkWaitN || 0) > 0));
+  const hasNetwork = !!DATA.exact && FRAMES.some(f => f.nodes.some(n => (n.networkInclN || 0) > 0));
+  const hasNetworkWait = !!DATA.exact && FRAMES.some(f => f.nodes.some(n => (n.networkWaitInclN || 0) > 0));
   // Selectable cost dimensions (Blackfire-style). Availability depends on data.
   const METRICS = [
     { key: 'time',  label: 'Time',     icon: '⏱', on: !!DATA.exact },
@@ -1188,14 +1203,14 @@ const DATA = __DATA_JSON__;
   let frameIoTotal = 0, frameNetworkTotal = 0, frameCallMax = 1, frameRetMax = 1;
   function computeScales(fN) {
     frameIoTotal = 0; frameNetworkTotal = 0; frameCallMax = 1; frameRetMax = 1;
-    fN.forEach(n => { frameIoTotal += (n.ioExclN || 0); frameNetworkTotal += (n.networkN || 0); if ((n.calls || 0) > frameCallMax) frameCallMax = n.calls;
+    fN.forEach(n => { frameIoTotal += (n.ioExclN || 0); frameNetworkTotal += (n.networkExclN || 0); if ((n.calls || 0) > frameCallMax) frameCallMax = n.calls;
       const r = Math.abs(n.retInclN || 0); if (r > frameRetMax) frameRetMax = r; });
   }
   function nodeShare(n) {
     if (metric === 'mem') return n.allocExcl || 0;
     if (metric === 'io') return frameIoTotal ? 100 * (n.ioExclN || 0) / frameIoTotal : 0;
-    if (metric === 'network') return frameNetworkTotal ? 100 * (n.networkN || 0) / frameNetworkTotal : 0;
-    if (metric === 'networkWait') return waitShare(n.networkWaitN);
+    if (metric === 'network') return frameNetworkTotal ? 100 * (n.networkExclN || 0) / frameNetworkTotal : 0;
+    if (metric === 'networkWait') return waitShare(n.networkWaitExclN);
     if (metric === 'calls') return frameCallMax ? 100 * (n.calls || 0) / frameCallMax : 0;
     // Retained is signed; only net GROWTH is "hot" (a net release is cold).
     if (metric === 'ret') return frameRetMax ? 100 * Math.max(0, n.retExclN || 0) / frameRetMax : 0;
@@ -1219,8 +1234,8 @@ const DATA = __DATA_JSON__;
   function nodeInclShare(n) {
     if (metric === 'mem') return n.allocIncl || 0;
     if (metric === 'io') return frameIoTotal ? 100 * (n.ioInclN || 0) / frameIoTotal : 0;
-    if (metric === 'network') return frameNetworkTotal ? 100 * (n.networkN || 0) / frameNetworkTotal : 0;
-    if (metric === 'networkWait') return waitShare(n.networkWaitN);
+    if (metric === 'network') return frameNetworkTotal ? 100 * (n.networkInclN || 0) / frameNetworkTotal : 0;
+    if (metric === 'networkWait') return waitShare(n.networkWaitInclN);
     if (metric === 'calls') return frameCallMax ? 100 * (n.calls || 0) / frameCallMax : 0;
     if (metric === 'ret') return frameRetMax ? 100 * Math.max(0, n.retInclN || 0) / frameRetMax : 0;
     if (metric === 'wait') return waitShare(n.waitInclN);
@@ -1231,8 +1246,8 @@ const DATA = __DATA_JSON__;
   function metricValue(n) {
     if (metric === 'mem') return fmtK(n.allocExclN || 0);
     if (metric === 'io') return (n.ioExclN || 0) + ' q';
-    if (metric === 'network') return (n.networkN || 0) + ' ops';
-    if (metric === 'networkWait') return fmtNs(n.networkWaitN || 0);
+    if (metric === 'network') return (n.networkExclN || 0) + ' ops';
+    if (metric === 'networkWait') return fmtNs(n.networkWaitExclN || 0);
     if (metric === 'calls') return fmtK(n.calls || 0);
     if (metric === 'ret') return fmtSigned(n.retExclN || 0);
     if (metric === 'wait') return fmtNs(n.waitExclN || 0);
@@ -1241,8 +1256,8 @@ const DATA = __DATA_JSON__;
   function metricSub(n) {
     if (metric === 'mem') return 'incl ' + fmtK(n.allocInclN || 0) + ' allocs';
     if (metric === 'io') return 'incl ' + (n.ioInclN || 0) + ' q';
-    if (metric === 'network') return 'outgoing network operations';
-    if (metric === 'networkWait') return 'outgoing network wait';
+    if (metric === 'network') return 'incl ' + (n.networkInclN || 0) + ' network ops';
+    if (metric === 'networkWait') return 'incl network wait ' + fmtNs(n.networkWaitInclN || 0);
     if (metric === 'calls') return 'self ' + n.excl.toFixed(1) + '% time';
     if (metric === 'ret') return 'incl ' + fmtSigned(n.retInclN || 0) + ' retained';
     if (metric === 'wait') return 'non-DB ' + fmtNs(nonDbNs(n)) + ' · incl wait ' + fmtNs(n.waitInclN || 0);
@@ -1251,8 +1266,8 @@ const DATA = __DATA_JSON__;
   function nodeSub(n) {
     if (metric === 'mem') return fmtK(n.allocExclN || 0) + ' allocs · incl ' + n.allocIncl.toFixed(0) + '%';
     if (metric === 'io') return (n.ioExclN || 0) + ' queries';
-    if (metric === 'network') return (n.networkN || 0) + ' network ops';
-    if (metric === 'networkWait') return 'network wait ' + fmtNs(n.networkWaitN || 0);
+    if (metric === 'network') return (n.networkExclN || 0) + ' network ops · incl ' + (n.networkInclN || 0);
+    if (metric === 'networkWait') return 'network wait ' + fmtNs(n.networkWaitExclN || 0) + ' · incl ' + fmtNs(n.networkWaitInclN || 0);
     if (metric === 'calls') return (n.calls || 0) + ' calls';
     if (metric === 'ret') return fmtSigned(n.retExclN || 0) + ' retained · incl ' + fmtSigned(n.retInclN || 0);
     if (metric === 'wait') return 'wait ' + fmtNs(n.waitExclN || 0) + ' · non-DB ' + fmtNs(nonDbNs(n));
@@ -1415,8 +1430,14 @@ const DATA = __DATA_JSON__;
         html += '<div class="row"><span>queries incl</span><b>' + (n.ioInclN || 0) + '</b></div>';
         html += '<div class="row"><span>queries self</span><b>' + (n.ioExclN || 0) + '</b></div>';
       }
-      if (hasNetwork) html += '<div class="row"><span>network operations</span><b>' + (n.networkN || 0) + '</b></div>';
-      if (hasNetworkWait) html += '<div class="row"><span>network wait</span><b>' + fmtNs(n.networkWaitN || 0) + '</b></div>';
+      if (hasNetwork) {
+        html += '<div class="row"><span>network operations incl</span><b>' + (n.networkInclN || 0) + '</b></div>';
+        html += '<div class="row"><span>network operations self</span><b>' + (n.networkExclN || 0) + '</b></div>';
+      }
+      if (hasNetworkWait) {
+        html += '<div class="row"><span>network wait incl</span><b>' + fmtNs(n.networkWaitInclN || 0) + '</b></div>';
+        html += '<div class="row"><span>network wait self</span><b>' + fmtNs(n.networkWaitExclN || 0) + '</b></div>';
+      }
       n.causes.forEach(c => { html += '<div class="cause">' + esc(c.name) + ' — ' + c.pct.toFixed(1) + '%<div class="bar" style="width:' + Math.min(100, c.pct*2) + '%"></div></div>'; });
     }
     tip.innerHTML = html; tip.style.display = 'block';
@@ -1499,7 +1520,7 @@ const DATA = __DATA_JSON__;
     const head = metric === 'mem' ? (FRAMES[i].totalAllocs + ' allocations')
       : metric === 'io' ? (frameIoTotal + ' queries')
       : metric === 'network' ? (frameNetworkTotal + ' network operations')
-      : metric === 'networkWait' ? (() => { let w = 0; fN.forEach(n => { w += (n.networkWaitN || 0); });
+      : metric === 'networkWait' ? (() => { let w = 0; fN.forEach(n => { w += (n.networkWaitExclN || 0); });
           return fmtNs(w) + ' network wait of ' + fmtNs(FRAMES[i].total); })()
       : metric === 'ret' ? (fmtSigned(rootRet) + ' retained')
       : metric === 'wait' ? (() => { let w = 0; fN.forEach(n => { w += (n.waitExclN || 0); });
@@ -2413,8 +2434,10 @@ mod tests {
                     retained_exclusive: 0,
                     wait_inclusive: 0,
                     wait_exclusive: 0,
-                    network_ops: 0,
-                    network_wait: 0,
+                    network_inclusive: 0,
+                    network_exclusive: 0,
+                    network_wait_inclusive: 0,
+                    network_wait_exclusive: 0,
                     causes: vec![],
                 },
                 GraphNode {
@@ -2430,8 +2453,10 @@ mod tests {
                     retained_exclusive: 0,
                     wait_inclusive: 0,
                     wait_exclusive: 0,
-                    network_ops: 0,
-                    network_wait: 0,
+                    network_inclusive: 0,
+                    network_exclusive: 0,
+                    network_wait_inclusive: 0,
+                    network_wait_exclusive: 0,
                     causes: vec![("heap allocation".into(), 30), ("Mixed cell boxing".into(), 20)],
                 },
             ],
@@ -2647,8 +2672,10 @@ mod tests {
                 retained_exclusive: 0,
                 wait_inclusive: 0,
                 wait_exclusive: 0,
-                network_ops: 0,
-                network_wait: 0,
+                network_inclusive: 0,
+                network_exclusive: 0,
+                network_wait_inclusive: 0,
+                network_wait_exclusive: 0,
                 causes: vec![],
             }],
             edges: vec![],

--- a/src/call_graph.rs
+++ b/src/call_graph.rs
@@ -53,6 +53,12 @@ pub(crate) struct GraphNode {
     pub wait_inclusive: u64,
     #[serde(default)]
     pub wait_exclusive: u64,
+    /// Exact outgoing network operation count attributed to this function.
+    #[serde(default)]
+    pub network_ops: u64,
+    /// Exact nanoseconds blocked in outgoing network work by this function.
+    #[serde(default)]
+    pub network_wait: u64,
     /// Runtime-cause breakdown of this function's exclusive time, most first.
     pub causes: Vec<(String, u64)>,
 }
@@ -183,6 +189,8 @@ pub(crate) struct TraceSpan {
     pub functions: usize,
     pub queries: u64,
     pub wait_ns: u64,
+    pub network_ops: u64,
+    pub network_wait_ns: u64,
     /// Wall-clock microseconds at which the span opened, when the capture
     /// recorded it. Present spans are laid out on a real time axis; without it
     /// the chart can only compare durations.
@@ -283,6 +291,12 @@ pub(crate) fn render_trace_html(spans: &[TraceSpan], title: &str) -> String {
             if span.wait_ns > 0 {
                 facts.push(format!("{} waiting", fmt_ns_short(span.wait_ns)));
             }
+            if span.network_ops > 0 {
+                facts.push(format!("{} network", span.network_ops));
+            }
+            if span.network_wait_ns > 0 {
+                facts.push(format!("{} network wait", fmt_ns_short(span.network_wait_ns)));
+            }
             let top: String = span
                 .top
                 .iter()
@@ -371,6 +385,12 @@ pub(crate) fn render_dot(graph: &CallGraph) -> String {
         if node.alloc_inclusive > 0 {
             let _ = write!(label, "\\n{} allocs self", node.alloc_exclusive);
         }
+        if node.network_ops > 0 {
+            let _ = write!(label, "\\n{} network ops", node.network_ops);
+        }
+        if node.network_wait > 0 {
+            let _ = write!(label, "\\n{} network wait", fmt_ns_short(node.network_wait));
+        }
         if let Some((cause, samples)) = node.causes.first() {
             let _ = write!(label, "\\n{}: {:.0}%", cause, graph.share(*samples));
         }
@@ -451,6 +471,8 @@ pub(crate) fn render_html_frames(
                         "retExclN": node.retained_exclusive,
                         "waitInclN": node.wait_inclusive,
                         "waitExclN": node.wait_exclusive,
+                        "networkN": node.network_ops,
+                        "networkWaitN": node.network_wait,
                         "causes": node.causes.iter()
                             .map(|(c, s)| serde_json::json!({"name": c, "pct": g.share(*s)}))
                             .collect::<Vec<_>>(),
@@ -1149,6 +1171,8 @@ const DATA = __DATA_JSON__;
   const hasIo = !!DATA.exact && FRAMES.some(f => f.nodes.some(n => (n.ioInclN || 0) > 0));
   const hasRet = !!DATA.exact && FRAMES.some(f => f.nodes.some(n => (n.retInclN || 0) !== 0));
   const hasWait = !!DATA.exact && FRAMES.some(f => f.nodes.some(n => (n.waitInclN || 0) > 0));
+  const hasNetwork = !!DATA.exact && FRAMES.some(f => f.nodes.some(n => (n.networkN || 0) > 0));
+  const hasNetworkWait = !!DATA.exact && FRAMES.some(f => f.nodes.some(n => (n.networkWaitN || 0) > 0));
   // Selectable cost dimensions (Blackfire-style). Availability depends on data.
   const METRICS = [
     { key: 'time',  label: 'Time',     icon: '⏱', on: !!DATA.exact },
@@ -1156,18 +1180,22 @@ const DATA = __DATA_JSON__;
     { key: 'ret',   label: 'Retained', icon: '💧', on: hasRet },
     { key: 'wait',  label: 'Wait',     icon: '⏳', on: hasWait },
     { key: 'io',    label: 'SQL',      icon: '🗄', on: hasIo },
+    { key: 'network', label: 'Network', icon: '↗', on: hasNetwork },
+    { key: 'networkWait', label: 'Net wait', icon: '🌐', on: hasNetworkWait },
     { key: 'calls', label: 'Calls',    icon: '#',  on: !!DATA.exact },
   ];
   // Per-frame scales used to color the io / calls / retained dimensions.
-  let frameIoTotal = 0, frameCallMax = 1, frameRetMax = 1;
+  let frameIoTotal = 0, frameNetworkTotal = 0, frameCallMax = 1, frameRetMax = 1;
   function computeScales(fN) {
-    frameIoTotal = 0; frameCallMax = 1; frameRetMax = 1;
-    fN.forEach(n => { frameIoTotal += (n.ioExclN || 0); if ((n.calls || 0) > frameCallMax) frameCallMax = n.calls;
+    frameIoTotal = 0; frameNetworkTotal = 0; frameCallMax = 1; frameRetMax = 1;
+    fN.forEach(n => { frameIoTotal += (n.ioExclN || 0); frameNetworkTotal += (n.networkN || 0); if ((n.calls || 0) > frameCallMax) frameCallMax = n.calls;
       const r = Math.abs(n.retInclN || 0); if (r > frameRetMax) frameRetMax = r; });
   }
   function nodeShare(n) {
     if (metric === 'mem') return n.allocExcl || 0;
     if (metric === 'io') return frameIoTotal ? 100 * (n.ioExclN || 0) / frameIoTotal : 0;
+    if (metric === 'network') return frameNetworkTotal ? 100 * (n.networkN || 0) / frameNetworkTotal : 0;
+    if (metric === 'networkWait') return waitShare(n.networkWaitN);
     if (metric === 'calls') return frameCallMax ? 100 * (n.calls || 0) / frameCallMax : 0;
     // Retained is signed; only net GROWTH is "hot" (a net release is cold).
     if (metric === 'ret') return frameRetMax ? 100 * Math.max(0, n.retExclN || 0) / frameRetMax : 0;
@@ -1191,6 +1219,8 @@ const DATA = __DATA_JSON__;
   function nodeInclShare(n) {
     if (metric === 'mem') return n.allocIncl || 0;
     if (metric === 'io') return frameIoTotal ? 100 * (n.ioInclN || 0) / frameIoTotal : 0;
+    if (metric === 'network') return frameNetworkTotal ? 100 * (n.networkN || 0) / frameNetworkTotal : 0;
+    if (metric === 'networkWait') return waitShare(n.networkWaitN);
     if (metric === 'calls') return frameCallMax ? 100 * (n.calls || 0) / frameCallMax : 0;
     if (metric === 'ret') return frameRetMax ? 100 * Math.max(0, n.retInclN || 0) / frameRetMax : 0;
     if (metric === 'wait') return waitShare(n.waitInclN);
@@ -1201,6 +1231,8 @@ const DATA = __DATA_JSON__;
   function metricValue(n) {
     if (metric === 'mem') return fmtK(n.allocExclN || 0);
     if (metric === 'io') return (n.ioExclN || 0) + ' q';
+    if (metric === 'network') return (n.networkN || 0) + ' ops';
+    if (metric === 'networkWait') return fmtNs(n.networkWaitN || 0);
     if (metric === 'calls') return fmtK(n.calls || 0);
     if (metric === 'ret') return fmtSigned(n.retExclN || 0);
     if (metric === 'wait') return fmtNs(n.waitExclN || 0);
@@ -1209,6 +1241,8 @@ const DATA = __DATA_JSON__;
   function metricSub(n) {
     if (metric === 'mem') return 'incl ' + fmtK(n.allocInclN || 0) + ' allocs';
     if (metric === 'io') return 'incl ' + (n.ioInclN || 0) + ' q';
+    if (metric === 'network') return 'outgoing network operations';
+    if (metric === 'networkWait') return 'outgoing network wait';
     if (metric === 'calls') return 'self ' + n.excl.toFixed(1) + '% time';
     if (metric === 'ret') return 'incl ' + fmtSigned(n.retInclN || 0) + ' retained';
     if (metric === 'wait') return 'non-DB ' + fmtNs(nonDbNs(n)) + ' · incl wait ' + fmtNs(n.waitInclN || 0);
@@ -1217,6 +1251,8 @@ const DATA = __DATA_JSON__;
   function nodeSub(n) {
     if (metric === 'mem') return fmtK(n.allocExclN || 0) + ' allocs · incl ' + n.allocIncl.toFixed(0) + '%';
     if (metric === 'io') return (n.ioExclN || 0) + ' queries';
+    if (metric === 'network') return (n.networkN || 0) + ' network ops';
+    if (metric === 'networkWait') return 'network wait ' + fmtNs(n.networkWaitN || 0);
     if (metric === 'calls') return (n.calls || 0) + ' calls';
     if (metric === 'ret') return fmtSigned(n.retExclN || 0) + ' retained · incl ' + fmtSigned(n.retInclN || 0);
     if (metric === 'wait') return 'wait ' + fmtNs(n.waitExclN || 0) + ' · non-DB ' + fmtNs(nonDbNs(n));
@@ -1379,6 +1415,8 @@ const DATA = __DATA_JSON__;
         html += '<div class="row"><span>queries incl</span><b>' + (n.ioInclN || 0) + '</b></div>';
         html += '<div class="row"><span>queries self</span><b>' + (n.ioExclN || 0) + '</b></div>';
       }
+      if (hasNetwork) html += '<div class="row"><span>network operations</span><b>' + (n.networkN || 0) + '</b></div>';
+      if (hasNetworkWait) html += '<div class="row"><span>network wait</span><b>' + fmtNs(n.networkWaitN || 0) + '</b></div>';
       n.causes.forEach(c => { html += '<div class="cause">' + esc(c.name) + ' — ' + c.pct.toFixed(1) + '%<div class="bar" style="width:' + Math.min(100, c.pct*2) + '%"></div></div>'; });
     }
     tip.innerHTML = html; tip.style.display = 'block';
@@ -1460,6 +1498,9 @@ const DATA = __DATA_JSON__;
     const rootRet = (() => { let m = 0; fN.forEach(n => { if ((n.retInclN || 0) > m) m = n.retInclN; }); return m; })();
     const head = metric === 'mem' ? (FRAMES[i].totalAllocs + ' allocations')
       : metric === 'io' ? (frameIoTotal + ' queries')
+      : metric === 'network' ? (frameNetworkTotal + ' network operations')
+      : metric === 'networkWait' ? (() => { let w = 0; fN.forEach(n => { w += (n.networkWaitN || 0); });
+          return fmtNs(w) + ' network wait of ' + fmtNs(FRAMES[i].total); })()
       : metric === 'ret' ? (fmtSigned(rootRet) + ' retained')
       : metric === 'wait' ? (() => { let w = 0; fN.forEach(n => { w += (n.waitExclN || 0); });
           return fmtNs(w) + ' waiting of ' + fmtNs(FRAMES[i].total); })()
@@ -2372,6 +2413,8 @@ mod tests {
                     retained_exclusive: 0,
                     wait_inclusive: 0,
                     wait_exclusive: 0,
+                    network_ops: 0,
+                    network_wait: 0,
                     causes: vec![],
                 },
                 GraphNode {
@@ -2387,6 +2430,8 @@ mod tests {
                     retained_exclusive: 0,
                     wait_inclusive: 0,
                     wait_exclusive: 0,
+                    network_ops: 0,
+                    network_wait: 0,
                     causes: vec![("heap allocation".into(), 30), ("Mixed cell boxing".into(), 20)],
                 },
             ],
@@ -2423,12 +2468,17 @@ mod tests {
             functions: 2,
             queries: 0,
             wait_ns: 0,
+            network_ops: 0,
+            network_wait_ns: 0,
             start_us: None,
             top: vec![("handle".into(), 100.0, 40.0)],
         };
+        let mut gateway = span("gateway", "aaaa", "", 1_000_000);
+        gateway.network_ops = 2;
+        gateway.network_wait_ns = 300_000;
         let html = render_trace_html(
             &[
-                span("gateway", "aaaa", "", 1_000_000),
+                gateway,
                 span("inventory", "bbbb", "aaaa", 250_000),
                 // Parent absent from the capture: must still render, as a root.
                 span("billing", "cccc", "zzzz", 500_000),
@@ -2444,6 +2494,8 @@ mod tests {
         // Bars scale against the trace's slowest span, not a global maximum.
         assert!(html.contains("width:100.00%"), "{html}");
         assert!(html.contains("width:25.00%"), "{html}");
+        assert!(html.contains("2 network"), "{html}");
+        assert!(html.contains("300.0 µs network wait"), "{html}");
         // Self-contained: no network reference of any kind.
         assert!(!html.contains("http://"), "{html}");
         assert!(!html.contains("https://"), "{html}");
@@ -2464,6 +2516,8 @@ mod tests {
             functions: 1,
             queries: 0,
             wait_ns: 0,
+            network_ops: 0,
+            network_wait_ns: 0,
             start_us,
             top: vec![],
         };
@@ -2530,6 +2584,8 @@ mod tests {
                 functions: 1,
                 queries: 0,
                 wait_ns: 0,
+                network_ops: 0,
+                network_wait_ns: 0,
                 start_us: None,
                 top: vec![("evil</td><img>".into(), 1.0, 1.0)],
             }],
@@ -2591,6 +2647,8 @@ mod tests {
                 retained_exclusive: 0,
                 wait_inclusive: 0,
                 wait_exclusive: 0,
+                network_ops: 0,
+                network_wait: 0,
                 causes: vec![],
             }],
             edges: vec![],

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -152,8 +152,9 @@ Codegen:
                           counts to stderr at exit
   --with-monitoring       Embed the profiling capability, dormant until `elephc monitor`
                           asks. Local/--exact captures report exact wall time,
-                          allocations, retained objects, DB queries/wait and calls,
-                          rooted at {main}; file I/O is not measured. A service's
+                          allocations, retained objects, DB queries/wait, outgoing
+                          network operations/wait and calls, rooted at {main}; file
+                          I/O is not measured. A service's
                           default answer is sampled CPU time. Inlined functions
                           fold into their caller (as with --counters).
   --with-monitoring=NAMES Embed it for the named functions only (comma list; trailing

--- a/src/codegen/frame.rs
+++ b/src/codegen/frame.rs
@@ -1434,6 +1434,16 @@ fn emit_probe_init(ctx: &mut FunctionContext<'_>) {
         0,
     );
     if !ctx.shared.instrument.is_on() {
+        // Let bridges ask whether the probe's shared event window is active.
+        // Unlike the exact-capture word, this observes remote asks in workers.
+        let event_active = target.extern_symbol("elephc_probe_event_active");
+        abi::emit_symbol_address(ctx.emitter, scratch, &event_active);
+        abi::emit_store_reg_to_symbol(
+            ctx.emitter,
+            scratch,
+            &target.extern_symbol("elephc_monitor_event_active_fn"),
+            0,
+        );
         let note_io = target.extern_symbol("elephc_probe_note_io");
         abi::emit_symbol_address(ctx.emitter, scratch, &note_io);
         abi::emit_store_reg_to_symbol(

--- a/src/codegen/frame.rs
+++ b/src/codegen/frame.rs
@@ -1450,6 +1450,22 @@ fn emit_probe_init(ctx: &mut FunctionContext<'_>) {
             &target.extern_symbol("elephc_instr_wait_fn"),
             0,
         );
+        let note_network = target.extern_symbol("elephc_probe_note_network");
+        abi::emit_symbol_address(ctx.emitter, scratch, &note_network);
+        abi::emit_store_reg_to_symbol(
+            ctx.emitter,
+            scratch,
+            &target.extern_symbol("elephc_instr_network_fn"),
+            0,
+        );
+        let note_network_wait = target.extern_symbol("elephc_probe_note_network_wait");
+        abi::emit_symbol_address(ctx.emitter, scratch, &note_network_wait);
+        abi::emit_store_reg_to_symbol(
+            ctx.emitter,
+            scratch,
+            &target.extern_symbol("elephc_instr_network_wait_fn"),
+            0,
+        );
     }
 }
 
@@ -1510,6 +1526,23 @@ fn emit_instr_init(ctx: &mut FunctionContext<'_>) {
     let wait_fn = target.extern_symbol("elephc_instr_wait");
     abi::emit_symbol_address(ctx.emitter, scratch, &wait_fn);
     abi::emit_store_reg_to_symbol(ctx.emitter, scratch, &target.extern_symbol("elephc_instr_wait_fn"), 0);
+    // Network slots remain separate so HTTP requests never inflate DB query or wait metrics.
+    let network_fn = target.extern_symbol("elephc_instr_network");
+    abi::emit_symbol_address(ctx.emitter, scratch, &network_fn);
+    abi::emit_store_reg_to_symbol(
+        ctx.emitter,
+        scratch,
+        &target.extern_symbol("elephc_instr_network_fn"),
+        0,
+    );
+    let network_wait_fn = target.extern_symbol("elephc_instr_network_wait");
+    abi::emit_symbol_address(ctx.emitter, scratch, &network_wait_fn);
+    abi::emit_store_reg_to_symbol(
+        ctx.emitter,
+        scratch,
+        &target.extern_symbol("elephc_instr_network_wait_fn"),
+        0,
+    );
     // Fourth slot: elephc_instr_trace_begin, so the web bridge can open each
     // request's W3C trace context (distributed profiling).
     let trace_fn = target.extern_symbol("elephc_instr_trace_begin");

--- a/src/codegen_support/runtime/data/fixed.rs
+++ b/src/codegen_support/runtime/data/fixed.rs
@@ -335,6 +335,17 @@ pub(crate) fn emit_runtime_data_fixed(heap_size: usize, target: Target) -> Strin
     // reports the nanoseconds through it, which separates recorded DB wait from
     // each function's remaining wall time. Zero (inert) in a normal binary.
     out.push_str(&comm_directive(&target.extern_symbol("elephc_instr_wait_fn"), 8, target));
+    // elephc_instr_network_fn: category-specific companion used by outgoing
+    // network bridges. Keeping this separate from the DB slot preserves query
+    // budgets and N+1 analysis when a request also performs HTTP calls.
+    out.push_str(&comm_directive(&target.extern_symbol("elephc_instr_network_fn"), 8, target));
+    // elephc_instr_network_wait_fn: blocked network duration reported without
+    // folding it into the DB-driver wait metric.
+    out.push_str(&comm_directive(
+        &target.extern_symbol("elephc_instr_network_wait_fn"),
+        8,
+        target,
+    ));
     // elephc_instr_trace_fn: fourth companion slot, filled with
     // elephc_instr_trace_begin under --instrument. The web bridge calls it at
     // the start of every request with the inbound W3C `traceparent`, so a

--- a/src/codegen_support/runtime/data/fixed.rs
+++ b/src/codegen_support/runtime/data/fixed.rs
@@ -313,6 +313,15 @@ pub(crate) fn emit_runtime_data_fixed(heap_size: usize, target: Target) -> Strin
     // it. One check, in one place: repeating it would consume the control
     // channel's marker twice and the second reader would see nothing.
     out.push_str(&comm_directive(&target.extern_symbol("elephc_monitor_active"), 8, target));
+    // elephc_monitor_event_active_fn: optional callback for a monitoring
+    // consumer whose shared event window is not represented by the exact-slice
+    // word above. The sampled probe installs it so bridges can avoid clock reads
+    // while dormant without losing remote-probe wait measurements.
+    out.push_str(&comm_directive(
+        &target.extern_symbol("elephc_monitor_event_active_fn"),
+        8,
+        target,
+    ));
     // elephc_probe_allocs_ptr: the ADDRESS of `_gc_allocs`, published under
     // --probe so the sampler can read the allocation counter without declaring
     // that symbol itself. `_gc_allocs` is spelled with a hardcoded underscore

--- a/src/ir/effects.rs
+++ b/src/ir/effects.rs
@@ -32,6 +32,8 @@ bitflags! {
         const MAY_FATAL      = 1 << 15;
         const MAY_WARN       = 1 << 16;
         const MAY_DEOPT      = 1 << 17;
+        const BLOCKING_IO    = 1 << 18;
+        const NETWORK_IO     = 1 << 19;
     }
 }
 
@@ -50,7 +52,8 @@ impl Effects {
                 | Effects::READS_HEAP
                 | Effects::READS_GLOBAL
                 | Effects::READS_FS
-                | Effects::READS_PROCESS,
+                | Effects::READS_PROCESS
+                | Effects::NETWORK_IO,
         )
     }
 
@@ -76,7 +79,9 @@ impl Effects {
                     | Effects::MAY_THROW
                     | Effects::MAY_FATAL
                     | Effects::MAY_WARN
-                    | Effects::MAY_DEOPT,
+                    | Effects::MAY_DEOPT
+                    | Effects::BLOCKING_IO
+                    | Effects::NETWORK_IO,
             )
     }
 
@@ -101,6 +106,8 @@ impl Effects {
             (Effects::MAY_FATAL, "may_fatal"),
             (Effects::MAY_WARN, "may_warn"),
             (Effects::MAY_DEOPT, "may_deopt"),
+            (Effects::BLOCKING_IO, "blocking_io"),
+            (Effects::NETWORK_IO, "network_io"),
         ];
         ordered
             .iter()

--- a/src/ir/runtime_fn.rs
+++ b/src/ir/runtime_fn.rs
@@ -76,6 +76,8 @@ pub struct RuntimeFnDescriptor {
     pub backend_mapping: RuntimeFnBackendMapping,
     /// Explicit target availability.
     pub target_support: RuntimeFnTargetSupport,
+    /// Machine-audited observability decision for this runtime boundary.
+    pub monitoring: elephc_monitoring_contract::MonitoringPolicy,
 }
 
 /// Stable semantic identity for one runtime function callable from EIR.
@@ -699,6 +701,7 @@ impl RuntimeFnId {
             requirements: self.requirements(),
             backend_mapping: RuntimeFnBackendMapping::TargetAwareEmitter,
             target_support: RuntimeFnTargetSupport::AllSupported,
+            monitoring: self.monitoring_policy(),
         }
     }
 
@@ -929,6 +932,25 @@ impl RuntimeFnId {
     /// Returns the conservative observable effects for this typed backend operation.
     pub const fn effects(self) -> crate::ir::Effects {
         match self {
+            RuntimeFnId::CurlEasyPerform
+            | RuntimeFnId::CurlEasyUpkeep
+            | RuntimeFnId::CurlMultiSelect => crate::ir::Effects::from_bits_retain(
+                crate::ir::Effects::READS_HEAP.bits()
+                    | crate::ir::Effects::WRITES_HEAP.bits()
+                    | crate::ir::Effects::READS_PROCESS.bits()
+                    | crate::ir::Effects::WRITES_PROCESS.bits()
+                    | crate::ir::Effects::MAY_WARN.bits()
+                    | crate::ir::Effects::BLOCKING_IO.bits()
+                    | crate::ir::Effects::NETWORK_IO.bits(),
+            ),
+            RuntimeFnId::CurlMultiExec => crate::ir::Effects::from_bits_retain(
+                crate::ir::Effects::READS_HEAP.bits()
+                    | crate::ir::Effects::WRITES_HEAP.bits()
+                    | crate::ir::Effects::READS_PROCESS.bits()
+                    | crate::ir::Effects::WRITES_PROCESS.bits()
+                    | crate::ir::Effects::MAY_WARN.bits()
+                    | crate::ir::Effects::NETWORK_IO.bits(),
+            ),
             RuntimeFnId::BcScale => crate::ir::Effects::from_bits_retain(
                 crate::ir::Effects::READS_PROCESS.bits()
                     | crate::ir::Effects::WRITES_PROCESS.bits()
@@ -1234,7 +1256,9 @@ impl RuntimeFnId {
             _ => crate::ir::Effects::from_bits_retain(
                 crate::ir::Effects::all().bits()
                     & !crate::ir::Effects::REFCOUNT_OP.bits()
-                    & !crate::ir::Effects::WRITES_GLOBAL.bits(),
+                    & !crate::ir::Effects::WRITES_GLOBAL.bits()
+                    & !crate::ir::Effects::BLOCKING_IO.bits()
+                    & !crate::ir::Effects::NETWORK_IO.bits(),
             ),
         }
     }
@@ -1271,6 +1295,129 @@ impl RuntimeFnId {
             RuntimeFnId::CallUserFunc => E::PURE,
             RuntimeFnId::CallUserFuncArray => E::READS_HEAP,
             _ => self.effects(),
+        }
+    }
+
+    /// Returns the explicit monitoring policy for bridge-backed or I/O runtime work.
+    ///
+    /// The registry audit rejects `Unspecified` whenever an operation requires a bridge
+    /// or carries `BLOCKING_IO`/`NETWORK_IO`. Adding another bridge operation therefore
+    /// requires updating this match in the same change, even inside an existing bridge.
+    pub const fn monitoring_policy(
+        self,
+    ) -> elephc_monitoring_contract::MonitoringPolicy {
+        use elephc_monitoring_contract::{
+            IoKind, MonitoringPolicy, TraceContextPolicy, WaitPolicy,
+        };
+        match self {
+            RuntimeFnId::CurlEasyPerform => MonitoringPolicy::Io {
+                kind: IoKind::Network,
+                wait: WaitPolicy::Measured,
+                trace_context: TraceContextPolicy::Automatic,
+            },
+            RuntimeFnId::CurlEasyUpkeep | RuntimeFnId::CurlMultiSelect => {
+                MonitoringPolicy::Io {
+                    kind: IoKind::Network,
+                    wait: WaitPolicy::Measured,
+                    trace_context: TraceContextPolicy::NotApplicable,
+                }
+            }
+            RuntimeFnId::CurlMultiExec => MonitoringPolicy::Io {
+                kind: IoKind::Network,
+                wait: WaitPolicy::GenericTiming,
+                trace_context: TraceContextPolicy::Automatic,
+            },
+            RuntimeFnId::BcAdd
+            | RuntimeFnId::BcCeil
+            | RuntimeFnId::BcComp
+            | RuntimeFnId::BcDiv
+            | RuntimeFnId::BcDivmod
+            | RuntimeFnId::BcFloor
+            | RuntimeFnId::BcMod
+            | RuntimeFnId::BcMul
+            | RuntimeFnId::BcPow
+            | RuntimeFnId::BcPowmod
+            | RuntimeFnId::BcRound
+            | RuntimeFnId::BcScale
+            | RuntimeFnId::BcSqrt
+            | RuntimeFnId::BcSub
+            | RuntimeFnId::ElephcPharBzip2Archive
+            | RuntimeFnId::ElephcPharDecompressArchive
+            | RuntimeFnId::ElephcPharGetFileMetadata
+            | RuntimeFnId::ElephcPharGetMetadata
+            | RuntimeFnId::ElephcPharGetSignatureHash
+            | RuntimeFnId::ElephcPharGetSignatureType
+            | RuntimeFnId::ElephcPharGetStub
+            | RuntimeFnId::ElephcPharGzipArchive
+            | RuntimeFnId::ElephcPharListEntries
+            | RuntimeFnId::ElephcPharSetCompression
+            | RuntimeFnId::ElephcPharSetFileMetadata
+            | RuntimeFnId::ElephcPharSetMetadata
+            | RuntimeFnId::ElephcPharSetStub
+            | RuntimeFnId::ElephcPharSetZipPassword
+            | RuntimeFnId::ElephcPharSignHash
+            | RuntimeFnId::ElephcPharSignOpenssl
+            | RuntimeFnId::CurlEasyBody
+            | RuntimeFnId::CurlEasyErrno
+            | RuntimeFnId::CurlEasyError
+            | RuntimeFnId::CurlEasyGetinfoLong
+            | RuntimeFnId::CurlEasyInit
+            | RuntimeFnId::CurlEasySetoptLong
+            | RuntimeFnId::CurlEasySetCallback
+            | RuntimeFnId::CurlEasyCopy
+            | RuntimeFnId::CurlEasyPause
+            | RuntimeFnId::CurlEasyReset
+            | RuntimeFnId::CurlStrerror
+            | RuntimeFnId::CurlEasyGetinfoDouble
+            | RuntimeFnId::CurlEasyStrOp
+            | RuntimeFnId::CurlEasySetoptSlist
+            | RuntimeFnId::CurlEasySetoptStr
+            | RuntimeFnId::CurlOptionKind
+            | RuntimeFnId::CurlEasyId
+            | RuntimeFnId::CurlMultiInit
+            | RuntimeFnId::CurlMultiAdd
+            | RuntimeFnId::CurlMultiRemove
+            | RuntimeFnId::CurlMultiInfoRead
+            | RuntimeFnId::CurlMultiSetopt
+            | RuntimeFnId::CurlMultiErrno
+            | RuntimeFnId::CurlMultiStrerror
+            | RuntimeFnId::CurlShareInit
+            | RuntimeFnId::CurlShareSetopt
+            | RuntimeFnId::CurlShareErrno
+            | RuntimeFnId::CurlShareStrerror
+            | RuntimeFnId::CurlEasySetShare
+            | RuntimeFnId::CurlShareInitPersistent
+            | RuntimeFnId::CurlMimeNew
+            | RuntimeFnId::CurlMimeAddPart
+            | RuntimeFnId::CurlMimePartField
+            | RuntimeFnId::CurlMimePost
+            | RuntimeFnId::CurlMimeAbort
+            | RuntimeFnId::CurlVersion
+            | RuntimeFnId::Hash
+            | RuntimeFnId::HashCopy
+            | RuntimeFnId::HashFile
+            | RuntimeFnId::HashFinal
+            | RuntimeFnId::HashHmac
+            | RuntimeFnId::HashInit
+            | RuntimeFnId::HashUpdate
+            | RuntimeFnId::OpensslCipherIvLength
+            | RuntimeFnId::OpensslDecrypt
+            | RuntimeFnId::OpensslEncrypt
+            | RuntimeFnId::OpensslGetCipherMethods
+            | RuntimeFnId::Iconv
+            | RuntimeFnId::IconvGetEncoding
+            | RuntimeFnId::IconvMimeDecode
+            | RuntimeFnId::IconvMimeDecodeHeaders
+            | RuntimeFnId::IconvMimeEncode
+            | RuntimeFnId::IconvSetEncoding
+            | RuntimeFnId::IconvStrlen
+            | RuntimeFnId::IconvStrpos
+            | RuntimeFnId::IconvStrrpos
+            | RuntimeFnId::IconvSubstr
+            | RuntimeFnId::Md5
+            | RuntimeFnId::Sha1
+            | RuntimeFnId::StreamSocketEnableCrypto => MonitoringPolicy::GenericTiming,
+            _ => MonitoringPolicy::Unspecified,
         }
     }
 

--- a/src/ir/runtime_fn.rs
+++ b/src/ir/runtime_fn.rs
@@ -932,25 +932,31 @@ impl RuntimeFnId {
     /// Returns the conservative observable effects for this typed backend operation.
     pub const fn effects(self) -> crate::ir::Effects {
         match self {
-            RuntimeFnId::CurlEasyPerform
-            | RuntimeFnId::CurlEasyUpkeep
-            | RuntimeFnId::CurlMultiSelect => crate::ir::Effects::from_bits_retain(
-                crate::ir::Effects::READS_HEAP.bits()
-                    | crate::ir::Effects::WRITES_HEAP.bits()
-                    | crate::ir::Effects::READS_PROCESS.bits()
+            // Both transfer drivers may invoke arbitrary PHP callbacks. Keep the
+            // callback-capable conservative set, then preserve their typed network and
+            // blocking distinctions so optimizer and monitoring consumers agree.
+            RuntimeFnId::CurlEasyPerform => crate::ir::Effects::from_bits_retain(
+                crate::ir::Effects::all().bits()
+                    & !crate::ir::Effects::REFCOUNT_OP.bits()
+                    & !crate::ir::Effects::WRITES_GLOBAL.bits(),
+            ),
+            RuntimeFnId::CurlMultiExec => crate::ir::Effects::from_bits_retain(
+                crate::ir::Effects::all().bits()
+                    & !crate::ir::Effects::REFCOUNT_OP.bits()
+                    & !crate::ir::Effects::WRITES_GLOBAL.bits()
+                    & !crate::ir::Effects::BLOCKING_IO.bits(),
+            ),
+            RuntimeFnId::CurlEasyUpkeep | RuntimeFnId::CurlMultiSelect => {
+                crate::ir::Effects::from_bits_retain(
+                    crate::ir::Effects::READS_HEAP.bits()
+                        | crate::ir::Effects::WRITES_HEAP.bits()
+                        | crate::ir::Effects::READS_PROCESS.bits()
                     | crate::ir::Effects::WRITES_PROCESS.bits()
                     | crate::ir::Effects::MAY_WARN.bits()
                     | crate::ir::Effects::BLOCKING_IO.bits()
-                    | crate::ir::Effects::NETWORK_IO.bits(),
-            ),
-            RuntimeFnId::CurlMultiExec => crate::ir::Effects::from_bits_retain(
-                crate::ir::Effects::READS_HEAP.bits()
-                    | crate::ir::Effects::WRITES_HEAP.bits()
-                    | crate::ir::Effects::READS_PROCESS.bits()
-                    | crate::ir::Effects::WRITES_PROCESS.bits()
-                    | crate::ir::Effects::MAY_WARN.bits()
-                    | crate::ir::Effects::NETWORK_IO.bits(),
-            ),
+                        | crate::ir::Effects::NETWORK_IO.bits(),
+                )
+            }
             RuntimeFnId::BcScale => crate::ir::Effects::from_bits_retain(
                 crate::ir::Effects::READS_PROCESS.bits()
                     | crate::ir::Effects::WRITES_PROCESS.bits()

--- a/src/ir/tests/effects_test.rs
+++ b/src/ir/tests/effects_test.rs
@@ -88,10 +88,16 @@ fn curl_runtime_effects_mark_network_boundaries() {
     let perform = RuntimeFnId::CurlEasyPerform.effects();
     assert!(perform.contains(Effects::NETWORK_IO));
     assert!(perform.contains(Effects::BLOCKING_IO));
+    assert!(perform.contains(Effects::MAY_THROW));
+    assert!(perform.contains(Effects::OUTPUT));
+    assert!(perform.contains(Effects::ALLOC_HEAP));
 
     let progress = RuntimeFnId::CurlMultiExec.effects();
     assert!(progress.contains(Effects::NETWORK_IO));
     assert!(!progress.contains(Effects::BLOCKING_IO));
+    assert!(progress.contains(Effects::MAY_THROW));
+    assert!(progress.contains(Effects::OUTPUT));
+    assert!(progress.contains(Effects::ALLOC_HEAP));
 
     let adapter = RuntimeFnId::CurlAdapterAddr.effects();
     assert!(!adapter.contains(Effects::NETWORK_IO));

--- a/src/ir/tests/effects_test.rs
+++ b/src/ir/tests/effects_test.rs
@@ -82,6 +82,31 @@ fn runtime_function_probes_expose_targeted_effects() {
     );
 }
 
+/// Curl transfer boundaries identify network work without classifying internal adapters.
+#[test]
+fn curl_runtime_effects_mark_network_boundaries() {
+    let perform = RuntimeFnId::CurlEasyPerform.effects();
+    assert!(perform.contains(Effects::NETWORK_IO));
+    assert!(perform.contains(Effects::BLOCKING_IO));
+
+    let progress = RuntimeFnId::CurlMultiExec.effects();
+    assert!(progress.contains(Effects::NETWORK_IO));
+    assert!(!progress.contains(Effects::BLOCKING_IO));
+
+    let adapter = RuntimeFnId::CurlAdapterAddr.effects();
+    assert!(!adapter.contains(Effects::NETWORK_IO));
+    assert!(!adapter.contains(Effects::BLOCKING_IO));
+
+    assert!(matches!(
+        RuntimeFnId::CurlEasyPerform.monitoring_policy(),
+        elephc_monitoring_contract::MonitoringPolicy::Io {
+            kind: elephc_monitoring_contract::IoKind::Network,
+            wait: elephc_monitoring_contract::WaitPolicy::Measured,
+            trace_context: elephc_monitoring_contract::TraceContextPolicy::Automatic,
+        }
+    ));
+}
+
 /// Formatting calls retain arbitrary `__toString()` effects, including throws and globals.
 #[test]
 fn printf_family_effects_cover_userland_string_conversion() {

--- a/src/linker/bridges.rs
+++ b/src/linker/bridges.rs
@@ -15,6 +15,10 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Mutex, OnceLock};
 
+use elephc_monitoring_contract::{
+    IoKind, MonitoringPolicy, TraceContextPolicy, WaitPolicy,
+};
+
 use crate::link_plan::{LinkItem, LinkOrigin, LinkPlan};
 
 use super::LinkError;
@@ -37,6 +41,8 @@ pub(super) struct BridgeStaticlib {
     pub(super) needs_libdl: bool,
     /// Canonical PHP extension reported when this bridge is linked, if distinct.
     pub(super) php_extension: Option<&'static str>,
+    /// Required monitoring decision for work crossing this bridge boundary.
+    pub(super) monitoring: MonitoringPolicy,
 }
 
 /// Every Elephc bridge known to discovery and CLI flag validation.
@@ -51,6 +57,7 @@ pub(super) const BRIDGES: &[BridgeStaticlib] = &[
         needs_libdl: true,
         // The TLS bridge implements PHP's OpenSSL-backed stream crypto surface.
         php_extension: Some("openssl"),
+        monitoring: MonitoringPolicy::GenericTiming,
     },
     BridgeStaticlib {
         lib_name: "elephc_pdo",
@@ -65,6 +72,11 @@ pub(super) const BRIDGES: &[BridgeStaticlib] = &[
         // from the injected PHP surface(s) instead: `pipeline::compile` passes
         // `linked_php_surfaces` ("PDO" / "mysqli") to the backend seeding.
         php_extension: None,
+        monitoring: MonitoringPolicy::Io {
+            kind: IoKind::Database,
+            wait: WaitPolicy::Measured,
+            trace_context: TraceContextPolicy::NotApplicable,
+        },
     },
     BridgeStaticlib {
         lib_name: "elephc_crypto",
@@ -76,6 +88,7 @@ pub(super) const BRIDGES: &[BridgeStaticlib] = &[
         needs_libdl: true,
         // The crypto bridge implements PHP's digest/HMAC `hash` extension.
         php_extension: Some("hash"),
+        monitoring: MonitoringPolicy::GenericTiming,
     },
     BridgeStaticlib {
         lib_name: "elephc_bcmath",
@@ -87,6 +100,7 @@ pub(super) const BRIDGES: &[BridgeStaticlib] = &[
         needs_libdl: true,
         // The decimal bridge implements PHP's procedural `bcmath` extension.
         php_extension: Some("bcmath"),
+        monitoring: MonitoringPolicy::GenericTiming,
     },
     BridgeStaticlib {
         lib_name: "elephc_iconv",
@@ -98,6 +112,7 @@ pub(super) const BRIDGES: &[BridgeStaticlib] = &[
         needs_libdl: true,
         // The charset bridge implements PHP's procedural `iconv` extension.
         php_extension: Some("iconv"),
+        monitoring: MonitoringPolicy::GenericTiming,
     },
     BridgeStaticlib {
         lib_name: "elephc_phar",
@@ -109,6 +124,7 @@ pub(super) const BRIDGES: &[BridgeStaticlib] = &[
         needs_libdl: true,
         // The archive reader/writer is exposed by PHP as `Phar`.
         php_extension: Some("Phar"),
+        monitoring: MonitoringPolicy::GenericTiming,
     },
     BridgeStaticlib {
         lib_name: "elephc_tz",
@@ -120,6 +136,7 @@ pub(super) const BRIDGES: &[BridgeStaticlib] = &[
         needs_libdl: true,
         // Timezone support folds into the always-present `date` extension.
         php_extension: None,
+        monitoring: MonitoringPolicy::GenericTiming,
     },
     BridgeStaticlib {
         lib_name: "elephc_image",
@@ -131,6 +148,7 @@ pub(super) const BRIDGES: &[BridgeStaticlib] = &[
         needs_libdl: true,
         // The image codec/drawing surface maps to PHP's `gd` extension.
         php_extension: Some("gd"),
+        monitoring: MonitoringPolicy::GenericTiming,
     },
     BridgeStaticlib {
         lib_name: "elephc_probe",
@@ -142,6 +160,9 @@ pub(super) const BRIDGES: &[BridgeStaticlib] = &[
         needs_libdl: true,
         // The sampling probe is an elephc-native diagnostic, not a PHP extension.
         php_extension: None,
+        monitoring: MonitoringPolicy::Infrastructure {
+            reason: "sampling monitor implementation",
+        },
     },
     BridgeStaticlib {
         lib_name: "elephc_instr",
@@ -153,6 +174,9 @@ pub(super) const BRIDGES: &[BridgeStaticlib] = &[
         needs_libdl: true,
         // Exact per-function instrumentation is an elephc-native diagnostic.
         php_extension: None,
+        monitoring: MonitoringPolicy::Infrastructure {
+            reason: "exact monitor implementation",
+        },
     },
     BridgeStaticlib {
         lib_name: "elephc_web",
@@ -164,6 +188,9 @@ pub(super) const BRIDGES: &[BridgeStaticlib] = &[
         needs_libdl: true,
         // The web bridge owns the PHP `session` extension surface.
         php_extension: Some("session"),
+        monitoring: MonitoringPolicy::Infrastructure {
+            reason: "request boundary already opens monitoring slices and trace context",
+        },
     },
     BridgeStaticlib {
         lib_name: "elephc_magician",
@@ -175,6 +202,7 @@ pub(super) const BRIDGES: &[BridgeStaticlib] = &[
         needs_libdl: true,
         // The eval interpreter is an internal compiler facility, not an extension.
         php_extension: None,
+        monitoring: MonitoringPolicy::GenericTiming,
     },
     BridgeStaticlib {
         lib_name: "elephc_curl",
@@ -191,6 +219,11 @@ pub(super) const BRIDGES: &[BridgeStaticlib] = &[
         needs_libdl: true,
         // The curl bridge implements PHP's libcurl-backed `curl` extension surface.
         php_extension: Some("curl"),
+        monitoring: MonitoringPolicy::Io {
+            kind: IoKind::Network,
+            wait: WaitPolicy::Measured,
+            trace_context: TraceContextPolicy::Automatic,
+        },
     },
 ];
 
@@ -400,7 +433,15 @@ fn validate_archive_path(name: &str, archive: PathBuf) -> Result<PathBuf, LinkEr
 
 /// Returns bridge metadata for one linker library name.
 fn bridge_for_library(name: &str) -> Option<&'static BridgeStaticlib> {
-    BRIDGES.iter().find(|bridge| bridge.lib_name == name)
+    let bridge = BRIDGES.iter().find(|bridge| bridge.lib_name == name);
+    if let Some(metadata) = bridge {
+        assert!(
+            metadata.monitoring.is_reviewed(),
+            "{} reached linker resolution without a monitoring policy",
+            metadata.lib_name
+        );
+    }
+    bridge
 }
 
 /// Returns whether any file under `directory` was modified after `instant`.
@@ -1178,6 +1219,44 @@ mod tests {
         }
         assert_eq!(bridge_lib_for_flag("bogus"), None);
         assert_eq!(crate_flag_names().len(), BRIDGES.len());
+    }
+
+    /// Verifies adding a bridge requires an explicit, machine-audited monitoring decision.
+    #[test]
+    fn every_bridge_declares_a_monitoring_policy() {
+        for bridge in BRIDGES {
+            assert!(
+                bridge.monitoring.is_reviewed(),
+                "{} has no monitoring policy",
+                bridge.lib_name
+            );
+            if let MonitoringPolicy::Infrastructure { reason } = bridge.monitoring {
+                assert!(
+                    !reason.trim().is_empty(),
+                    "{} has an empty monitoring-policy reason",
+                    bridge.lib_name
+                );
+            }
+        }
+
+        let pdo = bridge_for_library("elephc_pdo").expect("PDO bridge");
+        assert!(matches!(
+            pdo.monitoring,
+            MonitoringPolicy::Io {
+                kind: IoKind::Database,
+                wait: WaitPolicy::Measured,
+                trace_context: TraceContextPolicy::NotApplicable,
+            }
+        ));
+        let curl = bridge_for_library("elephc_curl").expect("curl bridge");
+        assert!(matches!(
+            curl.monitoring,
+            MonitoringPolicy::Io {
+                kind: IoKind::Network,
+                wait: WaitPolicy::Measured,
+                trace_context: TraceContextPolicy::Automatic,
+            }
+        ));
     }
 
     /// Verifies representative bridge metadata and archive naming remain registered.

--- a/src/monitor/command.rs
+++ b/src/monitor/command.rs
@@ -98,9 +98,10 @@ prints exactly like one built without it.
 
 A program monitor LAUNCHES (a source or a binary) is measured from inside: an
 exact per-function profile rooted at {main} — wall time, call counts,
-allocations, retained objects, SQL query counts and database-driver wait. The
-display derives wall-minus-recorded-DB-wait; it is not an OS CPU clock. File I/O
-is not counted or timed. Every local export is available.
+allocations, retained objects, SQL query counts, database-driver wait, outgoing
+network operations and network wait. The display derives
+wall-minus-recorded-DB-wait; it is not an OS CPU clock. File I/O is not counted
+or timed. Every local export is available.
 
 A service monitor CONNECTS to answers from its sample ring: CPU-time shares that
 sharpen as samples accumulate, sampled allocation attribution, and per-route
@@ -120,7 +121,8 @@ tags. Everything else works on Linux and macOS alike.
 --pprof writes the capture as a gzip pprof profile. --dot writes a Graphviz call
 graph (`dot -Tsvg`); --html writes a self-contained, interactive call graph (one
 node per function, caller->callee edges, hover metrics, search, zoom) that opens
-in any browser with no network, with a time/memory/retained/wait/SQL toggle, a
+in any browser with no network, with time, memory, retained, DB wait, SQL,
+network and network-wait dimensions, a
 flame view, a bottom-up callers/callees panel, a critical-path overlay, and —
 when DB queries ran — a Queries panel listing each distinct statement and how
 many times it ran, normalized so an N+1's repeated query folds into one x200
@@ -137,7 +139,8 @@ expose the profile).
 ui.perfetto.dev. The report prints recommendations, and --assert
 <metric>:<fn><op><value> (repeatable; op <= >= == < >) gates the build — any
 failed assertion exits 2, e.g. --assert calls:build<=1000. Metrics: calls,
-allocs, retained, queries, self_ms, incl_ms, wait_ms, time_pct. Use `*` as the
+allocs, retained, queries, self_ms, incl_ms, wait_ms, network,
+network_wait_ms, time_pct. Use `*` as the
 function to assert on the whole run, e.g. --assert queries:*<=50. A project can
 keep its budget in a `.elephc` file at its root (found by walking up from the
 source, or named with --assert-file): one assertion per line, `#` comments, and
@@ -166,7 +169,8 @@ and --pprof already feeds a Collector's pprof receiver.
 --stitch <file> (repeatable) captures nothing: it reads the stderr logs of
 services built with --web --with-monitoring and correlates their per-request
 slices into distributed traces by W3C Trace Context, printing one indented line
-per span (service, exact duration, function count, queries, waiting). A span
+per span (service, exact duration, function count, queries, DB waiting, network
+operations and network waiting). A span
 whose parent is not among the collected logs still renders, as a root, so a
 partial collection shows what it has. With --html it also writes a
 self-contained waterfall: each span placed by when it opened and sized by how

--- a/src/monitor/exact.rs
+++ b/src/monitor/exact.rs
@@ -92,20 +92,24 @@ pub(crate) fn instrument_recommendations(graph: &crate::call_graph::CallGraph) -
             ));
         }
     }
-    let total_network_wait: u64 = graph.nodes.iter().map(|n| n.network_wait).sum();
+    let total_network_wait: u64 = graph
+        .nodes
+        .iter()
+        .map(|n| n.network_wait_exclusive)
+        .sum();
     if root_ns > 0 && total_network_wait > 0 {
         let pct = 100.0 * total_network_wait as f64 / root_ns as f64;
         if pct >= 25.0 {
             let worst = graph
                 .nodes
                 .iter()
-                .max_by_key(|node| node.network_wait)
-                .filter(|node| node.network_wait > 0);
+                .max_by_key(|node| node.network_wait_exclusive)
+                .filter(|node| node.network_wait_exclusive > 0);
             let who = worst.map_or(String::new(), |node| {
                 format!(
                     " - {} blocks longest ({})",
                     node.name,
-                    fmt_ns(node.network_wait)
+                    fmt_ns(node.network_wait_exclusive)
                 )
             });
             hints.push(format!(
@@ -335,8 +339,23 @@ pub(crate) fn parse_instrument_dump(text: &str) -> crate::call_graph::CallGraph 
             let retained_exclusive = instr_field_i64(metrics, "excl_ret=");
             let wait_inclusive = instr_field(metrics, "incl_wait=");
             let wait_exclusive = instr_field(metrics, "excl_wait=");
-            let network_ops = instr_field(metrics, "network_ops=");
-            let network_wait = instr_field(metrics, "network_wait=");
+            let legacy_network = instr_field(metrics, "network_ops=");
+            let legacy_network_wait = instr_field(metrics, "network_wait=");
+            let mut network_inclusive = instr_field(metrics, "incl_network=");
+            let mut network_exclusive = instr_field(metrics, "excl_network=");
+            let mut network_wait_inclusive = instr_field(metrics, "incl_network_wait=");
+            let mut network_wait_exclusive = instr_field(metrics, "excl_network_wait=");
+            if network_inclusive == 0 && network_exclusive == 0 && legacy_network > 0 {
+                network_inclusive = legacy_network;
+                network_exclusive = legacy_network;
+            }
+            if network_wait_inclusive == 0
+                && network_wait_exclusive == 0
+                && legacy_network_wait > 0
+            {
+                network_wait_inclusive = legacy_network_wait;
+                network_wait_exclusive = legacy_network_wait;
+            }
             index.insert(name.to_string(), nodes.len());
             nodes.push(GraphNode {
                 name: name.to_string(),
@@ -351,8 +370,10 @@ pub(crate) fn parse_instrument_dump(text: &str) -> crate::call_graph::CallGraph 
                 retained_exclusive,
                 wait_inclusive,
                 wait_exclusive,
-                network_ops,
-                network_wait,
+                network_inclusive,
+                network_exclusive,
+                network_wait_inclusive,
+                network_wait_exclusive,
                 causes: Vec::new(),
             });
         }
@@ -496,8 +517,11 @@ pub(crate) fn instrument_table(graph: &crate::call_graph::CallGraph) -> String {
     let has_ret = graph.nodes.iter().any(|n| n.retained_inclusive != 0);
     // And the wait column: only when some call actually blocked in a driver.
     let has_wait = graph.nodes.iter().any(|n| n.wait_inclusive > 0);
-    let has_network = graph.nodes.iter().any(|node| node.network_ops > 0);
-    let has_network_wait = graph.nodes.iter().any(|node| node.network_wait > 0);
+    let has_network = graph.nodes.iter().any(|node| node.network_inclusive > 0);
+    let has_network_wait = graph
+        .nodes
+        .iter()
+        .any(|node| node.network_wait_inclusive > 0);
     for node in nodes {
         let incl = 100.0 * node.inclusive as f64 / root as f64;
         let excl = 100.0 * node.exclusive as f64 / root as f64;
@@ -524,12 +548,15 @@ pub(crate) fn instrument_table(graph: &crate::call_graph::CallGraph) -> String {
             String::new()
         };
         let network = if has_network {
-            format!("  network {}", node.network_ops)
+            format!("  network {}", node.network_exclusive)
         } else {
             String::new()
         };
         let network_wait = if has_network_wait {
-            format!("  network-wait {}", fmt_ns(node.network_wait))
+            format!(
+                "  network-wait {}",
+                fmt_ns(node.network_wait_exclusive)
+            )
         } else {
             String::new()
         };

--- a/src/monitor/exact.rs
+++ b/src/monitor/exact.rs
@@ -92,6 +92,29 @@ pub(crate) fn instrument_recommendations(graph: &crate::call_graph::CallGraph) -
             ));
         }
     }
+    let total_network_wait: u64 = graph.nodes.iter().map(|n| n.network_wait).sum();
+    if root_ns > 0 && total_network_wait > 0 {
+        let pct = 100.0 * total_network_wait as f64 / root_ns as f64;
+        if pct >= 25.0 {
+            let worst = graph
+                .nodes
+                .iter()
+                .max_by_key(|node| node.network_wait)
+                .filter(|node| node.network_wait > 0);
+            let who = worst.map_or(String::new(), |node| {
+                format!(
+                    " - {} blocks longest ({})",
+                    node.name,
+                    fmt_ns(node.network_wait)
+                )
+            });
+            hints.push(format!(
+                "• the run is network-bound: {:.0}% of it ({}) is outgoing network wait{who}",
+                pct,
+                fmt_ns(total_network_wait)
+            ));
+        }
+    }
     // Query hotspot: which function issues the most DB queries.
     let total_io: u64 = graph.nodes.iter().map(|n| n.io_exclusive).sum();
     if total_io > 0 {
@@ -312,6 +335,8 @@ pub(crate) fn parse_instrument_dump(text: &str) -> crate::call_graph::CallGraph 
             let retained_exclusive = instr_field_i64(metrics, "excl_ret=");
             let wait_inclusive = instr_field(metrics, "incl_wait=");
             let wait_exclusive = instr_field(metrics, "excl_wait=");
+            let network_ops = instr_field(metrics, "network_ops=");
+            let network_wait = instr_field(metrics, "network_wait=");
             index.insert(name.to_string(), nodes.len());
             nodes.push(GraphNode {
                 name: name.to_string(),
@@ -326,6 +351,8 @@ pub(crate) fn parse_instrument_dump(text: &str) -> crate::call_graph::CallGraph 
                 retained_exclusive,
                 wait_inclusive,
                 wait_exclusive,
+                network_ops,
+                network_wait,
                 causes: Vec::new(),
             });
         }
@@ -469,6 +496,8 @@ pub(crate) fn instrument_table(graph: &crate::call_graph::CallGraph) -> String {
     let has_ret = graph.nodes.iter().any(|n| n.retained_inclusive != 0);
     // And the wait column: only when some call actually blocked in a driver.
     let has_wait = graph.nodes.iter().any(|n| n.wait_inclusive > 0);
+    let has_network = graph.nodes.iter().any(|node| node.network_ops > 0);
+    let has_network_wait = graph.nodes.iter().any(|node| node.network_wait > 0);
     for node in nodes {
         let incl = 100.0 * node.inclusive as f64 / root as f64;
         let excl = 100.0 * node.exclusive as f64 / root as f64;
@@ -494,8 +523,18 @@ pub(crate) fn instrument_table(graph: &crate::call_graph::CallGraph) -> String {
         } else {
             String::new()
         };
+        let network = if has_network {
+            format!("  network {}", node.network_ops)
+        } else {
+            String::new()
+        };
+        let network_wait = if has_network_wait {
+            format!("  network-wait {}", fmt_ns(node.network_wait))
+        } else {
+            String::new()
+        };
         out.push_str(&format!(
-            "{name:<27} {}  incl {incl:>5.1}%  self {excl:>5.1}%  calls {calls}  self {}  allocs {}{queries}{retained}{wait}\n",
+            "{name:<27} {}  incl {incl:>5.1}%  self {excl:>5.1}%  calls {calls}  self {}  allocs {}{queries}{retained}{wait}{network}{network_wait}\n",
             bar(incl, 20),
             fmt_ns(node.exclusive),
             node.alloc_exclusive,

--- a/src/monitor/exports.rs
+++ b/src/monitor/exports.rs
@@ -132,6 +132,28 @@ pub(crate) fn prometheus_text(slices: &[Slice]) -> String {
             s.queries_per_request
         ));
     }
+    out.push_str(
+        "# HELP elephc_network_operations_per_request Mean outgoing network operations per request.\n\
+         # TYPE elephc_network_operations_per_request gauge\n",
+    );
+    for s in &stats {
+        out.push_str(&format!(
+            "elephc_network_operations_per_request{} {:.3}\n",
+            labels(s),
+            s.network_per_request
+        ));
+    }
+    out.push_str(
+        "# HELP elephc_network_wait_seconds_per_request Mean outgoing network wait per request.\n\
+         # TYPE elephc_network_wait_seconds_per_request gauge\n",
+    );
+    for s in &stats {
+        out.push_str(&format!(
+            "elephc_network_wait_seconds_per_request{} {:.6}\n",
+            labels(s),
+            s.network_wait_seconds_per_request
+        ));
+    }
     out
 }
 
@@ -159,8 +181,18 @@ pub(crate) fn export_otlp(slices: &[Slice], endpoint: &str) -> i32 {
         let start_ns = start_us.saturating_mul(1_000);
         let queries: u64 = slice.graph.nodes.iter().map(|n| n.io_exclusive).sum();
         let wait_ns: u64 = slice.graph.nodes.iter().map(|n| n.wait_exclusive).sum();
-        let network_ops: u64 = slice.graph.nodes.iter().map(|node| node.network_ops).sum();
-        let network_wait_ns: u64 = slice.graph.nodes.iter().map(|node| node.network_wait).sum();
+        let network_ops: u64 = slice
+            .graph
+            .nodes
+            .iter()
+            .map(|node| node.network_exclusive)
+            .sum();
+        let network_wait_ns: u64 = slice
+            .graph
+            .nodes
+            .iter()
+            .map(|node| node.network_wait_exclusive)
+            .sum();
         let name = if trace.route.is_empty() {
             slice.service.clone()
         } else {

--- a/src/monitor/exports.rs
+++ b/src/monitor/exports.rs
@@ -159,6 +159,8 @@ pub(crate) fn export_otlp(slices: &[Slice], endpoint: &str) -> i32 {
         let start_ns = start_us.saturating_mul(1_000);
         let queries: u64 = slice.graph.nodes.iter().map(|n| n.io_exclusive).sum();
         let wait_ns: u64 = slice.graph.nodes.iter().map(|n| n.wait_exclusive).sum();
+        let network_ops: u64 = slice.graph.nodes.iter().map(|node| node.network_ops).sum();
+        let network_wait_ns: u64 = slice.graph.nodes.iter().map(|node| node.network_wait).sum();
         let name = if trace.route.is_empty() {
             slice.service.clone()
         } else {
@@ -180,6 +182,8 @@ pub(crate) fn export_otlp(slices: &[Slice], endpoint: &str) -> i32 {
                 ("elephc.functions".to_string(), slice.graph.nodes.len() as i64),
                 ("elephc.queries".to_string(), queries as i64),
                 ("elephc.wait_ns".to_string(), wait_ns as i64),
+                ("elephc.network_operations".to_string(), network_ops as i64),
+                ("elephc.network_wait_ns".to_string(), network_wait_ns as i64),
             ],
             string_attributes,
         });

--- a/src/monitor/mod.rs
+++ b/src/monitor/mod.rs
@@ -338,6 +338,8 @@ pub(crate) static EMPTY_NODE: std::sync::LazyLock<crate::call_graph::GraphNode> 
         retained_exclusive: 0,
         wait_inclusive: 0,
         wait_exclusive: 0,
+        network_ops: 0,
+        network_wait: 0,
         causes: Vec::new(),
     });
 
@@ -371,6 +373,8 @@ pub(crate) const ASSERT_METRICS: &[(&str, &str)] = &[
     ("self_ms", "milliseconds of its own time"),
     ("incl_ms", "milliseconds including everything it calls"),
     ("wait_ms", "milliseconds blocked inside a driver call"),
+    ("network", "outgoing network operations it issues itself"),
+    ("network_wait_ms", "milliseconds blocked in outgoing network work"),
     ("time_pct", "inclusive time as a percentage of the run"),
 ];
 
@@ -388,6 +392,8 @@ pub(crate) fn assert_metric_value(
         "self_ms" => Some(node.exclusive as f64 / 1_000_000.0),
         "incl_ms" => Some(node.inclusive as f64 / 1_000_000.0),
         "wait_ms" => Some(node.wait_exclusive as f64 / 1_000_000.0),
+        "network" => Some(node.network_ops as f64),
+        "network_wait_ms" => Some(node.network_wait as f64 / 1_000_000.0),
         "time_pct" => Some(100.0 * node.inclusive as f64 / root_ns as f64),
         _ => None,
     }
@@ -409,6 +415,8 @@ pub(crate) fn assert_run_total(metric: &str, graph: &crate::call_graph::CallGrap
         "queries" => Some(sum_excl(|n| n.io_exclusive as f64)),
         "self_ms" | "incl_ms" => Some(root_ns as f64 / 1_000_000.0),
         "wait_ms" => Some(sum_excl(|n| n.wait_exclusive as f64) / 1_000_000.0),
+        "network" => Some(sum_excl(|n| n.network_ops as f64)),
+        "network_wait_ms" => Some(sum_excl(|n| n.network_wait as f64) / 1_000_000.0),
         "time_pct" => Some(100.0),
         _ => None,
     }

--- a/src/monitor/mod.rs
+++ b/src/monitor/mod.rs
@@ -338,8 +338,10 @@ pub(crate) static EMPTY_NODE: std::sync::LazyLock<crate::call_graph::GraphNode> 
         retained_exclusive: 0,
         wait_inclusive: 0,
         wait_exclusive: 0,
-        network_ops: 0,
-        network_wait: 0,
+        network_inclusive: 0,
+        network_exclusive: 0,
+        network_wait_inclusive: 0,
+        network_wait_exclusive: 0,
         causes: Vec::new(),
     });
 
@@ -392,8 +394,8 @@ pub(crate) fn assert_metric_value(
         "self_ms" => Some(node.exclusive as f64 / 1_000_000.0),
         "incl_ms" => Some(node.inclusive as f64 / 1_000_000.0),
         "wait_ms" => Some(node.wait_exclusive as f64 / 1_000_000.0),
-        "network" => Some(node.network_ops as f64),
-        "network_wait_ms" => Some(node.network_wait as f64 / 1_000_000.0),
+        "network" => Some(node.network_exclusive as f64),
+        "network_wait_ms" => Some(node.network_wait_exclusive as f64 / 1_000_000.0),
         "time_pct" => Some(100.0 * node.inclusive as f64 / root_ns as f64),
         _ => None,
     }
@@ -415,8 +417,10 @@ pub(crate) fn assert_run_total(metric: &str, graph: &crate::call_graph::CallGrap
         "queries" => Some(sum_excl(|n| n.io_exclusive as f64)),
         "self_ms" | "incl_ms" => Some(root_ns as f64 / 1_000_000.0),
         "wait_ms" => Some(sum_excl(|n| n.wait_exclusive as f64) / 1_000_000.0),
-        "network" => Some(sum_excl(|n| n.network_ops as f64)),
-        "network_wait_ms" => Some(sum_excl(|n| n.network_wait as f64) / 1_000_000.0),
+        "network" => Some(sum_excl(|n| n.network_exclusive as f64)),
+        "network_wait_ms" => {
+            Some(sum_excl(|n| n.network_wait_exclusive as f64) / 1_000_000.0)
+        }
         "time_pct" => Some(100.0),
         _ => None,
     }
@@ -566,6 +570,10 @@ pub(crate) struct ServiceStats {
     queries_per_request: f64,
     /// Share of request time spent blocked in a driver.
     wait_share: f64,
+    /// Mean outgoing network operations per request.
+    network_per_request: f64,
+    /// Mean seconds per request spent waiting on outgoing network work.
+    network_wait_seconds_per_request: f64,
 }
 
 /// Nearest-rank percentile: the value at position ceil(p/100 x n), 1-indexed.
@@ -584,7 +592,19 @@ pub(crate) fn percentile(sorted: &[u64], p: f64) -> u64 {
 /// Loads a saved exact call graph (`--save` output) for diffing.
 pub(crate) fn load_exact_graph(path: &str) -> Option<crate::call_graph::CallGraph> {
     let json = std::fs::read_to_string(path).ok()?;
-    serde_json::from_str(&json).ok()
+    let mut graph: crate::call_graph::CallGraph = serde_json::from_str(&json).ok()?;
+    // Profiles saved before network metrics became inclusive/exclusive deserialize their
+    // direct values through serde aliases. An exclusive value with no inclusive partner
+    // can only be that legacy shape, so restore the minimum valid inclusive value.
+    for node in &mut graph.nodes {
+        if node.network_inclusive == 0 && node.network_exclusive > 0 {
+            node.network_inclusive = node.network_exclusive;
+        }
+        if node.network_wait_inclusive == 0 && node.network_wait_exclusive > 0 {
+            node.network_wait_inclusive = node.network_wait_exclusive;
+        }
+    }
+    Some(graph)
 }
 
 /// Formats nanoseconds as a human duration for the exact table.

--- a/src/monitor/sampled.rs
+++ b/src/monitor/sampled.rs
@@ -51,8 +51,10 @@ pub(crate) fn build_call_graph(display: &[(Vec<(String, Kind)>, u64)]) -> crate:
                 retained_exclusive: 0,
                 wait_inclusive: 0,
                 wait_exclusive: 0,
-                network_ops: 0,
-                network_wait: 0,
+                network_inclusive: 0,
+                network_exclusive: 0,
+                network_wait_inclusive: 0,
+                network_wait_exclusive: 0,
                 causes,
             }
         })
@@ -200,7 +202,7 @@ pub(crate) fn probe_alloc_summary(text: &str) -> String {
     rows.sort_by(|a, b| b.1.cmp(&a.1));
     let total: u64 = rows.iter().map(|r| r.1).sum();
     let mut out = format!(
-        "\nallocations — {total} observed between samples; attribution is sampled, so it says\n\
+        "\nAllocations - {total} observed between samples; attribution is sampled, so it says\n\
          WHERE allocation happens rather than how much each function allocated. The first\n\
          baseline and allocations after the final sample are outside this total.\n\n"
     );

--- a/src/monitor/sampled.rs
+++ b/src/monitor/sampled.rs
@@ -51,6 +51,8 @@ pub(crate) fn build_call_graph(display: &[(Vec<(String, Kind)>, u64)]) -> crate:
                 retained_exclusive: 0,
                 wait_inclusive: 0,
                 wait_exclusive: 0,
+                network_ops: 0,
+                network_wait: 0,
                 causes,
             }
         })
@@ -89,7 +91,7 @@ pub(crate) fn build_call_graph(display: &[(Vec<(String, Kind)>, u64)]) -> crate:
     }
 }
 
-/// Renders the probe's per-route database counters, when the capture carries any.
+/// Renders the probe's exact database, allocation and network side summaries.
 ///
 /// Printed apart from the cause table and labelled, because these numbers are a
 /// different KIND from everything around them: the table's shares are sampled at
@@ -116,21 +118,56 @@ pub(crate) fn probe_io_summary(text: &str) -> String {
             _ => continue,
         }
     }
-    if rows.is_empty() {
-        return String::new();
-    }
     rows.sort_by(|a, b| b.1.cmp(&a.1));
     let total_ops: u64 = rows.iter().map(|r| r.1).sum();
     let total_wait: u64 = rows.iter().map(|r| r.2).sum();
+    let mut out = if rows.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "\nDatabase - {total_ops} query operation(s), {} driver wait. Exact, not sampled: a driver call \
+             reports itself,\nso these counts do not depend on how often the profiler looked.\n\n",
+            fmt_ns(total_wait)
+        )
+    };
+    for (route, ops, wait) in rows {
+        out.push_str(&format!("{route:<40}{ops:>8} ops{:>12}\n", fmt_ns(wait)));
+    }
+    out.push_str(&probe_alloc_summary(text));
+    out.push_str(&probe_network_summary(text));
+    out
+}
+
+/// Renders exact per-route outgoing-network events carried by a sampled capture.
+pub(crate) fn probe_network_summary(text: &str) -> String {
+    let mut rows = Vec::new();
+    for line in text.lines() {
+        let Some(rest) = line.strip_prefix("elephc-probe-network: ") else {
+            continue;
+        };
+        let Some((route, tail)) = rest.rsplit_once(" ops=") else {
+            continue;
+        };
+        let Some((ops, wait)) = tail.split_once(" wait_ns=") else {
+            continue;
+        };
+        if let (Ok(ops), Ok(wait)) = (ops.trim().parse::<u64>(), wait.trim().parse::<u64>()) {
+            rows.push((route.to_string(), ops, wait));
+        }
+    }
+    if rows.is_empty() {
+        return String::new();
+    }
+    rows.sort_by(|left, right| right.1.cmp(&left.1));
+    let total_ops: u64 = rows.iter().map(|row| row.1).sum();
+    let total_wait: u64 = rows.iter().map(|row| row.2).sum();
     let mut out = format!(
-        "\nDatabase — {total_ops} query operation(s), {} driver wait. Exact, not sampled: a driver call \
-         reports itself,\nso these counts do not depend on how often the profiler looked.\n\n",
+        "\nNetwork - {total_ops} outgoing operation(s), {} wait. Exact, not sampled.\n\n",
         fmt_ns(total_wait)
     );
     for (route, ops, wait) in rows {
         out.push_str(&format!("{route:<40}{ops:>8} ops{:>12}\n", fmt_ns(wait)));
     }
-    out.push_str(&probe_alloc_summary(text));
     out
 }
 

--- a/src/monitor/stitch.rs
+++ b/src/monitor/stitch.rs
@@ -56,6 +56,16 @@ pub(crate) fn service_stats(slices: &[Slice]) -> Vec<ServiceStats> {
                 .flat_map(|s| s.graph.nodes.iter())
                 .map(|n| n.wait_exclusive)
                 .sum();
+            let network: u64 = members
+                .iter()
+                .flat_map(|s| s.graph.nodes.iter())
+                .map(|n| n.network_exclusive)
+                .sum();
+            let network_wait_ns: u64 = members
+                .iter()
+                .flat_map(|s| s.graph.nodes.iter())
+                .map(|n| n.network_wait_exclusive)
+                .sum();
             // The window runs from the first request opening to the last one
             // finishing, the only span a rate can honestly divide by.
             let starts: Option<Vec<u64>> = members
@@ -86,6 +96,10 @@ pub(crate) fn service_stats(slices: &[Slice]) -> Vec<ServiceStats> {
                 } else {
                     100.0 * wait_ns as f64 / total_ns as f64
                 },
+                network_per_request: network as f64 / members.len() as f64,
+                network_wait_seconds_per_request: network_wait_ns as f64
+                    / members.len() as f64
+                    / 1e9,
             }
         })
         .collect()
@@ -311,8 +325,18 @@ pub(crate) fn stitch_report(slices: &[Slice]) -> String {
             };
             let queries: u64 = slice.graph.nodes.iter().map(|n| n.io_exclusive).sum();
             let waited: u64 = slice.graph.nodes.iter().map(|n| n.wait_exclusive).sum();
-            let network: u64 = slice.graph.nodes.iter().map(|node| node.network_ops).sum();
-            let network_wait: u64 = slice.graph.nodes.iter().map(|node| node.network_wait).sum();
+            let network: u64 = slice
+                .graph
+                .nodes
+                .iter()
+                .map(|node| node.network_exclusive)
+                .sum();
+            let network_wait: u64 = slice
+                .graph
+                .nodes
+                .iter()
+                .map(|node| node.network_wait_exclusive)
+                .sum();
             out.push_str(&format!(
                 "{:indent$}{} {}  {}  {}  {} fn{}{}{}{}\n",
                 "",
@@ -462,12 +486,17 @@ pub(crate) fn run_stitch(cmd: &MonitorCommand) -> i32 {
                     functions: slice.graph.nodes.len(),
                     queries: slice.graph.nodes.iter().map(|n| n.io_exclusive).sum(),
                     wait_ns: slice.graph.nodes.iter().map(|n| n.wait_exclusive).sum(),
-                    network_ops: slice.graph.nodes.iter().map(|node| node.network_ops).sum(),
+                    network_ops: slice
+                        .graph
+                        .nodes
+                        .iter()
+                        .map(|node| node.network_exclusive)
+                        .sum(),
                     network_wait_ns: slice
                         .graph
                         .nodes
                         .iter()
-                        .map(|node| node.network_wait)
+                        .map(|node| node.network_wait_exclusive)
                         .sum(),
                     start_us: trace.start_us,
                     top,

--- a/src/monitor/stitch.rs
+++ b/src/monitor/stitch.rs
@@ -311,8 +311,10 @@ pub(crate) fn stitch_report(slices: &[Slice]) -> String {
             };
             let queries: u64 = slice.graph.nodes.iter().map(|n| n.io_exclusive).sum();
             let waited: u64 = slice.graph.nodes.iter().map(|n| n.wait_exclusive).sum();
+            let network: u64 = slice.graph.nodes.iter().map(|node| node.network_ops).sum();
+            let network_wait: u64 = slice.graph.nodes.iter().map(|node| node.network_wait).sum();
             out.push_str(&format!(
-                "{:indent$}{} {}  {}  {}  {} fn{}{}\n",
+                "{:indent$}{} {}  {}  {}  {} fn{}{}{}{}\n",
                 "",
                 if depth == 0 { "●" } else { "└─" },
                 slice.service,
@@ -326,6 +328,16 @@ pub(crate) fn stitch_report(slices: &[Slice]) -> String {
                 },
                 if waited > 0 {
                     format!("  {} waiting", fmt_ns(waited))
+                } else {
+                    String::new()
+                },
+                if network > 0 {
+                    format!("  {network} network")
+                } else {
+                    String::new()
+                },
+                if network_wait > 0 {
+                    format!("  {} network-wait", fmt_ns(network_wait))
                 } else {
                     String::new()
                 },
@@ -450,6 +462,13 @@ pub(crate) fn run_stitch(cmd: &MonitorCommand) -> i32 {
                     functions: slice.graph.nodes.len(),
                     queries: slice.graph.nodes.iter().map(|n| n.io_exclusive).sum(),
                     wait_ns: slice.graph.nodes.iter().map(|n| n.wait_exclusive).sum(),
+                    network_ops: slice.graph.nodes.iter().map(|node| node.network_ops).sum(),
+                    network_wait_ns: slice
+                        .graph
+                        .nodes
+                        .iter()
+                        .map(|node| node.network_wait)
+                        .sum(),
                     start_us: trace.start_us,
                     top,
                 })

--- a/src/monitor/tests.rs
+++ b/src/monitor/tests.rs
@@ -181,6 +181,8 @@
                 retained_exclusive: 0,
                 wait_inclusive: 0,
                 wait_exclusive: 0,
+                network_ops: 0,
+                network_wait: 0,
                 causes: Vec::new(),
             }
         }
@@ -291,7 +293,8 @@
                 name: name.to_string(), inclusive, exclusive, call_count: None,
                 alloc_inclusive: 0, alloc_exclusive: 0, io_inclusive: 0, io_exclusive: 0,
                 retained_inclusive: 0, retained_exclusive: 0,
-                wait_inclusive: 0, wait_exclusive: 0, causes: Vec::new(),
+                wait_inclusive: 0, wait_exclusive: 0,
+                network_ops: 0, network_wait: 0, causes: Vec::new(),
             }
         }
 
@@ -464,7 +467,8 @@ Total number in stack (recursive counted multiple, when >=5):
         format!(
             "elephc-instr-trace: trace={trace} span={span} parent={parent}\n\
              elephc-instr: {fn_name} calls=1 incl_ns={ns} excl_ns={ns} incl_allocs=0 \
-             excl_allocs=0 incl_io=0 excl_io=0 incl_ret=0 excl_ret=0 incl_wait=0 excl_wait=0\n"
+             excl_allocs=0 incl_io=0 excl_io=0 incl_ret=0 excl_ret=0 incl_wait=0 excl_wait=0 \
+             network_ops=0 network_wait=0\n"
         )
     }
 
@@ -487,7 +491,8 @@ Total number in stack (recursive counted multiple, when >=5):
         let text = "elephc-probe: a;b 3\n\
                     elephc-probe-samples: 17\n\
                     elephc-probe-io: <untagged> ops=551 wait_ns=3449131\n\
-                    elephc-probe-io: GET /a b/c ops=2 wait_ns=1000\n";
+                    elephc-probe-io: GET /a b/c ops=2 wait_ns=1000\n\
+                    elephc-probe-network: GET /a b/c ops=3 wait_ns=2000\n";
         let out = probe_io_summary(text);
         assert!(out.contains("Database"), "{out}");
         // A route can contain spaces, so the counters are read from the RIGHT;
@@ -500,6 +505,7 @@ Total number in stack (recursive counted multiple, when >=5):
         assert!(untagged < other, "rows must sort by operation count:\n{out}");
         // The distinction the whole feature rests on.
         assert!(out.contains("Exact, not sampled"), "{out}");
+        assert!(out.contains("Network - 3 outgoing operation(s)"), "{out}");
 
         // Nothing to say when the capture carries no events.
         assert!(probe_io_summary("elephc-probe: a 1\n").is_empty());
@@ -933,8 +939,11 @@ Total number in stack (recursive counted multiple, when >=5):
             service: service.to_string(),
             graph: parse_instrument_dump(&chunk),
         };
+        let mut gateway = mk("gateway", slice_log("handle", 1_000, "tr", "aaaa", "-"));
+        gateway.graph.nodes[0].network_ops = 2;
+        gateway.graph.nodes[0].network_wait = 300;
         let slices = vec![
-            mk("gateway", slice_log("handle", 1_000, "tr", "aaaa", "-")),
+            gateway,
             mk("inventory", slice_log("stock", 400, "tr", "bbbb", "aaaa")),
             // Parent never appears in the logs (its service was not collected):
             // it must still render, as a root, not vanish.
@@ -943,6 +952,8 @@ Total number in stack (recursive counted multiple, when >=5):
         let out = stitch_report(&slices);
         assert!(out.contains("trace tr"), "{out}");
         assert!(out.contains("● gateway"), "root is un-indented: {out}");
+        assert!(out.contains("2 network"), "{out}");
+        assert!(out.contains("300 ns network-wait"), "{out}");
         assert!(out.contains("  └─ inventory"), "child is nested: {out}");
         assert!(out.contains("● billing"), "orphan survives as a root: {out}");
         assert!(out.contains("1 trace(s) over 3 slice(s)"), "{out}");
@@ -992,6 +1003,24 @@ elephc-instr-query: 200 INSERT INTO users (name) VALUES (?)
         assert!(graph
             .queries
             .contains(&("INSERT INTO users (name) VALUES (?)".to_string(), 200)));
+    }
+
+    /// Exact instrumentation dumps retain outgoing network counts and wait time.
+    #[test]
+    fn parses_instrument_network_metrics() {
+        let dump = "elephc-instr: fetch calls=2 incl_ns=500 excl_ns=400 incl_allocs=0 \
+                    excl_allocs=0 incl_io=0 excl_io=0 incl_ret=0 excl_ret=0 incl_wait=0 \
+                    excl_wait=0 network_ops=2 network_wait=300\n";
+        let graph = parse_instrument_dump(dump);
+        assert_eq!(graph.nodes.len(), 1);
+        assert_eq!(graph.nodes[0].network_ops, 2);
+        assert_eq!(graph.nodes[0].network_wait, 300);
+        let table = instrument_table(&graph);
+        assert!(table.contains("network 2"), "{table}");
+        assert!(table.contains("network-wait 300 ns"), "{table}");
+        let html = crate::call_graph::render_html_exact(&graph, "network profile", &[]);
+        assert!(html.contains("\"networkN\":2"), "{html}");
+        assert!(html.contains("Net wait"), "{html}");
     }
 
     #[test]
@@ -1213,6 +1242,8 @@ echo call_hot(1);
             retained_exclusive: 0,
             wait_inclusive: 0,
             wait_exclusive: 0,
+            network_ops: 0,
+            network_wait: 0,
             causes: vec![],
         };
         CallGraph {
@@ -1237,7 +1268,9 @@ echo call_hot(1);
             Some(("calls".into(), "leaf".into(), "<=".into(), 1000.0))
         );
         assert_eq!(parse_assert("bogus"), None);
-        let graph = instr_graph();
+        let mut graph = instr_graph();
+        graph.nodes[1].network_ops = 3;
+        graph.nodes[1].network_wait = 2_000_000;
         let run = |specs: &[&str]| {
             let owned: Vec<(String, Option<String>)> =
                 specs.iter().map(|s| ((*s).to_string(), None)).collect();
@@ -1251,6 +1284,8 @@ echo call_hot(1);
         let (report, ok) = run(&["calls:leaf<=2000", "time_pct:run>=90"]);
         assert!(ok, "{report}");
         assert!(report.contains("2 passed, 0 failed"), "{report}");
+        let (report, ok) = run(&["network:leaf<=3", "network_wait_ms:*<=2"]);
+        assert!(ok, "{report}");
         // A function the run never reached is reported as unevaluated, not as a
         // failure of the code: the budget names something that is not there.
         let (report, ok) = run(&["calls:ghost<1"]);

--- a/src/monitor/tests.rs
+++ b/src/monitor/tests.rs
@@ -181,8 +181,10 @@
                 retained_exclusive: 0,
                 wait_inclusive: 0,
                 wait_exclusive: 0,
-                network_ops: 0,
-                network_wait: 0,
+                network_inclusive: 0,
+                network_exclusive: 0,
+                network_wait_inclusive: 0,
+                network_wait_exclusive: 0,
                 causes: Vec::new(),
             }
         }
@@ -294,7 +296,11 @@
                 alloc_inclusive: 0, alloc_exclusive: 0, io_inclusive: 0, io_exclusive: 0,
                 retained_inclusive: 0, retained_exclusive: 0,
                 wait_inclusive: 0, wait_exclusive: 0,
-                network_ops: 0, network_wait: 0, causes: Vec::new(),
+                network_inclusive: 0,
+                network_exclusive: 0,
+                network_wait_inclusive: 0,
+                network_wait_exclusive: 0,
+                causes: Vec::new(),
             }
         }
 
@@ -468,7 +474,7 @@ Total number in stack (recursive counted multiple, when >=5):
             "elephc-instr-trace: trace={trace} span={span} parent={parent}\n\
              elephc-instr: {fn_name} calls=1 incl_ns={ns} excl_ns={ns} incl_allocs=0 \
              excl_allocs=0 incl_io=0 excl_io=0 incl_ret=0 excl_ret=0 incl_wait=0 excl_wait=0 \
-             network_ops=0 network_wait=0\n"
+             incl_network=0 excl_network=0 incl_network_wait=0 excl_network_wait=0\n"
         )
     }
 
@@ -520,6 +526,7 @@ Total number in stack (recursive counted multiple, when >=5):
         let text = "elephc-probe-alloc: a;b;load_price 900\n\
                     elephc-probe-alloc: a;record_audit 100\n";
         let out = probe_alloc_summary(text);
+        assert!(out.contains("Allocations - 1000"), "{out}");
         assert!(out.contains("1000 observed between samples"), "{out}");
         assert!(out.contains("attribution is sampled"), "{out}");
         assert!(out.contains("after the final sample are outside"), "{out}");
@@ -813,9 +820,13 @@ Total number in stack (recursive counted multiple, when >=5):
     /// quantile label inside the same brace group as the others.
     #[test]
     fn prometheus_output_is_a_valid_summary() {
-        let slices: Vec<Slice> = (0..25)
+        let mut slices: Vec<Slice> = (0..25)
             .map(|i| slice_of("api", 1_000_000 * (i + 1), None, &format!("s{i}")))
             .collect();
+        slices[0].graph.nodes[0].network_inclusive = 25;
+        slices[0].graph.nodes[0].network_exclusive = 25;
+        slices[0].graph.nodes[0].network_wait_inclusive = 25_000_000;
+        slices[0].graph.nodes[0].network_wait_exclusive = 25_000_000;
         let text = prometheus_text(&slices);
         assert!(text.contains("# TYPE elephc_request_duration_seconds summary"));
         assert!(
@@ -824,6 +835,14 @@ Total number in stack (recursive counted multiple, when >=5):
         );
         // Durations are seconds, as every Prometheus convention requires.
         assert!(text.contains(" 0.025000\n"), "p99 of 25ms should be 0.025 s:\n{text}");
+        assert!(
+            text.contains("elephc_network_operations_per_request{service=\"api\"} 1.000"),
+            "{text}"
+        );
+        assert!(
+            text.contains("elephc_network_wait_seconds_per_request{service=\"api\"} 0.001000"),
+            "{text}"
+        );
         // Every sample line must carry a value, or the scrape fails wholesale.
         for line in text.lines().filter(|l| !l.starts_with('#') && !l.is_empty()) {
             let value = line.rsplit(' ').next().unwrap_or("");
@@ -940,8 +959,10 @@ Total number in stack (recursive counted multiple, when >=5):
             graph: parse_instrument_dump(&chunk),
         };
         let mut gateway = mk("gateway", slice_log("handle", 1_000, "tr", "aaaa", "-"));
-        gateway.graph.nodes[0].network_ops = 2;
-        gateway.graph.nodes[0].network_wait = 300;
+        gateway.graph.nodes[0].network_inclusive = 2;
+        gateway.graph.nodes[0].network_exclusive = 2;
+        gateway.graph.nodes[0].network_wait_inclusive = 300;
+        gateway.graph.nodes[0].network_wait_exclusive = 300;
         let slices = vec![
             gateway,
             mk("inventory", slice_log("stock", 400, "tr", "bbbb", "aaaa")),
@@ -1005,22 +1026,72 @@ elephc-instr-query: 200 INSERT INTO users (name) VALUES (?)
             .contains(&("INSERT INTO users (name) VALUES (?)".to_string(), 200)));
     }
 
-    /// Exact instrumentation dumps retain outgoing network counts and wait time.
+    /// Exact instrumentation dumps retain inclusive and exclusive network metrics.
     #[test]
     fn parses_instrument_network_metrics() {
         let dump = "elephc-instr: fetch calls=2 incl_ns=500 excl_ns=400 incl_allocs=0 \
                     excl_allocs=0 incl_io=0 excl_io=0 incl_ret=0 excl_ret=0 incl_wait=0 \
-                    excl_wait=0 network_ops=2 network_wait=300\n";
+                    excl_wait=0 incl_network=5 excl_network=2 incl_network_wait=700 \
+                    excl_network_wait=300\n";
         let graph = parse_instrument_dump(dump);
         assert_eq!(graph.nodes.len(), 1);
-        assert_eq!(graph.nodes[0].network_ops, 2);
-        assert_eq!(graph.nodes[0].network_wait, 300);
+        assert_eq!(graph.nodes[0].network_inclusive, 5);
+        assert_eq!(graph.nodes[0].network_exclusive, 2);
+        assert_eq!(graph.nodes[0].network_wait_inclusive, 700);
+        assert_eq!(graph.nodes[0].network_wait_exclusive, 300);
         let table = instrument_table(&graph);
         assert!(table.contains("network 2"), "{table}");
         assert!(table.contains("network-wait 300 ns"), "{table}");
         let html = crate::call_graph::render_html_exact(&graph, "network profile", &[]);
-        assert!(html.contains("\"networkN\":2"), "{html}");
+        assert!(html.contains("\"networkInclN\":5"), "{html}");
+        assert!(html.contains("\"networkExclN\":2"), "{html}");
         assert!(html.contains("Net wait"), "{html}");
+    }
+
+    /// Logs written by the first monitoring implementation still load as direct metrics.
+    #[test]
+    fn parses_legacy_direct_network_metrics() {
+        let dump = "elephc-instr: fetch calls=1 incl_ns=500 excl_ns=400 incl_allocs=0 \
+                    excl_allocs=0 incl_io=0 excl_io=0 incl_ret=0 excl_ret=0 incl_wait=0 \
+                    excl_wait=0 network_ops=2 network_wait=300\n";
+        let graph = parse_instrument_dump(dump);
+        assert_eq!(graph.nodes[0].network_inclusive, 2);
+        assert_eq!(graph.nodes[0].network_exclusive, 2);
+        assert_eq!(graph.nodes[0].network_wait_inclusive, 300);
+        assert_eq!(graph.nodes[0].network_wait_exclusive, 300);
+    }
+
+    /// Saved graphs from before the network split restore direct values as inclusive too.
+    #[test]
+    fn loads_legacy_saved_network_metrics() {
+        let path = std::env::temp_dir().join(format!(
+            "elephc-monitor-legacy-network-{}.json",
+            std::process::id()
+        ));
+        let legacy = r#"{
+            "nodes": [{
+                "name": "fetch",
+                "inclusive": 1,
+                "exclusive": 1,
+                "call_count": 1,
+                "alloc_inclusive": 0,
+                "alloc_exclusive": 0,
+                "network_ops": 2,
+                "network_wait": 300,
+                "causes": []
+            }],
+            "edges": [],
+            "total": 1
+        }"#;
+        std::fs::write(&path, legacy).expect("write legacy graph fixture");
+        let graph = load_exact_graph(path.to_str().expect("UTF-8 fixture path"))
+            .expect("load legacy graph fixture");
+        let _ = std::fs::remove_file(path);
+
+        assert_eq!(graph.nodes[0].network_inclusive, 2);
+        assert_eq!(graph.nodes[0].network_exclusive, 2);
+        assert_eq!(graph.nodes[0].network_wait_inclusive, 300);
+        assert_eq!(graph.nodes[0].network_wait_exclusive, 300);
     }
 
     #[test]
@@ -1242,8 +1313,10 @@ echo call_hot(1);
             retained_exclusive: 0,
             wait_inclusive: 0,
             wait_exclusive: 0,
-            network_ops: 0,
-            network_wait: 0,
+            network_inclusive: 0,
+            network_exclusive: 0,
+            network_wait_inclusive: 0,
+            network_wait_exclusive: 0,
             causes: vec![],
         };
         CallGraph {
@@ -1269,8 +1342,10 @@ echo call_hot(1);
         );
         assert_eq!(parse_assert("bogus"), None);
         let mut graph = instr_graph();
-        graph.nodes[1].network_ops = 3;
-        graph.nodes[1].network_wait = 2_000_000;
+        graph.nodes[1].network_inclusive = 3;
+        graph.nodes[1].network_exclusive = 3;
+        graph.nodes[1].network_wait_inclusive = 2_000_000;
+        graph.nodes[1].network_wait_exclusive = 2_000_000;
         let run = |specs: &[&str]| {
             let owned: Vec<(String, Option<String>)> =
                 specs.iter().map(|s| ((*s).to_string(), None)).collect();


### PR DESCRIPTION
## Summary

Adds first-class monitoring support for the curl bridge and introduces a typed gate that requires new bridges and bridge-backed I/O operations to declare their monitoring behavior explicitly.

This PR now covers the full curl monitoring contract: operation counts, measured network wait, inclusive and exclusive attribution, trace propagation, report and export integration, dormant-path behavior, generated builtin documentation, and contributor guidance.

## Contract and quality gates

- Added the shared `elephc-monitoring-contract` crate.
- Added mandatory `MonitoringPolicy` metadata to every bridge and typed runtime function descriptor.
- Added CI audits for:
  - bridges without a reviewed monitoring policy
  - bridge-backed runtime functions without a policy
  - I/O operations without typed event monitoring
  - network effects not classified as `IoKind::Network`
  - blocking I/O without `WaitPolicy::Measured`
  - infrastructure exemptions without a source-level justification
- Added `BLOCKING_IO` and `NETWORK_IO` EIR effects.
- Kept callback-capable curl drivers conservative for PHP-visible effects such as throws, output, and heap allocation.
- Documented the monitoring contract in `CONTRIBUTING.md`, including operation semantics, callback-time exclusion, active-window ownership, and dormant-path requirements.

## Curl monitoring

- Added network operation and wait telemetry for:
  - `curl_exec()`
  - multi-handle transfers
  - `curl_multi_select()`
  - `curl_upkeep()` wait time
- Easy transfers count once per `curl_exec()`.
- Multi transfers count once per easy-handle attachment. Reading a completion message no longer clears the count while the handle remains attached; remove and re-add starts a new counted attachment.
- `curl_upkeep()` records measured maintenance wait without incrementing transfer operations.
- `curl_exec()` subtracts PHP callback execution from measured network wait, so user CPU in write, header, read, progress, debug, or transfer-info callbacks is not reported as driver wait.
- Nested transfers retain separate callback timing scopes, and inactive nested transfers cannot leak timing into an active caller.
- Dormant multi execution no longer clones the attachment list. Trace headers are refreshed in place while holding the established easy-then-multi lock order, with no steady-state per-drive allocation.

## Trace propagation

- Added automatic W3C `traceparent` propagation during active captures.
- Explicit user headers win case-insensitively.
- Removing a user header allows automatic propagation to resume on the next transfer.
- Injected headers are not copied as user headers by `curl_copy_handle()`.
- Stale injected headers are removed when a reused handle runs outside the capture that introduced them.
- Added a real libcurl regression test for slist replacement, removal, bookkeeping, and user precedence through the production pre-transfer path.
- Documented why replacing and freeing the previous slist is safe for an attached multi handle before `curl_multi_perform()` starts walking it.

## Attribution, reports, and exports

- Added inclusive and exclusive exact counters:
  - `incl_network`
  - `excl_network`
  - `incl_network_wait`
  - `excl_network_wait`
- Network events now propagate through nested calls, recursion, coroutine state, and exception resynchronization with the same attribution model used by database counters.
- Added network metrics to:
  - exact monitoring tables
  - sampled probe summaries
  - interactive HTML reports
  - distributed trace stitching
  - Graphviz output
  - OTLP span attributes
  - Prometheus gauges
  - performance assertions via `network` and `network_wait_ms`
- Prometheus now exports:
  - `elephc_network_operations_per_request`
  - `elephc_network_wait_seconds_per_request`
- Run totals and assertion metrics use exclusive values to avoid double-counting nested frames, while graphs expose both inclusive and exclusive values.

## Probe and PDO behavior

- Database and network telemetry use separate runtime slots, so HTTP work cannot affect query budgets or N+1 diagnostics.
- Event consumers retain ownership of their capture-window gate. Bridge-side exact timing stays dormant outside an active exact or remote-probe window.
- The shared helper fixes PDO wait timing in remote-probe windows: those windows previously recorded database operations with zero driver wait, and now record the measured wait duration. Exact PDO capture semantics remain unchanged.
- `probe_io_summary` intentionally continues into allocation and network summaries even when there are no database rows, so non-database activity is not hidden.
- Updated the probe shared-region layout comment after widening the event table.

## Compatibility

- Exact logs written with the earlier `network_ops` and `network_wait` fields still parse.
- Saved JSON graphs using the earlier field names deserialize through aliases and restore the direct value as the minimum valid inclusive value.
- Added regression tests for both legacy formats.

## Documentation

- Updated curl, profiling, CLI, and contributor documentation.
- Regenerated the builtin registry and internal pages after restoring conservative curl runtime effects.
- Validated generated docs, site compatibility, and the typed EIR boundary audit.

## Verification

- `cargo build -p elephc --features curl`
- `cargo check -p elephc-curl`
- `cargo test -p elephc-monitoring-contract`
- `cargo test -p elephc-curl timing_tests`
- Real libcurl tests:
  - `perform_refreshes_the_real_traceparent_slist`
  - `multi_perform_runs_a_transfer_and_queues_its_completion`
- `cargo test -p elephc-instr network_metrics`
- `cargo test -p elephc-probe io_events_are_counted_exactly_per_route`
- `cargo test -p elephc-probe the_first_ask_opens_a_fresh_event_window`
- `cargo test --bin elephc every_bridge_declares_a_monitoring_policy`
- `cargo test --bin elephc every_runtime_lowering_has_a_logical_signature`
- `cargo test --bin elephc curl_runtime_effects_mark_network_boundaries`
- Focused parsing, saved-profile compatibility, assertion, Prometheus, HTML, trace, and stitching tests
- `cargo build --example gen_builtins --features curl`
- `python3 scripts/docs/extract_builtins.py --render --force`
- `python3 scripts/docs/audit_builtins.py`
- `python3 scripts/docs/elephc_builtins/validate_site_compat.py`
- `python3 scripts/audit_builtin_eir_boundary.py --enforce-target-architecture`
- `git diff --check`
