### PR TITLE
docs: fix eval getenv unset polarity

### DIFF
--- a/examples/eval/main.php
+++ b/examples/eval/main.php
@@ -190,7 +190,7 @@ $date_sample = eval('$ts = mktime(0, 0, 0, 1, 2, 2024); return date("Y-m-d", $ts
 $strtotime_sample = eval('$ts = strtotime("2024-01-02 03:04:05"); return date("Y-m-d H:i:s", $ts);');
 $micro_time = eval('return microtime(true) > 1000000000 ? "ok" : "bad";');
 $realpath_cache = eval('return count(realpath_cache_get()) . ":" . realpath_cache_size();');
-$environment = eval('putenv("ELEPHC_EVAL_EXAMPLE=ok"); $value = getenv("ELEPHC_EVAL_EXAMPLE"); putenv("ELEPHC_EVAL_EXAMPLE"); return $value . ":" . (getenv("ELEPHC_EVAL_EXAMPLE") === "" ? "cleared" : "left");');
+$environment = eval('putenv("ELEPHC_EVAL_EXAMPLE=ok"); $value = getenv("ELEPHC_EVAL_EXAMPLE"); putenv("ELEPHC_EVAL_EXAMPLE"); return $value . ":" . (getenv("ELEPHC_EVAL_EXAMPLE") === false ? "cleared" : "left");');
 $sleeping = eval('usleep(0); return sleep(0) . ":awake";');
 $host_lookup = eval('return (strlen(gethostname()) > 0 ? "host" : "empty") . ":" . gethostbyname("127.0.0.1") . ":" . gethostbyname("not a host") . ":" . (strlen(gethostbyaddr("127.0.0.1")) > 0 ? "reverse" : "empty") . ":" . (gethostbyaddr("not-an-ip-address") === false ? "bad-ip" : "bad");');
 $protocol_services = eval('return getprotobyname("tcp") . ":" . getprotobynumber(17) . ":" . getservbyname("http", "tcp") . ":" . getservbyport(443, "tcp");');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update the eval example to test an unset environment variable against `false`
- preserve the existing runtime `getenv()`/`putenv()` semantics and already-correct documentation

## Verification
- `cargo test -p elephc-magician execute_program_dispatches_environment_builtins`
- `cargo test --test codegen_tests test_eval_dispatches_environment_builtin_calls`
- `cargo run -- examples/eval/main.php`
- `./examples/eval/main | rg '^environment='` → `environment=ok:cleared`
- `git diff --check main...HEAD`

## Review
A delegated Grok 4.6 review scoped the stale teaching to `examples/eval/main.php` and confirmed related docs already describe missing as `false` and set-empty as `""`. I independently inspected the Magician implementation and focused regression tests, then ran the checks above.

Fixes #936
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b978db8a-c78b-48eb-831b-6851b1569e74?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b978db8a-c78b-48eb-831b-6851b1569e74&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

