### PR TITLE
fix: reject invalid putenv assignments

### DIFF
--- a/crates/elephc-magician/src/interpreter/builtins/network_env/mod.rs
+++ b/crates/elephc-magician/src/interpreter/builtins/network_env/mod.rs
@@ -226,7 +226,7 @@ pub(in crate::interpreter) fn eval_network_env_values_result(
             let [assignment] = evaluated_args else {
                 return Err(EvalStatus::RuntimeFatal);
             };
-            eval_putenv_result(*assignment, values)
+            eval_putenv_result(*assignment, context, values)
         }
         "long2ip" => {
             let [value] = evaluated_args else {

--- a/crates/elephc-magician/src/interpreter/builtins/network_env/putenv.rs
+++ b/crates/elephc-magician/src/interpreter/builtins/network_env/putenv.rs
@@ -6,6 +6,7 @@
 //!
 //! Key details:
 //! - Assignments mutate the host process environment for the current eval process.
+//! - PHP's syntax guard raises a catchable `ValueError` before host environment APIs run.
 
 use super::*;
 
@@ -27,15 +28,23 @@ pub(in crate::interpreter) fn eval_builtin_putenv(
         return Err(EvalStatus::RuntimeFatal);
     };
     let assignment = eval_expr(assignment, context, scope, values)?;
-    eval_putenv_result(assignment, values)
+    eval_putenv_result(assignment, context, values)
 }
 
-/// Applies one `putenv()` assignment to the host environment.
+/// Validates and applies one `putenv()` assignment to the host environment.
 pub(in crate::interpreter) fn eval_putenv_result(
     assignment: RuntimeCellHandle,
+    context: &mut ElephcEvalContext,
     values: &mut impl RuntimeValueOps,
 ) -> Result<RuntimeCellHandle, EvalStatus> {
     let assignment = values.string_bytes(assignment)?;
+    if assignment.is_empty() || assignment[0] == b'=' {
+        return eval_throw_builtin_value_error(
+            "putenv(): Argument #1 ($assignment) must have a valid syntax",
+            context,
+            values,
+        );
+    }
     if let Some(separator) = assignment.iter().position(|byte| *byte == b'=') {
         let name = String::from_utf8_lossy(&assignment[..separator]);
         let value = String::from_utf8_lossy(&assignment[separator + 1..]);

--- a/crates/elephc-magician/src/interpreter/tests/builtins_system_network.rs
+++ b/crates/elephc-magician/src/interpreter/tests/builtins_system_network.rs
@@ -541,6 +541,31 @@ return function_exists("putenv");"#,
     assert_eq!(values.output, "direct:named:named:set:spread:missing:1");
     assert_eq!(values.get(result), FakeValue::Bool(true));
 }
+
+/// Verifies eval `putenv()` rejects invalid syntax before host environment mutation.
+#[test]
+fn execute_program_putenv_rejects_invalid_assignment_syntax() {
+    let program = parse_fragment(
+        br#"try { putenv(""); } catch (ValueError $error) { echo $error->getMessage(); }
+echo "|";
+try { putenv(assignment: "="); } catch (ValueError $error) { echo $error->getMessage(); }
+echo "|";
+try { call_user_func_array("putenv", ["assignment" => "=value"]); } catch (ValueError $error) { echo $error->getMessage(); }
+return putenv("ELEPHC_EVAL_VALID_EMPTY_VALUE=");"#,
+    )
+    .expect("parse eval fragment");
+    let mut scope = ElephcEvalScope::new();
+    let mut values = FakeOps::default();
+
+    let result = execute_program(&program, &mut scope, &mut values).expect("execute eval ir");
+
+    assert_eq!(
+        values.output,
+        "putenv(): Argument #1 ($assignment) must have a valid syntax|putenv(): Argument #1 ($assignment) must have a valid syntax|putenv(): Argument #1 ($assignment) must have a valid syntax"
+    );
+    assert_eq!(values.get(result), FakeValue::Bool(true));
+}
+
 /// Verifies eval `getenv()` with no name, a null name, and `local_only` answers the environment.
 #[test]
 fn execute_program_dispatches_getenv_whole_environment() {

--- a/src/codegen/lower_inst/builtins/system.rs
+++ b/src/codegen/lower_inst/builtins/system.rs
@@ -797,7 +797,7 @@ fn emit_getenv_all_result(
     store_if_result(ctx, inst)
 }
 
-/// Lowers `putenv(assignment)`, dispatching bare names to `unsetenv` and assignments to `putenv`.
+/// Lowers `putenv(assignment)`, rejecting invalid syntax before dispatching to libc.
 pub(crate) fn lower_putenv(
     ctx: &mut FunctionContext<'_>,
     inst: &Instruction,
@@ -805,6 +805,7 @@ pub(crate) fn lower_putenv(
     super::ensure_arg_count(inst, "putenv", 1)?;
     let assignment = expect_operand(inst, 0)?;
     require_string(ctx.load_value_to_result(assignment)?.codegen_repr(), "putenv assignment")?;
+    emit_putenv_syntax_guard(ctx);
     match ctx.emitter.target.arch {
         Arch::AArch64 => lower_putenv_aarch64(ctx),
         Arch::X86_64 => lower_putenv_x86_64(ctx),
@@ -930,6 +931,32 @@ fn emit_dynamic_exit(ctx: &mut FunctionContext<'_>) {
             panic!("Windows target is not yet supported (see issue #379)");
         }
     }
+}
+
+/// Raises PHP 8's catchable `ValueError` for an empty assignment or one beginning with `=`.
+fn emit_putenv_syntax_guard(ctx: &mut FunctionContext<'_>) {
+    let invalid = ctx.next_label("putenv_invalid");
+    let valid = ctx.next_label("putenv_valid");
+    match ctx.emitter.target.arch {
+        Arch::AArch64 => {
+            ctx.emitter.instruction(&format!("cbz x2, {}", invalid));           // reject an empty assignment before reading its first byte
+            ctx.emitter.instruction("ldrb w3, [x1]");                           // inspect the first assignment byte before any libc call
+            ctx.emitter.instruction("cmp w3, #61");                             // PHP rejects environment names beginning with '='
+            ctx.emitter.instruction(&format!("b.ne {}", valid));                // a nonempty name may proceed to set or unset dispatch
+        }
+        Arch::X86_64 => {
+            ctx.emitter.instruction("test rdx, rdx");                           // reject an empty assignment before reading its first byte
+            ctx.emitter.instruction(&format!("jz {}", invalid));                // an empty assignment has no valid environment name
+            ctx.emitter.instruction("cmp BYTE PTR [rax], 61");                  // PHP rejects environment names beginning with '='
+            ctx.emitter.instruction(&format!("jne {}", valid));                 // a nonempty name may proceed to set or unset dispatch
+        }
+    }
+    ctx.emitter.label(&invalid);
+    super::super::exceptions::emit_value_error(
+        ctx,
+        "putenv(): Argument #1 ($assignment) must have a valid syntax",
+    );
+    ctx.emitter.label(&valid);
 }
 
 /// Unsets a bare environment name using an allocated C string, frees the copy,

--- a/tests/codegen/callables/constants_and_system.rs
+++ b/tests/codegen/callables/constants_and_system.rs
@@ -2535,6 +2535,31 @@ echo getenv("ELEPHC_TEST_VAR");
     assert_eq!(out, "hello");
 }
 
+/// Verifies empty and leading-equals assignments throw PHP's exact catchable `ValueError`.
+#[test]
+fn test_putenv_rejects_invalid_assignment_syntax() {
+    let out = compile_and_run(
+        r#"<?php
+function probe_putenv_syntax(string $assignment): void {
+    try {
+        putenv($assignment);
+        echo "accepted";
+    } catch (ValueError $error) {
+        echo get_class($error) . "|" . $error->getMessage();
+    }
+    echo "\n";
+}
+probe_putenv_syntax("");
+probe_putenv_syntax("=");
+probe_putenv_syntax("=value");
+"#,
+    );
+    assert_eq!(
+        out,
+        "ValueError|putenv(): Argument #1 ($assignment) must have a valid syntax\n".repeat(3)
+    );
+}
+
 /// Verifies that `putenv("NAME")` without an equals sign removes the variable,
 /// matching PHP rather than leaving the previous value in the environment.
 #[test]

--- a/tests/codegen/eval.rs
+++ b/tests/codegen/eval.rs
@@ -7565,6 +7565,24 @@ echo function_exists("putenv");');
     assert_eq!(out, "direct:named:named:set:spread:missing:11");
 }
 
+/// Verifies eval `putenv()` raises PHP's exact `ValueError` across direct and callable dispatch.
+#[test]
+fn test_eval_putenv_rejects_invalid_assignment_syntax() {
+    let out = compile_and_run(
+        r#"<?php
+eval('try { putenv(""); } catch (ValueError $error) { echo $error->getMessage(); }
+echo "|";
+try { putenv(assignment: "="); } catch (ValueError $error) { echo $error->getMessage(); }
+echo "|";
+try { call_user_func_array("putenv", ["assignment" => "=value"]); } catch (ValueError $error) { echo $error->getMessage(); }');
+"#,
+    );
+    assert_eq!(
+        out,
+        "putenv(): Argument #1 ($assignment) must have a valid syntax|putenv(): Argument #1 ($assignment) must have a valid syntax|putenv(): Argument #1 ($assignment) must have a valid syntax"
+    );
+}
+
 /// Verifies eval `getenv()` with zero arguments and a null name answers the environment.
 #[test]
 fn test_eval_getenv_whole_environment() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- reject empty and leading-`=` `putenv()` assignments before libc or host environment APIs
- raise PHP 8's catchable `ValueError` with the exact `putenv(): Argument #1 ($assignment) must have a valid syntax` diagnostic in AOT and Magician
- preserve valid bare-name unsets and `NAME=` / `NAME=value` assignments from #907
- cover direct, named, and callable eval dispatch paths

## Testing
- `cargo test --test codegen_tests putenv_rejects_invalid_assignment_syntax -- --nocapture` (2 passed)
- `cargo test -p elephc-magician execute_program_putenv_rejects_invalid_assignment_syntax -- --nocapture` (1 passed)
- `cargo build` (Rust 1.95.0, no warnings)
- `./scripts/check_asm_comments.py src/codegen/lower_inst/builtins/system.rs`
- `git diff --check`
- independent Grok 4.6 review approved the PHP 8 predicate, diagnostic, catchability, pre-libc ordering, target register paths, and AOT/Magician parity

Fixes #908
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eba6af62-3663-44bd-831a-cc6138e59d1e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eba6af62-3663-44bd-831a-cc6138e59d1e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

