### PR TITLE
docs: refresh Magician curl support comments

### DIFF
--- a/crates/elephc-magician/src/curl_ffi.rs
+++ b/crates/elephc-magician/src/curl_ffi.rs
@@ -39,9 +39,9 @@ pub(crate) const KIND_SHARE: i32 = 7;
 pub(crate) const KIND_CALLBACK: i32 = 8;
 /// The four PHP-STREAM options (`CURLOPT_FILE`, `CURLOPT_INFILE`/`CURLOPT_READDATA`,
 /// `CURLOPT_WRITEHEADER`, `CURLOPT_STDERR`). The AOT build implements them in the curl
-/// prelude by composing its callback slots; `eval()` carries neither the slots nor a PHP
-/// stream it could hand them, so they take the same honest "not supported by this build"
-/// warning + `false` that `KIND_CALLBACK` and `KIND_SHARE` do.
+/// prelude by composing its callback slots; `eval()` carries the callback slots but no PHP
+/// stream it could hand them, so these four still take the honest "not supported by this
+/// build" warning plus `false`.
 pub(crate) const KIND_STREAM: i32 = 9;
 
 // `elephc_curl_easy_str_op`'s `op` codes, copied verbatim from

--- a/crates/elephc-magician/src/interpreter/builtins/curl/curl_copy_handle.rs
+++ b/crates/elephc-magician/src/interpreter/builtins/curl/curl_copy_handle.rs
@@ -5,9 +5,8 @@
 //! - `crate::interpreter::builtins::curl` dispatch.
 //!
 //! Key details:
-//! - CALLBACKS ARE NOT RE-REGISTERED, unlike `crate::curl_prelude::curl_copy_handle`:
-//!   this family does not implement curl callbacks in `eval()` at all (module doc), so
-//!   there is nothing to re-point at the copy.
+//! - Callbacks are re-registered onto the copy rather than inherited, so each callback
+//!   slot points at the copied eval handle and retains the same callable independently.
 
 use crate::curl_ffi as ffi;
 

--- a/crates/elephc-magician/src/interpreter/builtins/curl/curl_copy_handle.rs
+++ b/crates/elephc-magician/src/interpreter/builtins/curl/curl_copy_handle.rs
@@ -5,8 +5,8 @@
 //! - `crate::interpreter::builtins::curl` dispatch.
 //!
 //! Key details:
-//! - Callbacks are re-registered onto the copy rather than inherited, so each callback
-//!   slot points at the copied eval handle and retains the same callable independently.
+//! - Active callbacks are re-registered onto the copy rather than inherited, so their
+//!   slots point at the copied eval handle; all callables are retained independently.
 
 use crate::curl_ffi as ffi;
 

--- a/crates/elephc-magician/src/interpreter/builtins/curl/curl_getinfo.rs
+++ b/crates/elephc-magician/src/interpreter/builtins/curl/curl_getinfo.rs
@@ -9,7 +9,8 @@
 //!   exactly (see that function's own extensive comment for the mask values and why three
 //!   options are special-cased before the mask). `CURLINFO_HEADER_OUT` always answers
 //!   `false` here too, for the identical reason the AOT wrapper documents (the header
-//!   capture needs the `CURLOPT_DEBUGFUNCTION` plumbing this family does not implement).
+//!   capture needs internal request-header tracking that this family does not implement;
+//!   the `CURLOPT_DEBUGFUNCTION` callback option itself is supported).
 
 use crate::curl_ffi as ffi;
 

--- a/crates/elephc-magician/src/interpreter/builtins/curl/handle.rs
+++ b/crates/elephc-magician/src/interpreter/builtins/curl/handle.rs
@@ -1,7 +1,7 @@
 //! Purpose:
 //! Shared curl easy-handle resolution and `curl_setopt()`'s option-KIND dispatch, reused
-//! by every home file in this family (mirrors `crate::curl_prelude::curl_setopt`'s body
-//! one-for-one, minus the callback/share arms this module's doc defers).
+//! by every home file in this family (mirrors `crate::curl_prelude::curl_setopt`'s dispatch,
+//! including its callback, share, and `CURLOPT_POSTFIELDS` multipart arms).
 //!
 //! Called from:
 //! - Every `curl_*` home file in this directory.
@@ -269,10 +269,9 @@ pub(in crate::interpreter) fn eval_curl_require_php_85(
     Ok(())
 }
 
-/// `curl_setopt()`'s message for KIND 6 (a real option this build cannot carry), KIND 8
-/// (callbacks) and KIND 9 (the PHP-stream options) — accepted PHP API this eval interpreter
-/// specifically does not wire, per this family's module doc — formatted exactly like the
-/// AOT prelude's own
+/// `curl_setopt()`'s message for KIND 6 (a real option this build cannot carry), KIND 9
+/// (the PHP-stream options), or a defensive unknown KIND 8 callback slot — formatted
+/// exactly like the AOT prelude's own
 /// `__elephc_curl_setopt_unsupported_warning` (`src/codegen_support/runtime/curl/
 /// warn_option.rs`'s `CURL_SETOPT_UNSUPPORTED_PREFIX`/`_SUFFIX`), so a script observing
 /// the warning text sees the identical wording whether it runs compiled or through
@@ -304,11 +303,10 @@ pub(in crate::interpreter) fn eval_curl_warn_unsupported_multi_option(
 /// id, EVAL TABLE KEY (for the PHP-layer mirror fields), and already-evaluated option/value
 /// cells. Returns the same `bool` `curl_setopt()` itself returns.
 ///
-/// Mirrors `crate::curl_prelude::curl_setopt`'s body kind-for-kind (see that function's own
-/// extensive comments for the libcurl-side rationale of each branch), MINUS the
-/// `CURLOPT_POSTFIELDS` array/`multipart` special case and KIND 8 (callbacks) — both fall
-/// into the honest "not supported by this build" warning path instead, per this family's
-/// module doc.
+/// Mirrors `crate::curl_prelude::curl_setopt`'s body kind-for-kind, including
+/// `CURLOPT_POSTFIELDS` array/multipart handling and KIND 8 callbacks. KIND 9 PHP-stream
+/// options and KIND 6 options this build cannot carry still take the honest "not supported
+/// by this build" warning path.
 pub(in crate::interpreter) fn eval_curl_setopt_apply(
     raw: i64,
     table_id: i64,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update Magician curl comments to reflect existing callback and multipart support
- clarify callback re-registration on copied handles
- distinguish supported debug callbacks from unsupported request-header capture and PHP-stream composition

## Testing
- `cargo check -p elephc-magician --features curl`
- `git diff --check`
- targeted stale-denial search across `crates/elephc-magician`

Fixes #876
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2410760-29b0-4e71-8a55-1de59e73391a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2410760-29b0-4e71-8a55-1de59e73391a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

