### PR TITLE
fix: native-add curl before the release-artifact compile probe

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -162,6 +162,22 @@ filter = 'test(test_eval_declared_interface_parameter_type_contracts)'
 slow-timeout = { period = "180s", terminate-after = 1 }
 
 [[profile.default.overrides]]
+filter = 'test(test_eval_declared_abstract_interface_method_contracts)'
+slow-timeout = { period = "180s", terminate-after = 1 }
+
+[[profile.ci.overrides]]
+filter = 'test(test_eval_declared_abstract_interface_method_contracts)'
+slow-timeout = { period = "180s", terminate-after = 1 }
+
+[[profile.default.overrides]]
+filter = 'test(test_eval_declared_interface_return_type_contracts)'
+slow-timeout = { period = "180s", terminate-after = 1 }
+
+[[profile.ci.overrides]]
+filter = 'test(test_eval_declared_interface_return_type_contracts)'
+slow-timeout = { period = "180s", terminate-after = 1 }
+
+[[profile.default.overrides]]
 filter = 'test(test_eval_declared_interface_property_hook_contracts)'
 slow-timeout = { period = "180s", terminate-after = 1 }
 
@@ -183,6 +199,14 @@ slow-timeout = { period = "180s", terminate-after = 1 }
 
 [[profile.ci.overrides]]
 filter = 'test(test_eval_aot_function_by_ref_arg_prep_fatal_cleans_up_stack)'
+slow-timeout = { period = "180s", terminate-after = 1 }
+
+[[profile.default.overrides]]
+filter = 'test(test_eval_aot_static_method_callable_variants_by_ref_arg_prep_fatal_clean_up_stack)'
+slow-timeout = { period = "180s", terminate-after = 1 }
+
+[[profile.ci.overrides]]
+filter = 'test(test_eval_aot_static_method_callable_variants_by_ref_arg_prep_fatal_clean_up_stack)'
 slow-timeout = { period = "180s", terminate-after = 1 }
 
 [[profile.default.overrides]]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -256,6 +256,10 @@ jobs:
       - build
     if: needs.gate.outputs.build == 'true'
     runs-on: ${{ matrix.runner }}
+    # Cold `elephc native add curl` builds openssl/zlib/nghttp2/libssh2/curl
+    # from source (~6 minutes). A warm cache is a no-op. Other packed
+    # bridges still compile-probe in the same job.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -273,11 +277,28 @@ jobs:
 
       # The probe links real programs, which the build jobs never do on these
       # runners; macOS runners carry the Xcode command line tools already.
+      # `build-essential` is also what `elephc native add curl` needs to
+      # compile the managed libcurl chain (perl is on the image; openssl's
+      # Configure invokes it). Same package set as managed-native-smoke.
       - name: Install a linking toolchain
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y binutils build-essential file
+
+      # Packed `libelephc_curl.a` still fail-closes without the managed
+      # curl package. The verify script runs `elephc native add` inside
+      # its empty WORKDIR; this cache is the default root that add writes
+      # (`~/.cache/elephc/native`), keyed like curl-codegen-tests so a
+      # warm runner skips the from-source rebuild. The compiler itself
+      # stays fail-closed for real projects.
+      - name: Cache managed native curl/libssh2/nghttp2/openssl/zlib
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/elephc/native
+          key: verify-native-${{ matrix.target }}-${{ hashFiles('examples/curl-get/elephc.lock', 'src/native_deps/catalog.rs', 'src/native_deps/recipes/curl.rs', 'src/native_deps/recipes/libssh2.rs', 'src/native_deps/recipes/nghttp2.rs', 'src/native_deps/recipes/openssl.rs', 'src/native_deps/recipes/zlib.rs', 'src/native_deps/recipes/util.rs') }}
+          restore-keys: |
+            verify-native-${{ matrix.target }}-
 
       - name: Download the built tarball
         uses: actions/download-artifact@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -286,12 +286,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y binutils build-essential file
 
-      # Packed `libelephc_curl.a` still fail-closes without the managed
-      # curl package. The verify script runs `elephc native add` inside
-      # its empty WORKDIR; this cache is the default root that add writes
-      # (`~/.cache/elephc/native`), keyed like curl-codegen-tests so a
-      # warm runner skips the from-source rebuild. The compiler itself
-      # stays fail-closed for real projects.
+      # The probe native-adds curl in its empty WORKDIR before
+      # --with-curl, then compile-probes the packed archive. This cache
+      # is the default root that add writes (`~/.cache/elephc/native`),
+      # keyed like curl-codegen-tests so a warm runner skips the
+      # from-source openssl/libcurl rebuild. The compiler itself stays
+      # fail-closed for real projects.
       - name: Cache managed native curl/libssh2/nghttp2/openssl/zlib
         uses: actions/cache@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,6 +240,10 @@ jobs:
     needs:
       - prepare
       - build
