### PR TITLE
fix: keep emit-asm independent of runtime assembly

### DIFF
--- a/docs/compiling/compilation-pipeline.md
+++ b/docs/compiling/compilation-pipeline.md
@@ -155,5 +155,6 @@ intermediate artifact:
   only; when `#[Export]` is present it also lowers EIR and runs cdylib
   call-graph safety without emitting code.
 - [`--emit-ir`](output-and-diagnostics.md#--emit-ir) prints EIR (after `ir-opt`) and stops.
-- [`--emit-asm`](output-and-diagnostics.md#--emit-asm) writes assembly without linking.
+- [`--emit-asm`](output-and-diagnostics.md#--emit-asm) writes assembly and stops before
+  runtime-object preparation, native assembly, or linking.
 - [`--timings`](output-and-diagnostics.md#--timings) prints how long each phase took.

--- a/docs/compiling/output-and-diagnostics.md
+++ b/docs/compiling/output-and-diagnostics.md
@@ -36,8 +36,9 @@ the boundary contract and the static-linking distinction.
 
 ### `--emit-asm`
 
-Writes the generated assembly next to the source instead of assembling and
-linking a binary. Useful for inspecting exactly what the backend produced.
+Writes the generated assembly next to the source and stops before runtime-object
+preparation, native assembly, or linking. No assembler for the selected target
+is required. Useful for inspecting exactly what the backend produced.
 
 ```bash
 elephc --emit-asm hello.php

--- a/docs/internals/how-elephc-works.md
+++ b/docs/internals/how-elephc-works.md
@@ -342,11 +342,11 @@ Key observations:
 - `echo "big\n"` → load string address + length, then `svc` to write to stdout
 - The string literal lives in the `.data` section, referenced by label `_str_0`
 
-## Phase 17: Runtime preparation, assembly, and linking
+## Phase 17: Assembly output, runtime preparation, and linking
 
 **Tools:** native `as` and `ld` (or the equivalent system toolchain)
 
-elephc first prepares the shared runtime object, then writes the user assembly to a `.s` file, and finally invokes the system tools.
+elephc first writes the user assembly to a `.s` file. `--emit-asm` stops there, without preparing a runtime object or requiring an assembler. Final artifact builds continue through runtime preparation and the system toolchain.
 
 The runtime is not reassembled on every compile. elephc caches a pre-assembled runtime object under the user's cache directory (typically `~/.cache/elephc/`) using the compiler version, target, heap size, and generated runtime assembly hash in the cache key. If a matching object already exists, the compile reuses it directly.
 
@@ -354,9 +354,9 @@ The user program still gets its own assembly file. If `--source-map` is enabled,
 
 In normal compile mode, the toolchain flow is:
 
-1. Prepare or reuse the cached runtime object
-2. Write the program assembly to `file.s`
-3. Optionally write `file.map`
+1. Write the program assembly to `file.s`
+2. Optionally write `file.map`
+3. Prepare or reuse the cached runtime object
 4. Assemble `file.s` into `file.o`
 5. Link `file.o` together with the cached runtime object, any required optional
    bridge archives, and system libraries into the final executable

--- a/src/pipeline/backend.rs
+++ b/src/pipeline/backend.rs
@@ -5,7 +5,7 @@
 //! - `crate::pipeline::compile()` after EIR lowering and optimization.
 //!
 //! Key details:
-//! - Runtime feature selection, bridge planning, assembly emission, and linking preserve their original order.
+//! - Assembly-only output returns before runtime-object preparation, native resolution, assembly, and linking.
 
 use std::collections::{HashMap, HashSet};
 

--- a/tests/codegen/cli.rs
+++ b/tests/codegen/cli.rs
@@ -835,6 +835,12 @@ fn test_cli_emit_asm_does_not_require_target_assembler() {
         !dir.join("main.o").exists() && !dir.join("main").exists(),
         "cross-target --emit-asm must not assemble or link"
     );
+    let runtime_cache = dir.join("cache-root").join("elephc");
+    assert!(
+        !runtime_cache.exists(),
+        "cross-target --emit-asm must not prepare a runtime object cache at {}",
+        runtime_cache.display()
+    );
 
     let _ = fs::remove_dir_all(&dir);
 }

--- a/tests/codegen/cli.rs
+++ b/tests/codegen/cli.rs
@@ -821,6 +821,7 @@ fn test_cli_emit_asm_does_not_require_target_assembler() {
         .arg("--target")
         .arg(target)
         .arg("--emit-asm")
+        .arg("--timings")
         .arg(&php_path)
         .output()
         .expect("failed to run cross-target elephc CLI with --emit-asm");
@@ -830,6 +831,22 @@ fn test_cli_emit_asm_does_not_require_target_assembler() {
         "cross-target elephc --emit-asm failed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Writing assembly"),
+        "emit-asm should report its final output phase: {stderr}"
+    );
+    for skipped_phase in [
+        "Preparing runtime object",
+        "Assembling object file",
+        "Linking native output",
+        "Runtime cache:",
+    ] {
+        assert!(
+            !stderr.contains(skipped_phase),
+            "emit-asm unexpectedly reported `{skipped_phase}`: {stderr}"
+        );
+    }
     assert!(dir.join("main.s").exists(), "expected target assembly output");
     assert!(
         !dir.join("main.o").exists() && !dir.join("main").exists(),

--- a/tests/compiler_determinism_tests.rs
+++ b/tests/compiler_determinism_tests.rs
@@ -43,8 +43,8 @@ fn unique_test_id() -> usize {
 /// Every run compiles the SAME file in the SAME directory: the compiler bakes the
 /// canonicalized source path into the output (`__FILE__`, `Throwable::getFile()`),
 /// so compiling copies in sibling directories would report a path difference as a
-/// reproducibility failure. Runs also share one cache root, so the runtime object
-/// is built once; the assembly under test is regenerated from scratch regardless.
+/// reproducibility failure. The isolated cache root ensures a regression cannot
+/// populate the user's runtime-object cache; the assembly is regenerated each run.
 fn emit_asm_repeatedly(name: &str, source: &str, runs: usize) -> Vec<String> {
     let dir = std::env::temp_dir().join(format!(
         "elephc_determinism_{}_{}_{}",

--- a/tests/resource_id_and_hash_context_tests.rs
+++ b/tests/resource_id_and_hash_context_tests.rs
@@ -1095,12 +1095,10 @@ fn assert_asm_contains_ordered(asm: &str, needles: &[&str]) {
 
 /// Pins `__rt_resource_type_name` inside the REAL generated runtime, on both targets.
 ///
-/// The end-to-end tests above can only run on the host, and `--emit-asm --target
-/// linux-x86_64` cannot complete on an aarch64 host (the runtime cache is assembled with
-/// the host `as`, which rejects `xor eax, eax`). Generating the runtime text directly is
-/// therefore the mechanism that gives the x86_64 body real coverage here, and it proves
-/// something the emitter unit tests cannot: that the helper is actually REGISTERED in
-/// `emit_runtime` and that the two literals it names exist in the data section.
+/// The end-to-end tests above can only run on the host. Generating runtime text directly
+/// gives the x86_64 runtime body real coverage without assembling or linking it, and it
+/// proves something the emitter unit tests cannot: that the helper is actually REGISTERED
+/// in `emit_runtime` and that the two literals it names exist in the data section.
 #[test]
 fn the_runtime_defines_the_resource_type_name_helper_on_both_targets() {
     for (target_name, closed_label, open_needles, closed_needles, end_label) in [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- lock the assembly-only pipeline return before runtime-object preparation and all native build steps
- strengthen the cross-target CLI regression to assert that `--emit-asm` never creates the runtime-object cache or reports any native build phase, even when a cross-assembler is installed
- synchronize the authoritative CLI reference, pipeline, output-mode, and test documentation with assembler-free cross-target emission

## Testing

- `cargo test --test codegen_tests test_cli_emit_asm_does_not_require_target_assembler`
- `cargo build`
- direct `linux-aarch64 --emit-asm` probe on a Linux x86_64 host (assembly emitted; runtime cache absent)
- `git diff --check origin/main...HEAD`

## Independent verification

Two Grok 4.6 reviews traced the historical and current pipeline ordering, checked target/cache risks, and independently verified the regression. The final review returned `VERIFIED`.

Fixes #679
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-deb6b65e-b7e9-4f18-8413-948c67b9661c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-deb6b65e-b7e9-4f18-8413-948c67b9661c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

