### PR TITLE
ci: push to main and the tap with the Illegal Bot App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,9 +67,11 @@ jobs:
 
   prepare:
     name: Bump version on main
-    # Pushes the version-bump commit to main.
+    # Pushes the version-bump commit to main with an Illegal Bot installation
+    # token, not the workflow token: `main` is protected and the App is the
+    # ruleset's only bypass actor. The default token needs no write access.
     permissions:
-      contents: write
+      contents: read
     if: github.event.ref_type == 'tag' && startsWith(github.event.ref, 'v')
     runs-on: ubuntu-latest
     needs:
@@ -80,12 +82,27 @@ jobs:
       # version bump themselves.
       sha: ${{ steps.bump.outputs.sha }}
     steps:
+      # Pinned to a full commit SHA rather than the `v2` tag: this step receives
+      # the App private key, so a moved upstream tag would change the code that
+      # handles it without any diff to review here. Every workflow that mints a
+      # bot token pins the same SHA; bump them together.
+      - name: Mint Illegal Bot token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        with:
+          app-id: ${{ secrets.ILLEGAL_BOT_APP_ID }}
+          private-key: ${{ secrets.ILLEGAL_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set version from tag and push bump to main
         id: bump
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           export VERSION
@@ -118,10 +135,15 @@ jobs:
           )
           PY
           echo "Set Cargo.toml and Cargo.lock version to ${VERSION}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Unlike the workflow token, an App token *does* trigger workflows on
+          # push. `[skip ci]` keeps the bump commit from starting a second full
+          # CI run on main, matching the behaviour before the bot: the tagged
+          # commit this bump sits on was already verified green by `verify-ci`.
+          BOT_ID=$(gh api "/users/${APP_SLUG}%5Bbot%5D" --jq .id)
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${BOT_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
           git add Cargo.toml Cargo.lock
-          git commit -m "chore: bump version to ${VERSION}" || true
+          git commit -m "chore: bump version to ${VERSION} [skip ci]" || true
           git push origin HEAD:main
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
@@ -334,9 +356,23 @@ jobs:
           generate_release_notes: true
           files: dist/*
 
+      # Scoped to the tap repository only: an installation token minted for a
+      # single repo cannot touch anything else in the organisation. Pinned to a
+      # full commit SHA for the same reason as the other bot-token steps.
+      - name: Mint Illegal Bot token for the tap
+        id: tap-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        with:
+          app-id: ${{ secrets.ILLEGAL_BOT_APP_ID }}
+          private-key: ${{ secrets.ILLEGAL_BOT_PRIVATE_KEY }}
+          owner: illegalstudio
+          repositories: homebrew-tap
+
       - name: Update Homebrew tap
         env:
-          TAP_TOKEN: ${{ secrets.TAP_TOKEN }}
+          TAP_TOKEN: ${{ steps.tap-token.outputs.token }}
+          APP_SLUG: ${{ steps.tap-token.outputs.app-slug }}
+          GH_TOKEN: ${{ steps.tap-token.outputs.token }}
         run: |
           VERSION="${GITHUB_REF_NAME}"
           VERSION_NUM="${VERSION#v}"
@@ -435,8 +471,9 @@ jobs:
 
           # Push to tap
           cd /tmp/homebrew-tap
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          BOT_ID=$(gh api "/users/${APP_SLUG}%5Bbot%5D" --jq .id)
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${BOT_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
           git add Formula/elephc.rb
           git commit -m "Update elephc to ${VERSION}"
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,12 @@ jobs:
       checks: read
     if: github.event.ref_type == 'tag' && startsWith(github.event.ref, 'v')
     runs-on: ubuntu-latest
+    outputs:
+      # The exact commit this job verified. Downstream jobs check out this SHA
+      # rather than re-resolving the tag, which is mutable: a tag retargeted
+      # after the checks below would otherwise carry unverified code into the
+      # bump commit that `prepare` pushes to protected main.
+      sha: ${{ steps.tag.outputs.sha }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -95,7 +101,8 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          # The SHA `verify-ci` resolved and checked, never the tag itself.
+          ref: ${{ needs.verify-ci.outputs.sha }}
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Set version from tag and push bump to main

--- a/.github/workflows/traffic.yml
+++ b/.github/workflows/traffic.yml
@@ -5,18 +5,36 @@ on:
     - cron: '0 23 * * *' # daily at 23:00 UTC
   workflow_dispatch:
 
+# The commit below is pushed with an Illegal Bot installation token, not the
+# workflow token, so `main` can stay protected: the App is the branch ruleset's
+# only bypass actor. The default token needs no write access here.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   collect:
     runs-on: ubuntu-latest
     steps:
+      # Pinned to a full commit SHA rather than the `v2` tag: this step receives
+      # the App private key, so a moved upstream tag would change the code that
+      # handles it without any diff to review here. Every workflow that mints a
+      # bot token pins the same SHA; bump them together.
+      - name: Mint Illegal Bot token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        with:
+          app-id: ${{ secrets.ILLEGAL_BOT_APP_ID }}
+          private-key: ${{ secrets.ILLEGAL_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Fetch and accumulate clone stats
         env:
-          GH_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
+          # The traffic API needs `Administration: read`, which the App grants;
+          # this replaces the personal access token this step used to carry.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh api repos/${{ github.repository }}/traffic/clones > /tmp/api_clones.json
 
@@ -70,10 +88,17 @@ jobs:
                 --dark-output .github/traffic/star-history-dark.svg
 
       - name: Commit updated stats
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Unlike the workflow token, an App token *does* trigger workflows on
+          # push. `[skip ci]` keeps this nightly bookkeeping commit from starting
+          # a full CI run on main, matching the behaviour before the bot.
+          BOT_ID=$(gh api "/users/${APP_SLUG}%5Bbot%5D" --jq .id)
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${BOT_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
           git add .github/traffic/
           git diff --cached --quiet && echo "No changes" && exit 0
-          git commit -m "chore: update repository stats"
+          git commit -m "chore: update repository stats [skip ci]"
           git push


### PR DESCRIPTION
Two jobs push with the default workflow token today, which a branch ruleset on `main` would reject: the nightly repository-stats commit (`traffic.yml`) and the release version bump (`release.yml`). Both now mint a short-lived installation token for the **Illegal Bot** GitHub App, and their workflow token drops back to `contents: read`.

Two personal access tokens retire with the change:

- `TRAFFIC_TOKEN` — the traffic/clones API is covered by the App's `Administration: read`
- `TAP_TOKEN` — the Homebrew tap push uses a token minted **scoped to `homebrew-tap` alone**, so it cannot reach anything else in the organisation

### Notes

- `actions/create-github-app-token` is pinned to a full commit SHA (`fee1f7d`), matching how this repo already pins third-party actions that run with write access — this one receives the App private key.
- Unlike the workflow token, an App token **does** trigger workflows on push. Both commits carry `[skip ci]` so main keeps the behaviour it has today; the tagged commit the bump sits on is already verified green by `verify-ci`.
- `nightly.yml` and the release-publishing job still use `GITHUB_TOKEN`: they create tags and releases, which a *branch* ruleset does not gate. A future tag ruleset would need its own bypass configuration.