+    # Cold `elephc native add curl` builds openssl/zlib/nghttp2/libssh2/curl
+    # from source (~6 minutes). A warm cache is a no-op. Other packed
+    # bridges still compile-probe in the same job.
+    timeout-minutes: 45
     strategy:
       # One incomplete target should still report the state of the other two.
       fail-fast: false
@@ -258,11 +262,28 @@ jobs:
 
       # The probe links real programs, which the build jobs never do on these
       # runners; macOS runners carry the Xcode command line tools already.
+      # `build-essential` is also what `elephc native add curl` needs to
+      # compile the managed libcurl chain (perl is on the image; openssl's
+      # Configure invokes it). Same package set as managed-native-smoke.
       - name: Install a linking toolchain
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y binutils build-essential file
+
+      # Packed `libelephc_curl.a` still fail-closes without the managed
+      # curl package. The verify script runs `elephc native add` inside
+      # its empty WORKDIR; this cache is the default root that add writes
+      # (`~/.cache/elephc/native`), keyed like curl-codegen-tests so a
+      # warm runner skips the from-source rebuild. The compiler itself
+      # stays fail-closed for real projects.
+      - name: Cache managed native curl/libssh2/nghttp2/openssl/zlib
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/elephc/native
+          key: verify-native-${{ matrix.target }}-${{ hashFiles('examples/curl-get/elephc.lock', 'src/native_deps/catalog.rs', 'src/native_deps/recipes/curl.rs', 'src/native_deps/recipes/libssh2.rs', 'src/native_deps/recipes/nghttp2.rs', 'src/native_deps/recipes/openssl.rs', 'src/native_deps/recipes/zlib.rs', 'src/native_deps/recipes/util.rs') }}
+          restore-keys: |
+            verify-native-${{ matrix.target }}-
 
       - name: Download the built tarball
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,12 +271,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y binutils build-essential file
 
-      # Packed `libelephc_curl.a` still fail-closes without the managed
-      # curl package. The verify script runs `elephc native add` inside
-      # its empty WORKDIR; this cache is the default root that add writes
-      # (`~/.cache/elephc/native`), keyed like curl-codegen-tests so a
-      # warm runner skips the from-source rebuild. The compiler itself
-      # stays fail-closed for real projects.
+      # The probe native-adds curl in its empty WORKDIR before
+      # --with-curl, then compile-probes the packed archive. This cache
+      # is the default root that add writes (`~/.cache/elephc/native`),
+      # keyed like curl-codegen-tests so a warm runner skips the
+      # from-source openssl/libcurl rebuild. The compiler itself stays
+      # fail-closed for real projects.
       - name: Cache managed native curl/libssh2/nghttp2/openssl/zlib
         uses: actions/cache@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -668,6 +668,40 @@ cannot see it.
 - The relevant `docs/php/` or `docs/beyond-php/` page — document the PHP surface.
 - Update `CLAUDE.md` only if you changed the bridge/flag mechanism itself.
 
+### 8. Packed bridge + managed native package
+
+A bridge crate's `libelephc_<name>.a` is packed next to the compiler in the
+release and nightly tarballs. `scripts/verify-release-artifact.sh` unpacks that
+tarball into an empty directory (no checkout) and compile-probes every
+capability that names a packed archive, using the packaged binary's
+`--print-capabilities` list. That is how a missing, truncated, or wrong-arch
+archive is caught — the hole that left `libelephc_magician.a` out of every
+tarball from 0.26.3 to 0.26.5.
+
+`--with-regex` is not this case. It is a runtime capability; PCRE2 is only a
+managed package; there is no packed regex archive; the probe skips it
+(`needs no archive from this tarball`). Do not copy that skip for a packed
+bridge.
+
+If the new bridge's `.a` also needs a catalog package at PHP-program link time
+(curl is the precedent: `NativeRequirement::package("curl")` when `elephc_curl`
+is planned; `elephc native add curl` in the user project), then:
+
+1. Wire the native requirement in `src/pipeline/backend.rs` the same way curl
+   does.
+2. Pack `-p elephc-<name>` in nightly and release, like curl.
+3. Teach `scripts/verify-release-artifact.sh` to run
+   `$ELEPHC native add <package>` in the empty probe WORKDIR **before**
+   `--with-<name>`. Never fail-then-retry by grepping the compiler recovery
+   text. Never skip the compile probe.
+4. Cache `~/.cache/elephc/native` on the nightly and release `verify-artifact`
+   jobs (keyed like `curl-codegen-tests`) and give the job a long enough
+   timeout for a cold source build of the C library.
+
+System libraries — phar's zlib/bz2, `libdl`, Apple frameworks — are not
+managed native packages. They do not go through `elephc native add` and are
+not this rule.
+
 ## Contributor Certification
 
 By submitting a contribution to this repository, you represent and warrant that:

