### PR TITLE
ci: read stargazers with the bot token, not the workflow token

### DIFF
--- a/.github/workflows/traffic.yml
+++ b/.github/workflows/traffic.yml
@@ -76,8 +76,11 @@ jobs:
 
       - name: Generate static star history
         run: |
+          # The App token, not the workflow token: reading stargazers needs more
+          # than the `contents: read` this workflow's token now carries, and the
+          # App already holds the metadata access every other step here uses.
           set -o pipefail
-          GH_TOKEN="${{ github.token }}" gh api --paginate --slurp \
+          GH_TOKEN="${{ steps.app-token.outputs.token }}" gh api --paginate --slurp \
             -H "Accept: application/vnd.github.star+json" \
             -H "X-GitHub-Api-Version: 2026-03-10" \
             "repos/${{ github.repository }}/stargazers?per_page=100" \


### PR DESCRIPTION
Follow-up to #955.

Lowering the `Repository Stats` workflow token to `contents: read` left the star-history step short of what the stargazers API needs, and it failed with `403 Resource not accessible by integration`. The clone-stats, checkout and commit steps were unaffected — they already run on the Illegal Bot installation token.

That step now uses the same token, which holds `metadata: read`. The workflow token stays read-only rather than going back to `contents: write`.

Verified by dispatching the workflow: the run reaches this step with the token minted, the repository checked out and the traffic API answering.