### PR TITLE
docs: add putenv examples to generated builtin page

### DIFF
--- a/crates/elephc-builtin-contract/src/catalog_data.rs
+++ b/crates/elephc-builtin-contract/src/catalog_data.rs
@@ -26918,6 +26918,7 @@ pub(crate) static CONTRACTS: &[BuiltinContract] = &[
         by_ref_return: false,
         summary: "Sets an environment variable, or removes it when the argument has no equals sign.",
         examples: &[
+            "```php\nputenv(\"APP_ENV=production\");\necho getenv(\"APP_ENV\") . \"\\n\";\nputenv(\"APP_ENV\");\necho getenv(\"APP_ENV\") === false ? \"unset\\n\" : \"still set\\n\";\n```",
         ],
         php_manual: None,
         deprecation: None,

--- a/docs/php/builtins/filesystem/putenv.md
+++ b/docs/php/builtins/filesystem/putenv.md
@@ -23,7 +23,14 @@ Sets an environment variable, or removes it when the argument has no equals sign
 - **Compiled (AOT)**: supported by the Elephc code generator.
 - **`eval()` (magician interpreter)**: supported — declarative interpreter builtin ([`crates/elephc-magician/src/interpreter/builtins/network_env/putenv.rs`](https://github.com/illegalstudio/elephc/blob/main/crates/elephc-magician/src/interpreter/builtins/network_env/putenv.rs)).
 
-_No examples yet — check `examples/` and `showcases/` for usage patterns._
+**Examples**:
+
+```php
+putenv("APP_ENV=production");
+echo getenv("APP_ENV") . "\n";
+putenv("APP_ENV");
+echo getenv("APP_ENV") === false ? "unset\n" : "still set\n";
+```
 
 ## Internals
 

--- a/scripts/docs/builtin_registry.json
+++ b/scripts/docs/builtin_registry.json
@@ -96283,7 +96283,9 @@
       "variadic": null
     },
     "eval_only": false,
-    "examples": [],
+    "examples": [
+      "```php\nputenv(\"APP_ENV=production\");\necho getenv(\"APP_ENV\") . \"\\n\";\nputenv(\"APP_ENV\");\necho getenv(\"APP_ENV\") === false ? \"unset\\n\" : \"still set\\n\";\n```"
+    ],
     "in_catalog": true,
     "is_extension": false,
     "is_internal": false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a set-and-unset `putenv()` example to the shared builtin contract
- regenerate the builtin registry and PHP builtin page

## Verification
- `cargo build --example gen_builtins --features curl`
- `python3 -m unittest discover -s scripts/docs/elephc_builtins -p 'test_*.py'`
- `python3 scripts/docs/audit_builtins.py`
- `python3 scripts/docs/elephc_builtins/validate_site_compat.py`
- `python3 scripts/audit_builtin_eir_boundary.py --enforce-target-architecture`
- regeneration is idempotent (`git diff --exit-code`)
- `git diff --check`

Fixes #912
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de633c22-d516-4fef-96e4-59fd61fcb961?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de633c22-d516-4fef-96e4-59fd61fcb961&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