--- a/scripts/verify-release-artifact.sh
+++ b/scripts/verify-release-artifact.sh
@@ -19,6 +19,9 @@
 # anyone to forget to update.
 #
 # Usage: scripts/verify-release-artifact.sh <tarball>
+#
+# Focused fixture (mock packaged binary, no cargo suite):
+#   cargo test --test verify_release_artifact
 set -euo pipefail
 
 if [ $# -ne 1 ]; then
@@ -75,6 +78,25 @@ fail() {
     FAILURES=$((FAILURES + 1))
 }
 
+# Prints the catalog package named by a compiler recovery line of the form
+# `elephc native add <package>`, but only when the diagnostic is the
+# fail-closed "requires managed native package" error. Other compile
+# failures (wrong-arch archive, truncated `.a`, missing toolchain) must
+# still fail the probe. The empty WORKDIR prints `cd -- ''`; the package
+# name is taken from the `native add` token, not from that path.
+missing_native_package() {
+    local log="$1"
+    if ! grep -q 'requires managed native package' "$log"; then
+        return 1
+    fi
+    local package
+    package="$(sed -n 's/.*elephc native add \([A-Za-z0-9][A-Za-z0-9._-]*\).*/\1/p' "$log" | head -n 1)"
+    if [ -z "$package" ]; then
+        return 1
+    fi
+    printf '%s\n' "$package"
+}
+
 # `--print-capabilities` prints `<kind>\t<name>[\t<archive>...]`.
 CAPABILITIES="$("$ELEPHC" --print-capabilities)"
 if [ -z "$CAPABILITIES" ]; then
@@ -106,6 +128,19 @@ while IFS=$'\t' read -r kind name archives; do
     # resolves a managed native package and `mysqli` links the `pdo` archive
     # already covered by its own line.
     #
+    # A packed archive is still not always enough to link. `curl` ships
+    # `libelephc_curl.a` and so must be compile-probed — skipping it the way
+    # `regex` is skipped would stop proving the archive links — but the
+    # compiler also fail-closes without a managed native package (`elephc
+    # native add curl` / pinned libcurl). This probe runs in a fresh empty
+    # directory on purpose, so that diagnostic is expected. When the first
+    # compile names a missing managed package, the recovery the compiler
+    # printed is run with the packaged binary and the compile is retried.
+    # The package name comes from that recovery line, not from a curl-only
+    # special case, so the next packed-plus-catalog capability does not
+    # need a second edit here. A truncated or wrong-arch archive still
+    # fails: those errors do not print `elephc native add`.
+    #
     # The check ends at the link. Producing the executable is what proves the
     # archive was packed and usable, and it is the whole of what packaging can
     # get wrong; whether the program then behaves is what CI compiles and runs
@@ -121,9 +156,26 @@ while IFS=$'\t' read -r kind name archives; do
     CHECKED=$((CHECKED + 1))
     rm -f probe
     if ! "$ELEPHC" "--with-$name" probe.php >compile.log 2>&1; then
-        fail "$kind $name: --with-$name did not link"
-        sed 's/^/          /' compile.log
-        continue
+        if package="$(missing_native_package compile.log)"; then
+            echo "  ...   $kind $name: running packaged 'native add $package' in empty probe project"
+            if ! "$ELEPHC" native add "$package" >native-add.log 2>&1; then
+                fail "$kind $name: --with-$name did not link"
+                sed 's/^/          /' compile.log
+                echo "          native add $package failed:"
+                sed 's/^/          /' native-add.log
+                continue
+            fi
+            rm -f probe
+            if ! "$ELEPHC" "--with-$name" probe.php >compile.log 2>&1; then
+                fail "$kind $name: --with-$name did not link after native add $package"
+                sed 's/^/          /' compile.log
+                continue
+            fi
+        else
+            fail "$kind $name: --with-$name did not link"
+            sed 's/^/          /' compile.log
+            continue
+        fi
     fi
     if [ ! -x probe ]; then
         fail "$kind $name: --with-$name reported success but produced no executable"

--- a/scripts/verify-release-artifact.sh
+++ b/scripts/verify-release-artifact.sh
@@ -78,25 +78,6 @@ fail() {
     FAILURES=$((FAILURES + 1))
 }
 
-# Prints the catalog package named by a compiler recovery line of the form
-# `elephc native add <package>`, but only when the diagnostic is the
-# fail-closed "requires managed native package" error. Other compile
-# failures (wrong-arch archive, truncated `.a`, missing toolchain) must
-# still fail the probe. The empty WORKDIR prints `cd -- ''`; the package
-# name is taken from the `native add` token, not from that path.
-missing_native_package() {
-    local log="$1"
-    if ! grep -q 'requires managed native package' "$log"; then
-        return 1
-    fi
-    local package
-    package="$(sed -n 's/.*elephc native add \([A-Za-z0-9][A-Za-z0-9._-]*\).*/\1/p' "$log" | head -n 1)"
-    if [ -z "$package" ]; then
-        return 1
-    fi
-    printf '%s\n' "$package"
-}
-
 # `--print-capabilities` prints `<kind>\t<name>[\t<archive>...]`.
 CAPABILITIES="$("$ELEPHC" --print-capabilities)"
 if [ -z "$CAPABILITIES" ]; then
@@ -128,18 +109,14 @@ while IFS=$'\t' read -r kind name archives; do
     # resolves a managed native package and `mysqli` links the `pdo` archive
     # already covered by its own line.
     #
-    # A packed archive is still not always enough to link. `curl` ships
-    # `libelephc_curl.a` and so must be compile-probed — skipping it the way
-    # `regex` is skipped would stop proving the archive links — but the
-    # compiler also fail-closes without a managed native package (`elephc
-    # native add curl` / pinned libcurl). This probe runs in a fresh empty
-    # directory on purpose, so that diagnostic is expected. When the first
-    # compile names a missing managed package, the recovery the compiler
-    # printed is run with the packaged binary and the compile is retried.
-    # The package name comes from that recovery line, not from a curl-only
-    # special case, so the next packed-plus-catalog capability does not
-    # need a second edit here. A truncated or wrong-arch archive still
-    # fails: those errors do not print `elephc native add`.
+    # `curl` is the one packed-archive capability that also needs a managed
+    # catalog package. `libelephc_curl.a` is the PHP ext/curl bridge and
+    # must be compile-probed — skipping it the way `regex` is skipped would
+    # stop proving the archive links — but `--with-curl` fail-closes until
+    # the empty WORKDIR has `elephc native add curl` (pinned libcurl +
+    # openssl/zlib/nghttp2/libssh2). That is a real user workflow, so this
+    # probe adds the catalog package first, then compiles once. A truncated
+    # or wrong-arch archive still fails that single compile.
     #
     # The check ends at the link. Producing the executable is what proves the
     # archive was packed and usable, and it is the whole of what packaging can
@@ -155,27 +132,19 @@ while IFS=$'\t' read -r kind name archives; do
 
     CHECKED=$((CHECKED + 1))
     rm -f probe
-    if ! "$ELEPHC" "--with-$name" probe.php >compile.log 2>&1; then
-        if package="$(missing_native_package compile.log)"; then
-            echo "  ...   $kind $name: running packaged 'native add $package' in empty probe project"
-            if ! "$ELEPHC" native add "$package" >native-add.log 2>&1; then
-                fail "$kind $name: --with-$name did not link"
-                sed 's/^/          /' compile.log
-                echo "          native add $package failed:"
-                sed 's/^/          /' native-add.log
-                continue
-            fi
-            rm -f probe
-            if ! "$ELEPHC" "--with-$name" probe.php >compile.log 2>&1; then
-                fail "$kind $name: --with-$name did not link after native add $package"
-                sed 's/^/          /' compile.log
-                continue
-            fi
-        else
-            fail "$kind $name: --with-$name did not link"
-            sed 's/^/          /' compile.log
+    if [ "$name" = "curl" ]; then
+        echo "  ...   $kind $name: adding managed native package curl before --with-curl"
+        if ! "$ELEPHC" native add curl >native-add.log 2>&1; then
+            fail "$kind $name: native add curl failed"
+            sed 's/^/          /' native-add.log
             continue
         fi
+        sed 's/^/          /' native-add.log
+    fi
+    if ! "$ELEPHC" "--with-$name" probe.php >compile.log 2>&1; then
+        fail "$kind $name: --with-$name did not link"
+        sed 's/^/          /' compile.log
+        continue
     fi
     if [ ! -x probe ]; then
         fail "$kind $name: --with-$name reported success but produced no executable"

--- a/src/linker/bridges.rs
+++ b/src/linker/bridges.rs
@@ -1104,7 +1104,26 @@ mod tests {
                 "{rel} publishes an artifact without running {probe}, so a \
                  bridge missing from the tarball ships unnoticed again"
             );
+            assert!(
+                body.contains("~/.cache/elephc/native"),
+                "{rel} runs {probe} without caching managed native packages, so \
+                 --with-curl fails closed in the empty probe directory every \
+                 night instead of reusing a verified libcurl build"
+            );
         }
