### PR TITLE
test: cover array_walk by-reference lvalue rejection

### DIFF
--- a/tests/codegen/arrays/callbacks.rs
+++ b/tests/codegen/arrays/callbacks.rs
@@ -384,20 +384,21 @@ echo $product;
     assert_eq!(out, "24");
 }
 
-// Tests `array_walk` with a callback that mutates each element by reference, verifying the
-// variable argument remains a writable lvalue and receives the callback's changes.
-/// Verifies `array_walk` writes callback mutations back to a variable argument.
+// Tests `array_walk` with a variable argument, verifying the by-reference lvalue guard keeps
+// accepting writable storage and leaves the walked array available after the call.
+/// Verifies `array_walk` accepts and walks a variable argument.
 #[test]
 fn test_array_walk() {
     let out = compile_and_run(
         r#"<?php
-function increment(&$x) { $x = $x + 1; }
+function show($x) { echo $x; }
 $a = [10, 20, 30];
-array_walk($a, "increment");
+array_walk($a, "show");
+echo "|";
 echo implode(",", $a);
 "#,
     );
-    assert_eq!(out, "11,21,31");
+    assert_eq!(out, "102030|10,20,30");
 }
 
 // Tests `usort` with a comparison callback that sorts an unsorted array in ascending

--- a/tests/codegen/arrays/callbacks.rs
+++ b/tests/codegen/arrays/callbacks.rs
@@ -384,19 +384,20 @@ echo $product;
     assert_eq!(out, "24");
 }
 
-// Tests `array_walk` with a callback that echoes each element, verifying the function
-// walks by reference and mutates the array in place.
-/// Verifies that array walk.
+// Tests `array_walk` with a callback that mutates each element by reference, verifying the
+// variable argument remains a writable lvalue and receives the callback's changes.
+/// Verifies `array_walk` writes callback mutations back to a variable argument.
 #[test]
 fn test_array_walk() {
     let out = compile_and_run(
         r#"<?php
-function show($x) { echo $x; }
+function increment(&$x) { $x = $x + 1; }
 $a = [10, 20, 30];
-array_walk($a, "show");
+array_walk($a, "increment");
+echo implode(",", $a);
 "#,
     );
-    assert_eq!(out, "102030");
+    assert_eq!(out, "11,21,31");
 }
 
 // Tests `usort` with a comparison callback that sorts an unsorted array in ascending

--- a/tests/error_tests/array_builtins.rs
+++ b/tests/error_tests/array_builtins.rs
@@ -299,6 +299,22 @@ fn test_error_by_ref_builtin_parameter_refuses_a_value_with_no_storage() {
             "array_walk(): Argument #1 ($array) could not be passed by reference",
         ),
         (
+            r#"<?php function f($v) {} array_walk(["key" => 1], "f");"#,
+            "array_walk(): Argument #1 ($array) could not be passed by reference",
+        ),
+        (
+            r#"<?php function f($v) {} array_walk(callback: "f", array: [1, 2]);"#,
+            "array_walk(): Argument #1 ($array) could not be passed by reference",
+        ),
+        (
+            r#"<?php function make_array(): array { return [1]; } function f($v) {} array_walk(make_array(), "f");"#,
+            "array_walk(): Argument #1 ($array) could not be passed by reference",
+        ),
+        (
+            r#"<?php function f($v) {} array_walk_recursive([[1]], "f");"#,
+            "array_walk_recursive(): Argument #1 ($array) could not be passed by reference",
+        ),
+        (
             "<?php sort([3, 1, 2]);",
             "sort(): Argument #1 ($array) could not be passed by reference",
         ),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- pin the centralized AOT by-reference guard for indexed, associative, named, and call-result arguments to `array_walk()`
- cover the matching `array_walk_recursive()` by-reference contract without widening implementation scope
- prove valid variable and named property storage remains accepted and executable

## Context
The centralized registry-driven checker guard landed on `main` after this issue was filed. This PR adds the missing issue-specific acceptance coverage so the PHP-incompatible literal behavior cannot regress.

## Testing
- `cargo build`
- `cargo test --test error_tests test_error_by_ref_builtin_parameter_refuses_a_value_with_no_storage`
- `cargo test --test codegen_tests codegen::arrays::callbacks::test_array_walk -- --exact`
- `cargo test --test codegen_tests codegen::arrays::by_ref_places::test_named_by_ref_argument_on_property_mutates_property -- --exact`
- `git diff --check`

Fixes #537
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9dd1f93-0fa1-437e-93bb-42bc7435234b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9dd1f93-0fa1-437e-93bb-42bc7435234b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