+        let script = std::fs::read_to_string(root.join(probe))
+            .unwrap_or_else(|_| panic!("cannot read {probe}"));
+        assert!(
+            script.contains("elephc native add")
+                && script.contains("requires managed native package"),
+            "{probe} must retry a missing managed native package from the \
+             compiler recovery line; skipping curl the way regex is skipped \
+             would stop proving libelephc_curl.a links"
+        );
+        assert!(
+            !script.contains("name == \"curl\"") && !script.contains("[ \"$name\" = \"curl\" ]"),
+            "{probe} must not special-case curl; the retry is generic"
+        );
     }
 
     /// Verifies release artifacts also ship the curl-aware Magician variant.

--- a/src/linker/bridges.rs
+++ b/src/linker/bridges.rs
@@ -1107,22 +1107,39 @@ mod tests {
             assert!(
                 body.contains("~/.cache/elephc/native"),
                 "{rel} runs {probe} without caching managed native packages, so \
-                 --with-curl fails closed in the empty probe directory every \
-                 night instead of reusing a verified libcurl build"
+                 a cold native add curl rebuilds openssl/libcurl from source \
+                 on every nightly instead of reusing a verified cache"
             );
         }
         let script = std::fs::read_to_string(root.join(probe))
             .unwrap_or_else(|_| panic!("cannot read {probe}"));
         assert!(
-            script.contains("elephc native add")
-                && script.contains("requires managed native package"),
-            "{probe} must retry a missing managed native package from the \
-             compiler recovery line; skipping curl the way regex is skipped \
-             would stop proving libelephc_curl.a links"
+            script.contains("[ \"$name\" = \"curl\" ]") && script.contains("native add curl"),
+            "{probe} must run native add curl before --with-curl; curl is \
+             the packed-archive capability that also needs a catalog package"
         );
         assert!(
-            !script.contains("name == \"curl\"") && !script.contains("[ \"$name\" = \"curl\" ]"),
-            "{probe} must not special-case curl; the retry is generic"
+            script.contains("adding managed native package curl before --with-curl"),
+            "{probe} must native-add curl first, not after a failed compile"
+        );
+        assert!(
+            !script.contains("missing_native_package")
+                && !script.contains("requires managed native package")
+                && !script.contains("after native add"),
+            "{probe} must not retry from a compiler FAIL / recovery line"
+        );
+        assert!(
+            script.contains("needs no archive from this tarball"),
+            "{probe} must keep the empty-archive skip for regex/mysqli"
+        );
+        let after_curl = script
+            .split_once("[ \"$name\" = \"curl\" ]")
+            .map(|(_, rest)| rest)
+            .unwrap_or("");
+        assert!(
+            after_curl.contains("native add curl")
+                && !after_curl.contains("needs no archive from this tarball"),
+            "{probe} must not skip curl the way regex is skipped"
         );
     }
 

--- a/tests/verify_release_artifact.rs
+++ b/tests/verify_release_artifact.rs
@@ -1,0 +1,233 @@
+//! Purpose:
+//! Fixture tests for `scripts/verify-release-artifact.sh`: a packed archive
+//! that still needs a managed native package must `ok` after the packaged
+//! `native add`, while archive-less capabilities stay skipped and a real
+//! link failure still fails.
+//!
+//! Called from:
+//! - `cargo test` through Rust's test harness (`cargo test --test verify_release_artifact`).
+//!
+//! Key details:
+//! - The script unpacks into an empty prefix on purpose, so these tests ship a
+//!   mock `elephc` inside a tarball rather than the real compiler.
+//! - The mock prints the same missing-package diagnostic the production
+//!   resolver emits; it never downloads or builds catalog sources.
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Directory of this crate, used to locate the packaging probe script.
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Isolated scratch directory unique across parallel test threads.
+fn scratch(label: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "elephc_verify_artifact_{}_{}_{:?}_{}",
+        label,
+        std::process::id(),
+        std::thread::current().id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).expect("create scratch dir");
+    dir
+}
+
+/// Writes a mock packaged `elephc` that implements the probe's exact calls.
+///
+/// `--print-capabilities` reports `tls` (archive-only), `curl` (archive plus
+/// managed native package), `regex` and `mysqli` (no archive). `--with-tls`
+/// always "links". `--with-curl` fail-closes until `native add curl` has
+/// created a project marker. A `broken` capability, when advertised, always
+/// fails with a non-recovery error so a truncated archive still FAILs.
+fn write_mock_elephc(path: &Path, advertise_broken: bool) {
+    let broken_line = if advertise_broken {
+        "echo -e 'bridge\\tbroken\\tlibelephc_broken.a'\n"
+    } else {
+        ""
+    };
+    let script = format!(
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+state_dir="${{ELEPHC_MOCK_STATE:-$here/../.mock-state}}"
+mkdir -p "$state_dir"
+case "${{1:-}}" in
+  --version)
+    echo "elephc 0.0.0-fixture"
+    ;;
+  --print-capabilities)
+    echo -e 'bridge\ttls\tlibelephc_tls.a'
+    echo -e 'bridge\tcurl\tlibelephc_curl.a'
+    {broken_line}    echo -e 'capability\tregex'
+    echo -e 'capability\tmysqli'
+    ;;
+  --with-tls)
+    printf '#!/bin/sh\necho ok\n' > probe
+    chmod +x probe
+    ;;
+  --with-curl)
+    if [ ! -f "$state_dir/added-curl" ]; then
+      echo "native project error: curl support requires managed native package curl" >&2
+      echo "project: not found (searched from )" >&2
+      echo "recovery: cd -- '' && elephc native add curl" >&2
+      exit 1
+    fi
+    printf '#!/bin/sh\necho ok\n' > probe
+    chmod +x probe
+    ;;
+  --with-broken)
+    echo "ld: archive is truncated" >&2
+    exit 1
+    ;;
+  native)
+    if [ "${{2:-}}" = "add" ] && [ -n "${{3:-}}" ]; then
+      touch "$state_dir/added-$3"
+      echo "added $3"
+      exit 0
+    fi
+    echo "unexpected native invocation: $*" >&2
+    exit 1
+    ;;
+  *)
+    echo "unexpected invocation: $*" >&2
+    exit 1
+    ;;
+esac
+"#
+    );
+    fs::write(path, script).expect("write mock elephc");
+    let mut perms = fs::metadata(path).expect("stat mock elephc").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).expect("chmod mock elephc");
+}
+
+/// Packs the mock compiler and named archives into a `.tar.gz` the probe accepts.
+fn pack_tarball(staging: &Path, tarball: &Path, advertise_broken: bool) {
+    let pack = staging.join("pack");
+    fs::create_dir_all(&pack).expect("create pack dir");
+    write_mock_elephc(&pack.join("elephc"), advertise_broken);
+    fs::write(pack.join("libelephc_tls.a"), b"tls-archive\n").expect("write tls archive");
+    fs::write(pack.join("libelephc_curl.a"), b"curl-archive\n").expect("write curl archive");
+    if advertise_broken {
+        fs::write(pack.join("libelephc_broken.a"), b"broken-archive\n")
+            .expect("write broken archive");
+    }
+    let status = Command::new("tar")
+        .args(["czf"])
+        .arg(tarball)
+        .args(["-C"])
+        .arg(&pack)
+        .args(["elephc", "libelephc_tls.a", "libelephc_curl.a"])
+        .args(if advertise_broken {
+            vec!["libelephc_broken.a"]
+        } else {
+            vec![]
+        })
+        .status()
+        .expect("run tar");
+    assert!(status.success(), "tar failed: {status}");
+}
+
+/// Runs `scripts/verify-release-artifact.sh` against `tarball` and returns output plus success.
+fn run_probe(tarball: &Path) -> (bool, String) {
+    let script = repo_root().join("scripts/verify-release-artifact.sh");
+    let output = Command::new("bash")
+        .arg(&script)
+        .arg(tarball)
+        .output()
+        .expect("run verify-release-artifact.sh");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let combined = format!("{stdout}{stderr}");
+    (output.status.success(), combined)
+}
+
+/// A tarball that packs `libelephc_curl.a` must `ok` curl after `native add`, not FAIL.
+#[test]
+fn packed_curl_is_ok_after_native_add() {
+    let dir = scratch("curl_ok");
+    let tarball = dir.join("elephc-fixture.tar.gz");
+    pack_tarball(&dir, &tarball, false);
+
+    let (ok, log) = run_probe(&tarball);
+    assert!(ok, "probe should pass after native add; log:\n{log}");
+    assert!(
+        log.contains("ok    bridge curl (libelephc_curl.a)"),
+        "curl must be reported ok after the generic native-add retry; log:\n{log}"
+    );
+    assert!(
+        log.contains("running packaged 'native add curl'"),
+        "the first --with-curl miss must trigger the recovery; log:\n{log}"
+    );
+    assert!(
+        log.contains("ok    bridge tls (libelephc_tls.a)"),
+        "archive-only bridges must still pass; log:\n{log}"
+    );
+    assert!(
+        log.contains("skip  capability regex (needs no archive from this tarball)"),
+        "regex skip must be unchanged; log:\n{log}"
+    );
+    assert!(
+        log.contains("skip  capability mysqli (needs no archive from this tarball)"),
+        "mysqli skip must be unchanged; log:\n{log}"
+    );
+    assert!(
+        !log.contains("FAIL"),
+        "no capability should fail; log:\n{log}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// A compile that is not a missing managed package must still FAIL, not `native add`.
+#[test]
+fn non_native_link_failure_is_not_retried() {
+    let dir = scratch("broken");
+    let tarball = dir.join("elephc-fixture.tar.gz");
+    pack_tarball(&dir, &tarball, true);
+
+    let (ok, log) = run_probe(&tarball);
+    assert!(!ok, "a truncated-archive style failure must fail the probe; log:\n{log}");
+    assert!(
+        log.contains("FAIL  bridge broken: --with-broken did not link"),
+        "broken must fail without a native-add retry; log:\n{log}"
+    );
+    assert!(
+        log.contains("ld: archive is truncated"),
+        "the original linker error must be shown; log:\n{log}"
+    );
+    assert!(
+        !log.contains("native add broken") && !log.contains("running packaged 'native add broken'"),
+        "a non-recovery failure must not invent a native add; log:\n{log}"
+    );
+    assert!(
+        log.contains("ok    bridge curl (libelephc_curl.a)"),
+        "curl should still recover in the same run; log:\n{log}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// Nightly still packs the curl bridge; the verify hole is the probe, not #730.
+#[test]
+fn nightly_still_packs_elephc_curl() {
+    let body = fs::read_to_string(repo_root().join(".github/workflows/nightly.yml"))
+        .expect("read nightly workflow");
+    assert!(
+        body.contains("-p elephc-curl"),
+        "nightly.yml must still build elephc-curl; do not revert #730"
+    );
+    assert!(
+        body.contains("elephc native add") || body.contains("Cache managed native"),
+        "nightly verify-artifact must give native add a cache; the empty probe \
+         directory has no checkout project"
+    );
+}

--- a/tests/verify_release_artifact.rs
+++ b/tests/verify_release_artifact.rs
@@ -1,8 +1,7 @@
 //! Purpose:
-//! Fixture tests for `scripts/verify-release-artifact.sh`: a packed archive
-//! that still needs a managed native package must `ok` after the packaged
-//! `native add`, while archive-less capabilities stay skipped and a real
-//! link failure still fails.
+//! Fixture tests for `scripts/verify-release-artifact.sh`: a packed curl
+//! archive is compile-probed after `native add curl` in the empty WORKDIR,
+//! archive-less capabilities stay skipped, and a real link failure still fails.
 //!
 //! Called from:
 //! - `cargo test` through Rust's test harness (`cargo test --test verify_release_artifact`).
@@ -10,8 +9,8 @@
 //! Key details:
 //! - The script unpacks into an empty prefix on purpose, so these tests ship a
 //!   mock `elephc` inside a tarball rather than the real compiler.
-//! - The mock prints the same missing-package diagnostic the production
-//!   resolver emits; it never downloads or builds catalog sources.
+//! - The mock accepts `native add curl` before `--with-curl`; it never
+//!   downloads or builds catalog sources.
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -44,9 +43,10 @@ fn scratch(label: &str) -> PathBuf {
 ///
 /// `--print-capabilities` reports `tls` (archive-only), `curl` (archive plus
 /// managed native package), `regex` and `mysqli` (no archive). `--with-tls`
-/// always "links". `--with-curl` fail-closes until `native add curl` has
-/// created a project marker. A `broken` capability, when advertised, always
-/// fails with a non-recovery error so a truncated archive still FAILs.
+/// always "links". `--with-curl` fail-closes unless `native add curl` has
+/// already created a project marker. A `broken` capability, when advertised,
+/// always fails with a truncated-archive error so a real link failure still
+/// FAILs without inventing a native add.
 fn write_mock_elephc(path: &Path, advertise_broken: bool) {
     let broken_line = if advertise_broken {
         "echo -e 'bridge\\tbroken\\tlibelephc_broken.a'\n"
@@ -90,7 +90,7 @@ case "${{1:-}}" in
   native)
     if [ "${{2:-}}" = "add" ] && [ -n "${{3:-}}" ]; then
       touch "$state_dir/added-$3"
-      echo "added $3"
+      echo "mock: native add $3"
       exit 0
     fi
     echo "unexpected native invocation: $*" >&2
@@ -150,7 +150,7 @@ fn run_probe(tarball: &Path) -> (bool, String) {
     (output.status.success(), combined)
 }
 
-/// A tarball that packs `libelephc_curl.a` must `ok` curl after `native add`, not FAIL.
+/// A tarball that packs `libelephc_curl.a` must `ok` curl after add-first, not FAIL.
 #[test]
 fn packed_curl_is_ok_after_native_add() {
     let dir = scratch("curl_ok");
@@ -158,14 +158,26 @@ fn packed_curl_is_ok_after_native_add() {
     pack_tarball(&dir, &tarball, false);
 
     let (ok, log) = run_probe(&tarball);
-    assert!(ok, "probe should pass after native add; log:\n{log}");
+    assert!(ok, "probe should pass after add-first native add; log:\n{log}");
     assert!(
         log.contains("ok    bridge curl (libelephc_curl.a)"),
-        "curl must be reported ok after the generic native-add retry; log:\n{log}"
+        "curl must be reported ok after native add then one --with-curl; log:\n{log}"
     );
     assert!(
-        log.contains("running packaged 'native add curl'"),
-        "the first --with-curl miss must trigger the recovery; log:\n{log}"
+        log.contains("adding managed native package curl before --with-curl"),
+        "curl must native-add first, before the compile; log:\n{log}"
+    );
+    assert!(
+        log.contains("mock: native add curl"),
+        "the packaged binary must have seen native add curl; log:\n{log}"
+    );
+    assert!(
+        !log.contains("running packaged 'native add curl'"),
+        "must not log the old fail-then-retry line; log:\n{log}"
+    );
+    assert!(
+        !log.contains("requires managed native package"),
+        "add-first must not compile-fail before native add; log:\n{log}"
     );
     assert!(
         log.contains("ok    bridge tls (libelephc_tls.a)"),
@@ -187,9 +199,9 @@ fn packed_curl_is_ok_after_native_add() {
     let _ = fs::remove_dir_all(&dir);
 }
 
-/// A compile that is not a missing managed package must still FAIL, not `native add`.
+/// A truncated-archive compile must FAIL without inventing a native add for that capability.
 #[test]
-fn non_native_link_failure_is_not_retried() {
+fn truncated_archive_still_fails_without_inventing_native_add() {
     let dir = scratch("broken");
     let tarball = dir.join("elephc-fixture.tar.gz");
     pack_tarball(&dir, &tarball, true);
@@ -198,19 +210,20 @@ fn non_native_link_failure_is_not_retried() {
     assert!(!ok, "a truncated-archive style failure must fail the probe; log:\n{log}");
     assert!(
         log.contains("FAIL  bridge broken: --with-broken did not link"),
-        "broken must fail without a native-add retry; log:\n{log}"
+        "broken must fail as a real link error; log:\n{log}"
     );
     assert!(
         log.contains("ld: archive is truncated"),
         "the original linker error must be shown; log:\n{log}"
     );
     assert!(
-        !log.contains("native add broken") && !log.contains("running packaged 'native add broken'"),
-        "a non-recovery failure must not invent a native add; log:\n{log}"
+        !log.contains("native add broken") && !log.contains("mock: native add broken"),
+        "a truncated archive must not invent a native add; log:\n{log}"
     );
     assert!(
-        log.contains("ok    bridge curl (libelephc_curl.a)"),
-        "curl should still recover in the same run; log:\n{log}"
+        log.contains("ok    bridge curl (libelephc_curl.a)")
+            && log.contains("mock: native add curl"),
+        "curl should still native-add first in the same run; log:\n{log}"
     );
 
     let _ = fs::remove_dir_all(&dir);
@@ -226,8 +239,8 @@ fn nightly_still_packs_elephc_curl() {
         "nightly.yml must still build elephc-curl; do not revert #730"
     );
     assert!(
-        body.contains("elephc native add") || body.contains("Cache managed native"),
-        "nightly verify-artifact must give native add a cache; the empty probe \
-         directory has no checkout project"
+        body.contains("Cache managed native"),
+        "nightly verify-artifact must cache ~/.cache/elephc/native so a cold \
+         native add curl can finish"
     );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nightly 2026-09-03 failed **Verify tarball** on all three targets after #730 packed `libelephc_curl.a`. Builds succeeded; publish was skipped.

## The hole

`scripts/verify-release-artifact.sh` unpacks the tarball into an empty prefix and compile-probes every capability that names a packed `.a`. TLS/PDO/image link from the archive alone. Curl also requires the managed native package (`elephc native add curl` / pinned libcurl). `regex` is skipped because it has no archive in the tarball. Curl has an archive, so it entered the compile probe and fail-closed:

```
FAIL  bridge curl: --with-curl did not link
        native project error: curl support requires managed native package curl
        project: not found (searched from )
        recovery: cd -- '' && elephc native add curl
```

PR CI stayed green because `curl-codegen-tests` run in the checkout after `elephc native install --locked`. #880 does not touch this script.

## Fix

Add-first for curl, the only packed-archive capability that also needs a catalog package:

1. When the capability name is `curl`, run `$ELEPHC native add curl` in the empty probe WORKDIR, then `$ELEPHC --with-curl probe.php` once.
2. If native add fails, FAIL with that log. If the compile still fails, FAIL as a real link error (truncated / wrong-arch archive).
3. TLS/PDO/image stay a single `--with-$name`. `regex` / `mysqli` skip (no archive) is unchanged. Nightly still packs `-p elephc-curl`.
4. CONTRIBUTING.md now has the packed-bridge + managed-native-package recipe so the next catalog-backed archive is add-first too, not a recovery-line retry.

Nightly and release `verify-artifact` jobs keep the `~/.cache/elephc/native` cache (same recipe hash as `curl-codegen-tests`) and the 45-minute timeout so a cold openssl/libcurl source build can finish. Compiler fail-closed behavior for real user projects is unchanged.

## Test

```
cargo test --test verify_release_artifact
cargo test --bin elephc the_publishing_workflows_run_the_packaging_probe
```

The fixture ships a mock packaged `elephc` so the script can be exercised without building a real tarball.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f865b59-468d-43ea-9396-028db4b51089?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f865b59-468d-43ea-9396-028db4b51089&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

